### PR TITLE
Fix e2e tests to match updated translation strings

### DIFF
--- a/src/views/AppointmentForm.vue
+++ b/src/views/AppointmentForm.vue
@@ -207,7 +207,7 @@
                     <template #icon>
                         <Plus :size="20" />
                     </template>
-                    {{ t("attendance", "Add from Files") }}
+                    {{ t("attendance", "Add from files") }}
                 </NcButton>
             </div>
 

--- a/tests/e2e/2-appointment.spec.js
+++ b/tests/e2e/2-appointment.spec.js
@@ -3,7 +3,7 @@ import { test, expect } from './fixtures/nextcloud.js'
 // Helper function to create an appointment
 async function createAppointment(page, { name, description, daysFromNow = 2, durationHours = 1 }) {
 	// Wait for Create Appointment link to be ready
-	const createLink = page.getByRole('link', { name: 'Create Appointment' })
+	const createLink = page.getByRole('link', { name: 'Create appointment' })
 	await createLink.waitFor({ state: 'visible' })
 
 	// Click create button (navigates to form page)
@@ -12,10 +12,10 @@ async function createAppointment(page, { name, description, daysFromNow = 2, dur
 	// Wait for form page to load
 	await page.waitForURL(/.*\/create$/)
 	await page.waitForLoadState('networkidle')
-	await expect(page.getByRole('heading', { name: 'Create Appointment' })).toBeVisible()
+	await expect(page.getByRole('heading', { name: 'Create appointment' })).toBeVisible()
 
 	// Wait for name field to be ready and fill it
-	const nameInput = page.getByRole('textbox', { name: 'Appointment Name' })
+	const nameInput = page.getByRole('textbox', { name: 'Appointment name' })
 	await nameInput.waitFor({ state: 'visible' })
 	await nameInput.fill(name)
 
@@ -31,8 +31,8 @@ async function createAppointment(page, { name, description, daysFromNow = 2, dur
 	const startDate = new Date(now.getTime() + daysFromNow * 24 * 60 * 60 * 1000)
 	const endDate = new Date(startDate.getTime() + durationHours * 60 * 60 * 1000)
 
-	await page.getByRole('textbox', { name: 'Start Date & Time' }).fill(startDate.toISOString().slice(0, 16))
-	await page.getByRole('textbox', { name: 'End Date & Time' }).fill(endDate.toISOString().slice(0, 16))
+	await page.getByRole('textbox', { name: 'Start date & time' }).fill(startDate.toISOString().slice(0, 16))
+	await page.getByRole('textbox', { name: 'End date & time' }).fill(endDate.toISOString().slice(0, 16))
 
 	// Save
 	await page.getByRole('button', { name: 'Save' }).click()
@@ -69,7 +69,7 @@ test.describe('Attendance App - Appointment Management', () => {
 		await page.getByRole('button', { name: 'Actions' }).first().click()
 
 		// Click Share Link
-		await page.getByRole('menuitem', { name: 'Share Link' }).click()
+		await page.getByRole('menuitem', { name: 'Share link' }).click()
 		
 		// Wait for clipboard to be written and verify
 		await page.waitForLoadState('networkidle')
@@ -89,10 +89,10 @@ test.describe('Attendance App - Appointment Management', () => {
 
 		// Wait for form page and verify it's Edit mode
 		await page.waitForURL(/.*\/edit\/\d+$/)
-		await expect(page.getByRole('heading', { name: 'Edit Appointment' })).toBeVisible()
+		await expect(page.getByRole('heading', { name: 'Edit appointment' })).toBeVisible()
 
 		// Modify title
-		const nameInput = page.getByRole('textbox', { name: 'Appointment Name' })
+		const nameInput = page.getByRole('textbox', { name: 'Appointment name' })
 		await nameInput.clear()
 		await nameInput.fill(originalTitle + ' (Edited)')
 
@@ -118,17 +118,17 @@ test.describe('Attendance App - Appointment Management', () => {
 
 		// Wait for form page and verify it's Copy mode
 		await page.waitForURL(/.*\/copy\/\d+$/)
-		await expect(page.getByRole('heading', { name: 'Copy Appointment' })).toBeVisible()
+		await expect(page.getByRole('heading', { name: 'Copy appointment' })).toBeVisible()
 
 		// Verify name is pre-filled with (Copy) suffix
-		const nameInput = page.getByRole('textbox', { name: 'Appointment Name' })
+		const nameInput = page.getByRole('textbox', { name: 'Appointment name' })
 		const nameValue = await nameInput.inputValue()
 		expect(nameValue).toContain(originalTitle)
 		expect(nameValue).toContain('(Copy)')
 
 		// Verify dates are empty (user must set new dates per spec)
-		const startInput = page.getByRole('textbox', { name: 'Start Date & Time' })
-		const endInput = page.getByRole('textbox', { name: 'End Date & Time' })
+		const startInput = page.getByRole('textbox', { name: 'Start date & time' })
+		const endInput = page.getByRole('textbox', { name: 'End date & time' })
 		await expect(startInput).toHaveValue('')
 		await expect(endInput).toHaveValue('')
 
@@ -195,7 +195,7 @@ test.describe('Attendance App - User Responses', () => {
 		await page.getByRole('button', { name: 'Yes', exact: true }).first().click()
 
 		// Wait for response to be saved by checking summary is visible
-		const summary = page.getByRole('heading', { name: 'Response Summary' }).first()
+		const summary = page.getByRole('heading', { name: 'Response summary' }).first()
 		await expect(summary).toBeVisible()
 	})
 
@@ -213,7 +213,7 @@ test.describe('Attendance App - User Responses', () => {
 		await page.waitForLoadState('networkidle')
 
 		// Verify by checking response summary or button states (use .first() since multiple appointment cards exist)
-		await expect(page.getByRole('heading', { name: 'Response Summary' }).first()).toBeVisible()
+		await expect(page.getByRole('heading', { name: 'Response summary' }).first()).toBeVisible()
 	})
 
 	test('should add comment to response', async ({ page, loginAsUser, attendanceApp }) => {
@@ -222,7 +222,7 @@ test.describe('Attendance App - User Responses', () => {
 		await page.waitForLoadState('networkidle')
 
 		// Navigate to Upcoming Appointments (not Unanswered) to ensure appointment stays visible after voting
-		await page.getByRole('link', { name: 'Upcoming Appointments' }).click()
+		await page.getByRole('link', { name: 'Upcoming appointments' }).click()
 		await page.waitForLoadState('networkidle')
 
 		// Click Yes first (comment section appears after voting)
@@ -249,7 +249,7 @@ test.describe('Attendance App - User Responses', () => {
 		await page.waitForLoadState('networkidle')
 
 		// Navigate back to Upcoming Appointments after reload
-		await page.getByRole('link', { name: 'Upcoming Appointments' }).click()
+		await page.getByRole('link', { name: 'Upcoming appointments' }).click()
 		await page.waitForLoadState('networkidle')
 
 		// Wait for comment toggle button to appear after reload

--- a/tests/e2e/3-voting.spec.js
+++ b/tests/e2e/3-voting.spec.js
@@ -114,8 +114,8 @@ test.describe('Attendance App - Dashboard Widget Voting', () => {
 		await expect(page.getByRole('heading', { level: 3, name: titleText })).toBeVisible()
 		
 		// Verify detail page elements
-		await expect(page.getByRole('heading', { name: 'Your Response' })).toBeVisible()
-		await expect(page.getByRole('heading', { name: 'Response Summary' })).toBeVisible()
+		await expect(page.getByRole('heading', { name: 'Your response' })).toBeVisible()
+		await expect(page.getByRole('heading', { name: 'Response summary' })).toBeVisible()
 	})
 
 	test('should open detail view by clicking appointment description', async ({ page }) => {
@@ -148,8 +148,8 @@ test.describe('Attendance App - Dashboard Widget Voting', () => {
 		await expect(page).toHaveURL(/\/apps\/attendance/)
 		
 		// Verify we're on the listing page (navigation is visible)
-		await expect(page.getByRole('link', { name: 'Upcoming Appointments' })).toBeVisible()
-		await expect(page.getByRole('link', { name: 'Create Appointment' })).toBeVisible()
+		await expect(page.getByRole('link', { name: 'Upcoming appointments' })).toBeVisible()
+		await expect(page.getByRole('link', { name: 'Create appointment' })).toBeVisible()
 	})
 
 	test('should vote Maybe on appointment from dashboard', async ({ page }) => {

--- a/tests/e2e/4-admin-settings.spec.js
+++ b/tests/e2e/4-admin-settings.spec.js
@@ -69,11 +69,11 @@ test.describe('Attendance App - Admin Settings', () => {
 			await page.waitForLoadState('networkidle')
 
 			// Create test appointment
-			await page.getByRole('link', { name: 'Create Appointment' }).click()
+			await page.getByRole('link', { name: 'Create appointment' }).click()
 			await page.waitForURL(/.*\/create$/)
 			await page.waitForLoadState('networkidle')
-			await expect(page.getByRole('heading', { name: 'Create Appointment' })).toBeVisible()
-			await page.getByRole('textbox', { name: 'Appointment Name' }).fill('Check-in Test Meeting')
+			await expect(page.getByRole('heading', { name: 'Create appointment' })).toBeVisible()
+			await page.getByRole('textbox', { name: 'Appointment name' }).fill('Check-in Test Meeting')
 			const descEditor1 = page.locator('[data-test="input-appointment-description"] .CodeMirror')
 			await descEditor1.waitFor({ state: 'visible' })
 			await descEditor1.click()
@@ -83,8 +83,8 @@ test.describe('Attendance App - Admin Settings', () => {
 			const startDate = new Date(now.getTime() + 2 * 24 * 60 * 60 * 1000)
 			const endDate = new Date(startDate.getTime() + 1 * 60 * 60 * 1000)
 
-			await page.getByRole('textbox', { name: 'Start Date & Time' }).fill(startDate.toISOString().slice(0, 16))
-			await page.getByRole('textbox', { name: 'End Date & Time' }).fill(endDate.toISOString().slice(0, 16))
+			await page.getByRole('textbox', { name: 'Start date & time' }).fill(startDate.toISOString().slice(0, 16))
+			await page.getByRole('textbox', { name: 'End date & time' }).fill(endDate.toISOString().slice(0, 16))
 			await page.getByRole('button', { name: 'Save' }).click()
 			await page.waitForURL(/.*\/apps\/attendance(?!\/(create|edit|copy))/)
 			await page.waitForLoadState('networkidle')
@@ -159,11 +159,11 @@ test.describe('Attendance App - Admin Settings', () => {
 			await attendanceApp()
 			await page.waitForLoadState('networkidle')
 
-			await page.getByRole('link', { name: 'Create Appointment' }).click()
+			await page.getByRole('link', { name: 'Create appointment' }).click()
 			await page.waitForURL(/.*\/create$/)
 			await page.waitForLoadState('networkidle')
-			await expect(page.getByRole('heading', { name: 'Create Appointment' })).toBeVisible()
-			await page.getByRole('textbox', { name: 'Appointment Name' }).fill('Response Overview Test')
+			await expect(page.getByRole('heading', { name: 'Create appointment' })).toBeVisible()
+			await page.getByRole('textbox', { name: 'Appointment name' }).fill('Response Overview Test')
 			const descEditor2 = page.locator('[data-test="input-appointment-description"] .CodeMirror')
 			await descEditor2.waitFor({ state: 'visible' })
 			await descEditor2.click()
@@ -173,14 +173,14 @@ test.describe('Attendance App - Admin Settings', () => {
 			const startDate = new Date(now.getTime() + 2 * 24 * 60 * 60 * 1000)
 			const endDate = new Date(startDate.getTime() + 1 * 60 * 60 * 1000)
 
-			await page.getByRole('textbox', { name: 'Start Date & Time' }).fill(startDate.toISOString().slice(0, 16))
-			await page.getByRole('textbox', { name: 'End Date & Time' }).fill(endDate.toISOString().slice(0, 16))
+			await page.getByRole('textbox', { name: 'Start date & time' }).fill(startDate.toISOString().slice(0, 16))
+			await page.getByRole('textbox', { name: 'End date & time' }).fill(endDate.toISOString().slice(0, 16))
 			await page.getByRole('button', { name: 'Save' }).click()
 			await page.waitForURL(/.*\/apps\/attendance(?!\/(create|edit|copy))/)
 			await page.waitForLoadState('networkidle')
 
 			// Admin should see response summary
-			const adminResponseSummary = page.getByRole('heading', { name: 'Response Summary' }).first()
+			const adminResponseSummary = page.getByRole('heading', { name: 'Response summary' }).first()
 			await expect(adminResponseSummary).toBeVisible()
 
 			// Login as test user
@@ -189,7 +189,7 @@ test.describe('Attendance App - Admin Settings', () => {
 			await page.waitForLoadState('networkidle')
 
 			// Test user should NOT see response summary
-			const testUserResponseSummary = page.getByRole('heading', { name: 'Response Summary' })
+			const testUserResponseSummary = page.getByRole('heading', { name: 'Response summary' })
 			await expect(testUserResponseSummary).not.toBeVisible()
 
 			// But test user should still be able to respond

--- a/tests/e2e/5-export.spec.js
+++ b/tests/e2e/5-export.spec.js
@@ -3,7 +3,7 @@ import { test, expect } from './fixtures/nextcloud.js'
 // Helper function to create an appointment
 async function createAppointment(page, { name, description, daysFromNow = 2, durationHours = 1 }) {
 	// Wait for Create Appointment link to be ready
-	const createLink = page.getByRole('link', { name: 'Create Appointment' })
+	const createLink = page.getByRole('link', { name: 'Create appointment' })
 	await createLink.waitFor({ state: 'visible' })
 
 	// Click create button (navigates to form page)
@@ -12,10 +12,10 @@ async function createAppointment(page, { name, description, daysFromNow = 2, dur
 	// Wait for form page to load
 	await page.waitForURL(/.*\/create$/)
 	await page.waitForLoadState('networkidle')
-	await expect(page.getByRole('heading', { name: 'Create Appointment' })).toBeVisible()
+	await expect(page.getByRole('heading', { name: 'Create appointment' })).toBeVisible()
 
 	// Wait for name field to be ready and fill it
-	const nameInput = page.getByRole('textbox', { name: 'Appointment Name' })
+	const nameInput = page.getByRole('textbox', { name: 'Appointment name' })
 	await nameInput.waitFor({ state: 'visible' })
 	await nameInput.fill(name)
 
@@ -30,8 +30,8 @@ async function createAppointment(page, { name, description, daysFromNow = 2, dur
 	const startDate = new Date(now.getTime() + daysFromNow * 24 * 60 * 60 * 1000)
 	const endDate = new Date(startDate.getTime() + durationHours * 60 * 60 * 1000)
 
-	await page.getByRole('textbox', { name: 'Start Date & Time' }).fill(startDate.toISOString().slice(0, 16))
-	await page.getByRole('textbox', { name: 'End Date & Time' }).fill(endDate.toISOString().slice(0, 16))
+	await page.getByRole('textbox', { name: 'Start date & time' }).fill(startDate.toISOString().slice(0, 16))
+	await page.getByRole('textbox', { name: 'End date & time' }).fill(endDate.toISOString().slice(0, 16))
 
 	// Save
 	await page.getByRole('button', { name: 'Save' }).click()

--- a/tests/e2e/5-visibility-users.spec.js
+++ b/tests/e2e/5-visibility-users.spec.js
@@ -3,7 +3,7 @@ import { test, expect, login } from './fixtures/nextcloud.js'
 // Helper function to create an appointment with visibility settings
 async function createAppointmentWithVisibility(page, { name, description, daysFromNow = 2, durationHours = 1, visibleUsers = [] }) {
 	// Wait for Create Appointment link to be ready
-	const createLink = page.getByRole('link', { name: 'Create Appointment' })
+	const createLink = page.getByRole('link', { name: 'Create appointment' })
 	await createLink.waitFor({ state: 'visible' })
 
 	// Click create button (navigates to form page)
@@ -12,10 +12,10 @@ async function createAppointmentWithVisibility(page, { name, description, daysFr
 	// Wait for form page to load
 	await page.waitForURL(/.*\/create$/)
 	await page.waitForLoadState('networkidle')
-	await expect(page.getByRole('heading', { name: 'Create Appointment' })).toBeVisible()
+	await expect(page.getByRole('heading', { name: 'Create appointment' })).toBeVisible()
 
 	// Wait for name field to be ready and fill it
-	const nameInput = page.getByRole('textbox', { name: 'Appointment Name' })
+	const nameInput = page.getByRole('textbox', { name: 'Appointment name' })
 	await nameInput.waitFor({ state: 'visible' })
 	await nameInput.fill(name)
 
@@ -30,8 +30,8 @@ async function createAppointmentWithVisibility(page, { name, description, daysFr
 	const startDate = new Date(now.getTime() + daysFromNow * 24 * 60 * 60 * 1000)
 	const endDate = new Date(startDate.getTime() + durationHours * 60 * 60 * 1000)
 
-	await page.getByRole('textbox', { name: 'Start Date & Time' }).fill(startDate.toISOString().slice(0, 16))
-	await page.getByRole('textbox', { name: 'End Date & Time' }).fill(endDate.toISOString().slice(0, 16))
+	await page.getByRole('textbox', { name: 'Start date & time' }).fill(startDate.toISOString().slice(0, 16))
+	await page.getByRole('textbox', { name: 'End date & time' }).fill(endDate.toISOString().slice(0, 16))
 
 	// Add visible users if specified
 	if (visibleUsers.length > 0) {
@@ -210,7 +210,7 @@ test.describe('Attendance App - User Visibility Filtering', () => {
 
 		// Wait for form page and verify it's Edit mode
 		await page.waitForURL(/.*\/edit\/\d+$/)
-		await expect(page.getByRole('heading', { name: 'Edit Appointment' })).toBeVisible()
+		await expect(page.getByRole('heading', { name: 'Edit appointment' })).toBeVisible()
 
 		// Verify that "test1" is shown in the visibility field
 		// The visibility selector should show the selected user(s) in .vs__selected spans

--- a/tests/e2e/6-visibility-groups.spec.js
+++ b/tests/e2e/6-visibility-groups.spec.js
@@ -59,7 +59,7 @@ async function addUserToGroup(page, username, groupName) {
 // Helper function to create an appointment with group visibility
 async function createAppointmentWithGroupVisibility(page, { name, description, daysFromNow = 2, durationHours = 1, visibleGroups = [] }) {
 	// Wait for Create Appointment link to be ready
-	const createLink = page.getByRole('link', { name: 'Create Appointment' })
+	const createLink = page.getByRole('link', { name: 'Create appointment' })
 	await createLink.waitFor({ state: 'visible' })
 
 	// Click create button (navigates to form page)
@@ -68,10 +68,10 @@ async function createAppointmentWithGroupVisibility(page, { name, description, d
 	// Wait for form page to load
 	await page.waitForURL(/.*\/create$/)
 	await page.waitForLoadState('networkidle')
-	await expect(page.getByRole('heading', { name: 'Create Appointment' })).toBeVisible()
+	await expect(page.getByRole('heading', { name: 'Create appointment' })).toBeVisible()
 
 	// Wait for name field to be ready and fill it
-	const nameInput = page.getByRole('textbox', { name: 'Appointment Name' })
+	const nameInput = page.getByRole('textbox', { name: 'Appointment name' })
 	await nameInput.waitFor({ state: 'visible' })
 	await nameInput.fill(name)
 
@@ -86,8 +86,8 @@ async function createAppointmentWithGroupVisibility(page, { name, description, d
 	const startDate = new Date(now.getTime() + daysFromNow * 24 * 60 * 60 * 1000)
 	const endDate = new Date(startDate.getTime() + durationHours * 60 * 60 * 1000)
 
-	await page.getByRole('textbox', { name: 'Start Date & Time' }).fill(startDate.toISOString().slice(0, 16))
-	await page.getByRole('textbox', { name: 'End Date & Time' }).fill(endDate.toISOString().slice(0, 16))
+	await page.getByRole('textbox', { name: 'Start date & time' }).fill(startDate.toISOString().slice(0, 16))
+	await page.getByRole('textbox', { name: 'End date & time' }).fill(endDate.toISOString().slice(0, 16))
 
 	// Add visible groups if specified
 	if (visibleGroups.length > 0) {
@@ -227,7 +227,7 @@ test.describe('Attendance App - Group Visibility Filtering', () => {
 
 			// Wait for form page and verify it's Edit mode
 			await page.waitForURL(/.*\/edit\/\d+$/)
-			await expect(page.getByRole('heading', { name: 'Edit Appointment' })).toBeVisible()
+			await expect(page.getByRole('heading', { name: 'Edit appointment' })).toBeVisible()
 
 			// Verify that the developers group is shown in the visibility field in .vs__selected span
 			// Scope to the visibility selector component to avoid ambiguity
@@ -251,17 +251,17 @@ test.describe('Attendance App - Group Visibility Filtering', () => {
 			await page.waitForLoadState('networkidle')
 
 			// Create appointment with both specific user and group
-			const createLink = page.getByRole('link', { name: 'Create Appointment' })
+			const createLink = page.getByRole('link', { name: 'Create appointment' })
 			await createLink.waitFor({ state: 'visible' })
 			await createLink.click()
 
 			// Wait for form page to load
 			await page.waitForURL(/.*\/create$/)
 			await page.waitForLoadState('networkidle')
-			await expect(page.getByRole('heading', { name: 'Create Appointment' })).toBeVisible()
+			await expect(page.getByRole('heading', { name: 'Create appointment' })).toBeVisible()
 
 			// Fill form
-			await page.getByRole('textbox', { name: 'Appointment Name' }).fill('Mixed Visibility Meeting')
+			await page.getByRole('textbox', { name: 'Appointment name' }).fill('Mixed Visibility Meeting')
 			const descEditor = page.locator('[data-test="input-appointment-description"] .CodeMirror')
 			await descEditor.waitFor({ state: 'visible' })
 			await descEditor.click()
@@ -271,8 +271,8 @@ test.describe('Attendance App - Group Visibility Filtering', () => {
 			const startDate = new Date(now.getTime() + 5 * 24 * 60 * 60 * 1000)
 			const endDate = new Date(startDate.getTime() + 60 * 60 * 1000)
 
-			await page.getByRole('textbox', { name: 'Start Date & Time' }).fill(startDate.toISOString().slice(0, 16))
-			await page.getByRole('textbox', { name: 'End Date & Time' }).fill(endDate.toISOString().slice(0, 16))
+			await page.getByRole('textbox', { name: 'Start date & time' }).fill(startDate.toISOString().slice(0, 16))
+			await page.getByRole('textbox', { name: 'End date & time' }).fill(endDate.toISOString().slice(0, 16))
 
 			// Add developers group (no ambiguity)
 			await page.getByRole('searchbox').click()
@@ -310,7 +310,7 @@ test.describe('Attendance App - Group Visibility Filtering', () => {
 			await page.waitForLoadState('networkidle')
 
 			// Navigate to Upcoming Appointments to see all appointments
-			await page.getByRole('link', { name: 'Upcoming Appointments' }).click()
+			await page.getByRole('link', { name: 'Upcoming appointments' }).click()
 			await page.waitForLoadState('networkidle')
 
 			// Should see "Mixed Visibility Meeting" because test2 user was explicitly added

--- a/tests/e2e/8-attachments.spec.js
+++ b/tests/e2e/8-attachments.spec.js
@@ -105,7 +105,7 @@ test.describe.serial('Attendance App - Attachments', () => {
 
 			// Verify attachment section exists
 			await expect(page.getByText('Attachments')).toBeVisible()
-			await expect(page.getByRole('button', { name: 'Add from Files' })).toBeVisible()
+			await expect(page.getByRole('button', { name: 'Add from files' })).toBeVisible()
 
 			// Close form (navigate back)
 			await page.getByRole('button', { name: 'Cancel' }).click()
@@ -121,11 +121,10 @@ test.describe.serial('Attendance App - Attachments', () => {
 			await expect(page.getByRole('heading', { name: 'Create appointment' })).toBeVisible()
 
 			// Click Add from Files button
-			await page.getByRole('button', { name: 'Add from Files' }).click()
+			await page.getByRole('button', { name: 'Add from files' }).click()
 
-			// Verify file picker opens (look for file picker modal/dialog)
-			// The file picker from @nextcloud/dialogs should show
-			const filePicker = page.locator('.file-picker, .oc-dialog, [class*="filepicker"]').first()
+			// Verify file picker opens with the correct title
+			const filePicker = page.getByRole('dialog', { name: 'Choose files or folders' })
 			await expect(filePicker).toBeVisible({ timeout: 5000 })
 
 			// File picker verified as open - the test goal is achieved
@@ -156,10 +155,10 @@ test.describe.serial('Attendance App - Attachments', () => {
 			await page.getByRole('textbox', { name: 'End date & time' }).fill(endDate.toISOString().slice(0, 16))
 
 			// Click Add from Files button
-			await page.getByRole('button', { name: 'Add from Files' }).click()
+			await page.getByRole('button', { name: 'Add from files' }).click()
 
 			// Wait for file picker
-			const filePicker = page.locator('.file-picker, .oc-dialog, [class*="filepicker"]').first()
+			const filePicker = page.getByRole('dialog', { name: 'Choose files or folders' })
 			await expect(filePicker).toBeVisible({ timeout: 5000 })
 
 			// Look for the test file and select it
@@ -218,7 +217,7 @@ test.describe.serial('Attendance App - Attachments', () => {
 
 				// Verify attachment section is visible
 				await expect(page.getByText('Attachments')).toBeVisible()
-				await expect(page.getByRole('button', { name: 'Add from Files' })).toBeVisible()
+				await expect(page.getByRole('button', { name: 'Add from files' })).toBeVisible()
 
 				// Close form
 				await page.getByRole('button', { name: 'Cancel' }).click()

--- a/tests/e2e/8-attachments.spec.js
+++ b/tests/e2e/8-attachments.spec.js
@@ -42,7 +42,7 @@ async function getFileId(request, username, password, filename) {
 // Helper function to create an appointment with optional attachments
 async function createAppointment(page, { name, description, daysFromNow = 2, durationHours = 1 }) {
 	// Wait for Create Appointment link to be ready
-	const createLink = page.getByRole('link', { name: 'Create Appointment' })
+	const createLink = page.getByRole('link', { name: 'Create appointment' })
 	await createLink.waitFor({ state: 'visible' })
 
 	// Click create button (navigates to form page)
@@ -51,10 +51,10 @@ async function createAppointment(page, { name, description, daysFromNow = 2, dur
 	// Wait for form page to load
 	await page.waitForURL(/.*\/create$/)
 	await page.waitForLoadState('networkidle')
-	await expect(page.getByRole('heading', { name: 'Create Appointment' })).toBeVisible()
+	await expect(page.getByRole('heading', { name: 'Create appointment' })).toBeVisible()
 
 	// Wait for name field to be ready and fill it
-	const nameInput = page.getByRole('textbox', { name: 'Appointment Name' })
+	const nameInput = page.getByRole('textbox', { name: 'Appointment name' })
 	await nameInput.waitFor({ state: 'visible' })
 	await nameInput.fill(name)
 
@@ -69,8 +69,8 @@ async function createAppointment(page, { name, description, daysFromNow = 2, dur
 	const startDate = new Date(now.getTime() + daysFromNow * 24 * 60 * 60 * 1000)
 	const endDate = new Date(startDate.getTime() + durationHours * 60 * 60 * 1000)
 
-	await page.getByRole('textbox', { name: 'Start Date & Time' }).fill(startDate.toISOString().slice(0, 16))
-	await page.getByRole('textbox', { name: 'End Date & Time' }).fill(endDate.toISOString().slice(0, 16))
+	await page.getByRole('textbox', { name: 'Start date & time' }).fill(startDate.toISOString().slice(0, 16))
+	await page.getByRole('textbox', { name: 'End date & time' }).fill(endDate.toISOString().slice(0, 16))
 
 	// Save
 	await page.getByRole('button', { name: 'Save' }).click()
@@ -96,12 +96,12 @@ test.describe.serial('Attendance App - Attachments', () => {
 
 		test('should show attachment section in create appointment form', async ({ page }) => {
 			// Click create button
-			await page.getByRole('link', { name: 'Create Appointment' }).click()
+			await page.getByRole('link', { name: 'Create appointment' }).click()
 
 			// Wait for form page to load
 			await page.waitForURL(/.*\/create$/)
 			await page.waitForLoadState('networkidle')
-			await expect(page.getByRole('heading', { name: 'Create Appointment' })).toBeVisible()
+			await expect(page.getByRole('heading', { name: 'Create appointment' })).toBeVisible()
 
 			// Verify attachment section exists
 			await expect(page.getByText('Attachments')).toBeVisible()
@@ -113,12 +113,12 @@ test.describe.serial('Attendance App - Attachments', () => {
 
 		test('should open file picker when clicking Add from Files', async ({ page }) => {
 			// Click create button
-			await page.getByRole('link', { name: 'Create Appointment' }).click()
+			await page.getByRole('link', { name: 'Create appointment' }).click()
 
 			// Wait for form page to load
 			await page.waitForURL(/.*\/create$/)
 			await page.waitForLoadState('networkidle')
-			await expect(page.getByRole('heading', { name: 'Create Appointment' })).toBeVisible()
+			await expect(page.getByRole('heading', { name: 'Create appointment' })).toBeVisible()
 
 			// Click Add from Files button
 			await page.getByRole('button', { name: 'Add from Files' }).click()
@@ -135,15 +135,15 @@ test.describe.serial('Attendance App - Attachments', () => {
 
 		test('should add attachment via file picker', async ({ page }) => {
 			// Click create button
-			await page.getByRole('link', { name: 'Create Appointment' }).click()
+			await page.getByRole('link', { name: 'Create appointment' }).click()
 
 			// Wait for form page to load
 			await page.waitForURL(/.*\/create$/)
 			await page.waitForLoadState('networkidle')
-			await expect(page.getByRole('heading', { name: 'Create Appointment' })).toBeVisible()
+			await expect(page.getByRole('heading', { name: 'Create appointment' })).toBeVisible()
 
 			// Fill required fields first
-			await page.getByRole('textbox', { name: 'Appointment Name' }).fill('Attachment Test Meeting')
+			await page.getByRole('textbox', { name: 'Appointment name' }).fill('Attachment Test Meeting')
 			const descEditor = page.locator('[data-test="input-appointment-description"] .CodeMirror')
 			await descEditor.waitFor({ state: 'visible' })
 			await descEditor.click()
@@ -152,8 +152,8 @@ test.describe.serial('Attendance App - Attachments', () => {
 			const now = new Date()
 			const startDate = new Date(now.getTime() + 3 * 24 * 60 * 60 * 1000)
 			const endDate = new Date(startDate.getTime() + 1 * 60 * 60 * 1000)
-			await page.getByRole('textbox', { name: 'Start Date & Time' }).fill(startDate.toISOString().slice(0, 16))
-			await page.getByRole('textbox', { name: 'End Date & Time' }).fill(endDate.toISOString().slice(0, 16))
+			await page.getByRole('textbox', { name: 'Start date & time' }).fill(startDate.toISOString().slice(0, 16))
+			await page.getByRole('textbox', { name: 'End date & time' }).fill(endDate.toISOString().slice(0, 16))
 
 			// Click Add from Files button
 			await page.getByRole('button', { name: 'Add from Files' }).click()
@@ -214,7 +214,7 @@ test.describe.serial('Attendance App - Attachments', () => {
 
 				// Wait for form page and verify it's Edit mode
 				await page.waitForURL(/.*\/edit\/\d+$/)
-				await expect(page.getByRole('heading', { name: 'Edit Appointment' })).toBeVisible()
+				await expect(page.getByRole('heading', { name: 'Edit appointment' })).toBeVisible()
 
 				// Verify attachment section is visible
 				await expect(page.getByText('Attachments')).toBeVisible()

--- a/tests/e2e/9-recurrence.spec.js
+++ b/tests/e2e/9-recurrence.spec.js
@@ -5,16 +5,16 @@ import { test, expect } from './fixtures/nextcloud.js'
  * Returns the start date for further use.
  */
 async function navigateToCreateForm(page, { name = 'Recurring Test', daysFromNow = 5, durationHours = 1 } = {}) {
-	const createLink = page.getByRole('link', { name: 'Create Appointment' })
+	const createLink = page.getByRole('link', { name: 'Create appointment' })
 	await createLink.waitFor({ state: 'visible' })
 	await createLink.click()
 
 	await page.waitForURL(/.*\/create$/)
 	await page.waitForLoadState('networkidle')
-	await expect(page.getByRole('heading', { name: 'Create Appointment' })).toBeVisible()
+	await expect(page.getByRole('heading', { name: 'Create appointment' })).toBeVisible()
 
 	// Fill name
-	const nameInput = page.getByRole('textbox', { name: 'Appointment Name' })
+	const nameInput = page.getByRole('textbox', { name: 'Appointment name' })
 	await nameInput.waitFor({ state: 'visible' })
 	await nameInput.fill(name)
 
@@ -23,8 +23,8 @@ async function navigateToCreateForm(page, { name = 'Recurring Test', daysFromNow
 	const startDate = new Date(now.getTime() + daysFromNow * 24 * 60 * 60 * 1000)
 	const endDate = new Date(startDate.getTime() + durationHours * 60 * 60 * 1000)
 
-	await page.getByRole('textbox', { name: 'Start Date & Time' }).fill(startDate.toISOString().slice(0, 16))
-	await page.getByRole('textbox', { name: 'End Date & Time' }).fill(endDate.toISOString().slice(0, 16))
+	await page.getByRole('textbox', { name: 'Start date & time' }).fill(startDate.toISOString().slice(0, 16))
+	await page.getByRole('textbox', { name: 'End date & time' }).fill(endDate.toISOString().slice(0, 16))
 
 	return startDate
 }
@@ -45,7 +45,7 @@ test.describe('Attendance App - Recurrence', () => {
 	})
 
 	test('recurrence toggle should be disabled without start date', async ({ page }) => {
-		const createLink = page.getByRole('link', { name: 'Create Appointment' })
+		const createLink = page.getByRole('link', { name: 'Create appointment' })
 		await createLink.waitFor({ state: 'visible' })
 		await createLink.click()
 
@@ -258,20 +258,20 @@ test.describe('Attendance App - Recurrence', () => {
 		const endTime = new Date(nextWednesday.getTime() + 2 * 60 * 60 * 1000)
 
 		// Navigate to create form manually (need a Wednesday start date)
-		const createLink = page.getByRole('link', { name: 'Create Appointment' })
+		const createLink = page.getByRole('link', { name: 'Create appointment' })
 		await createLink.waitFor({ state: 'visible' })
 		await createLink.click()
 		await page.waitForURL(/.*\/create$/)
 		await page.waitForLoadState('networkidle')
 
 		// Fill name
-		const nameInput = page.getByRole('textbox', { name: 'Appointment Name' })
+		const nameInput = page.getByRole('textbox', { name: 'Appointment name' })
 		await nameInput.waitFor({ state: 'visible' })
 		await nameInput.fill('Triweekly Wednesday Sync')
 
 		// Set start to next Wednesday
-		await page.getByRole('textbox', { name: 'Start Date & Time' }).fill(nextWednesday.toISOString().slice(0, 16))
-		await page.getByRole('textbox', { name: 'End Date & Time' }).fill(endTime.toISOString().slice(0, 16))
+		await page.getByRole('textbox', { name: 'Start date & time' }).fill(nextWednesday.toISOString().slice(0, 16))
+		await page.getByRole('textbox', { name: 'End date & time' }).fill(endTime.toISOString().slice(0, 16))
 
 		// Enable recurrence
 		await enableRecurrence(page)
@@ -331,7 +331,7 @@ test.describe('Attendance App - Date Validation', () => {
 	})
 
 	test('should block save when end date is before start date', async ({ page }) => {
-		const createLink = page.getByRole('link', { name: 'Create Appointment' })
+		const createLink = page.getByRole('link', { name: 'Create appointment' })
 		await createLink.waitFor({ state: 'visible' })
 		await createLink.click()
 
@@ -339,7 +339,7 @@ test.describe('Attendance App - Date Validation', () => {
 		await page.waitForLoadState('networkidle')
 
 		// Fill name
-		const nameInput = page.getByRole('textbox', { name: 'Appointment Name' })
+		const nameInput = page.getByRole('textbox', { name: 'Appointment name' })
 		await nameInput.fill('Date Validation Test')
 
 		// Set end date before start date
@@ -347,8 +347,8 @@ test.describe('Attendance App - Date Validation', () => {
 		const startDate = new Date(now.getTime() + 5 * 24 * 60 * 60 * 1000)
 		const endDate = new Date(startDate.getTime() - 2 * 60 * 60 * 1000) // 2 hours BEFORE start
 
-		await page.getByRole('textbox', { name: 'Start Date & Time' }).fill(startDate.toISOString().slice(0, 16))
-		await page.getByRole('textbox', { name: 'End Date & Time' }).fill(endDate.toISOString().slice(0, 16))
+		await page.getByRole('textbox', { name: 'Start date & time' }).fill(startDate.toISOString().slice(0, 16))
+		await page.getByRole('textbox', { name: 'End date & time' }).fill(endDate.toISOString().slice(0, 16))
 
 		// Try to save
 		await page.getByRole('button', { name: 'Save' }).click()


### PR DESCRIPTION
Update all e2e test assertions to use lowercase capitalization
matching the Nextcloud translation guidelines (only capitalize
first word). Affected strings: Create appointment, Edit appointment,
Copy appointment, Appointment name, Start/End date & time,
Response summary, Your response, Upcoming appointments, Share link.

https://claude.ai/code/session_01M4V5LNJVZRKU1WNa6oySde