### PR TITLE
refactor: Separate API concerns, consistent wrapping, typed responses

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -38,6 +38,10 @@ return [
 
 		// User data
 		['name' => 'appointment#getPermissions', 'url' => '/api/user/permissions', 'verb' => 'GET'],
+		['name' => 'appointment#getUserConfig', 'url' => '/api/user/config', 'verb' => 'GET'],
+
+		// Capabilities
+		['name' => 'appointment#getCapabilities', 'url' => '/api/capabilities', 'verb' => 'GET'],
 
 		// Search
 		['name' => 'appointment#searchUsersGroupsTeams', 'url' => '/api/search/users-groups-teams', 'verb' => 'GET'],

--- a/docs/api-migration.md
+++ b/docs/api-migration.md
@@ -1,0 +1,141 @@
+# API migration guide (v1.32 to v1.33)
+
+This document describes the breaking API changes for consumers (Flutter app, external integrations).
+
+## New endpoints
+
+### `GET /api/capabilities`
+
+Returns system-wide capabilities. No authentication required beyond Nextcloud login.
+
+**Response:**
+```json
+{
+  "calendarAvailable": true,
+  "calendarSyncEnabled": true,
+  "teamsAvailable": true,
+  "calendarSyncAvailable": true,
+  "notificationsAppEnabled": true
+}
+```
+
+### `GET /api/user/config`
+
+Returns user-relevant app configuration.
+
+**Response:**
+```json
+{
+  "displayOrder": "name_first"
+}
+```
+
+## Changed endpoints
+
+### `GET /api/user/permissions`
+
+**Removed fields:** `calendarAvailable`, `calendarSyncEnabled`, `displayOrder`
+
+These are now available via `GET /api/capabilities` and `GET /api/user/config`.
+
+**Before:**
+```json
+{
+  "canManageAppointments": true,
+  "canCheckin": true,
+  "canSeeResponseOverview": true,
+  "canSeeComments": true,
+  "canSelfCheckin": true,
+  "calendarAvailable": true,
+  "calendarSyncEnabled": true,
+  "displayOrder": "name_first"
+}
+```
+
+**After:**
+```json
+{
+  "canManageAppointments": true,
+  "canCheckin": true,
+  "canSeeResponseOverview": true,
+  "canSeeComments": true,
+  "canSelfCheckin": true
+}
+```
+
+### `GET /api/admin/settings`
+
+Response is now structured into `config`, `status`, and `groups`.
+
+Capabilities (`teamsAvailable`, `calendarSyncAvailable`, `notificationsAppEnabled`) are now served by `GET /api/capabilities`.
+
+**Before:**
+```json
+{
+  "groups": [...],
+  "whitelistedGroups": [...],
+  "whitelistedTeams": [...],
+  "teamsAvailable": true,
+  "permissions": {...},
+  "reminders": {
+    "enabled": true,
+    "reminderDays": 7,
+    "reminderFrequency": 0,
+    "notificationsAppEnabled": true,
+    "nextAppointment": {...},
+    "nextReminderRun": "..."
+  },
+  "calendarSync": {"enabled": true, "available": true},
+  "displayOrder": "name_first"
+}
+```
+
+**After:**
+```json
+{
+  "config": {
+    "whitelistedGroups": [...],
+    "whitelistedTeams": [...],
+    "permissions": {...},
+    "reminders": {
+      "enabled": true,
+      "reminderDays": 7,
+      "reminderFrequency": 0
+    },
+    "calendarSync": {"enabled": true},
+    "displayOrder": "name_first"
+  },
+  "status": {
+    "nextAppointment": {"name": "...", "startDatetime": "..."},
+    "nextReminderRun": "2026-03-23 10:00:00"
+  },
+  "groups": [{"id": "admin", "displayName": "Admin"}, ...]
+}
+```
+
+### `POST /api/admin/settings`
+
+**Before:** returned `{"success": true}`
+**After:** returns `{}`
+
+### `DELETE /api/appointments/{id}`
+
+**Before:** returned `{"success": true, "deletedCount": 1}`
+**After:** returns `{"deletedCount": 1}`
+
+### `DELETE /api/appointments/{id}/checkin-reset`
+
+**Before:** returned `{"success": true}`
+**After:** returns `{}`
+
+### `POST /api/export`
+
+**Before:** returned `{"success": true, "path": "...", "filename": "..."}`
+**After:** returns `{"path": "...", "filename": "..."}`
+
+## Status code fixes
+
+- `POST /api/appointments` now correctly returns `201 Created` (was `200 OK` in the OpenAPI spec)
+- `POST /api/appointments/bulk` now correctly returns `201 Created` (was `200 OK` in the OpenAPI spec)
+
+Note: The actual HTTP status codes were already correct in the implementation; only the OpenAPI documentation was fixed.

--- a/lib/Controller/AdminController.php
+++ b/lib/Controller/AdminController.php
@@ -54,9 +54,13 @@ class AdminController extends Controller {
 	}
 
 	/**
-	 * Get admin settings data (groups and current whitelist)
+	 * Get admin settings data
 	 *
-	 * @return JSONResponse<Http::STATUS_OK, array{success: bool, groups: list<AttendanceGroupOption>, whitelistedGroups: list<string>, whitelistedTeams: list<AttendanceTeamOption>, teamsAvailable: bool, permissions: AttendancePermissionSettings, reminders: AttendanceReminderSettings, calendarSync: AttendanceCalendarSyncSettings, displayOrder: string}, array{}>|JSONResponse<Http::STATUS_OK, array{success: bool, error: string}, array{}>|JSONResponse<Http::STATUS_UNAUTHORIZED, array{success: bool, error: string}, array{}>|JSONResponse<Http::STATUS_FORBIDDEN, array{success: bool, error: string}, array{}>
+	 * Returns admin-editable configuration, computed status, and available groups.
+	 * System-wide capabilities (teamsAvailable, calendarSyncAvailable, notificationsAppEnabled)
+	 * are available via GET /api/capabilities.
+	 *
+	 * @return DataResponse<Http::STATUS_OK, array{config: AttendanceAdminConfig, status: AttendanceAdminStatus, groups: list<AttendanceGroupOption>}, array{}>|DataResponse<Http::STATUS_UNAUTHORIZED, array{error: string}, array{}>|DataResponse<Http::STATUS_FORBIDDEN, array{error: string}, array{}>|DataResponse<Http::STATUS_INTERNAL_SERVER_ERROR, array{error: string}, array{}>
 	 */
 	#[NoCSRFRequired]
 	#[OpenAPI(OpenAPI::SCOPE_ADMINISTRATION)]
@@ -92,7 +96,7 @@ class AdminController extends Controller {
 			// Get permission settings
 			$permissionSettings = $this->permissionService->getAllPermissionSettings();
 
-			// Get reminder settings
+			// Compute status: next appointment
 			$upcomingAppointments = $this->appointmentMapper->findUpcoming();
 			$nextAppointment = null;
 			if (!empty($upcomingAppointments)) {
@@ -103,7 +107,7 @@ class AdminController extends Controller {
 				];
 			}
 
-			// Get next planned reminder run from background job
+			// Compute status: next reminder run
 			$nextReminderRun = null;
 			$reminderJobs = $this->jobList->getJobs(ReminderJob::class, 1, 0);
 			if (!empty($reminderJobs)) {
@@ -113,34 +117,26 @@ class AdminController extends Controller {
 				}
 			}
 
-			$reminderSettings = [
-				'enabled' => $this->config->getAppValue('attendance', 'reminders_enabled', 'no') === 'yes',
-				'reminderDays' => (int)$this->config->getAppValue('attendance', 'reminder_days', '7'),
-				'reminderFrequency' => (int)$this->config->getAppValue('attendance', 'reminder_frequency', '0'),
-				'notificationsAppEnabled' => $this->appManager->isEnabledForUser('notifications'),
-				'nextAppointment' => $nextAppointment,
-				'nextReminderRun' => $nextReminderRun,
-			];
-
-			// Get calendar sync settings
-			// Calendar sync is only available in NC 32+ when the calendar event classes exist
-			// Use version check as class_exists() can be unreliable with autoloading
-			$ncVersion = \OCP\Util::getVersion();
-			$calendarSyncAvailable = $ncVersion[0] >= 32;
-			$calendarSyncSettings = [
-				'enabled' => $this->configService->isCalendarSyncEnabled(),
-				'available' => $calendarSyncAvailable,
-			];
-
 			return new DataResponse([
+				'config' => [
+					'whitelistedGroups' => $whitelistedGroups,
+					'whitelistedTeams' => $whitelistedTeams,
+					'permissions' => $permissionSettings,
+					'reminders' => [
+						'enabled' => $this->config->getAppValue('attendance', 'reminders_enabled', 'no') === 'yes',
+						'reminderDays' => (int)$this->config->getAppValue('attendance', 'reminder_days', '7'),
+						'reminderFrequency' => (int)$this->config->getAppValue('attendance', 'reminder_frequency', '0'),
+					],
+					'calendarSync' => [
+						'enabled' => $this->configService->isCalendarSyncEnabled(),
+					],
+					'displayOrder' => $this->configService->getDisplayOrder(),
+				],
+				'status' => [
+					'nextAppointment' => $nextAppointment,
+					'nextReminderRun' => $nextReminderRun,
+				],
 				'groups' => $groupOptions,
-				'whitelistedGroups' => $whitelistedGroups,
-				'whitelistedTeams' => $whitelistedTeams,
-				'teamsAvailable' => $this->visibilityService->isTeamsAvailable(),
-				'permissions' => $permissionSettings,
-				'reminders' => $reminderSettings,
-				'calendarSync' => $calendarSyncSettings,
-				'displayOrder' => $this->configService->getDisplayOrder(),
 			]);
 		} catch (\Exception $e) {
 			return new DataResponse(['error' => $e->getMessage()], 500);
@@ -156,7 +152,7 @@ class AdminController extends Controller {
 	 * @param array{enabled?: bool, reminderDays?: int, reminderFrequency?: int} $reminders Reminder settings
 	 * @param array{enabled?: bool} $calendarSync Calendar sync settings
 	 * @param ?string $displayOrder Display order for appointments: chronological, name, or group
-	 * @return JSONResponse<Http::STATUS_OK, array{success: bool}, array{}>|JSONResponse<Http::STATUS_OK, array{success: bool, error: string}, array{}>|JSONResponse<Http::STATUS_UNAUTHORIZED, array{success: bool, error: string}, array{}>|JSONResponse<Http::STATUS_FORBIDDEN, array{success: bool, error: string}, array{}>
+	 * @return DataResponse<Http::STATUS_OK, array<string, mixed>, array{}>|DataResponse<Http::STATUS_UNAUTHORIZED, array{error: string}, array{}>|DataResponse<Http::STATUS_FORBIDDEN, array{error: string}, array{}>|DataResponse<Http::STATUS_INTERNAL_SERVER_ERROR, array{error: string}, array{}>
 	 */
 	#[NoCSRFRequired]
 	#[OpenAPI(OpenAPI::SCOPE_ADMINISTRATION)]
@@ -212,7 +208,7 @@ class AdminController extends Controller {
 				$this->configService->setDisplayOrder($displayOrder);
 			}
 
-			return new DataResponse(['success' => true]);
+			return new DataResponse([]);
 		} catch (\Exception $e) {
 			return new DataResponse(['error' => $e->getMessage()], 500);
 		}

--- a/lib/Controller/AppointmentController.php
+++ b/lib/Controller/AppointmentController.php
@@ -12,6 +12,8 @@ use OCA\Attendance\Service\ConfigService;
 use OCA\Attendance\Service\ExportService;
 use OCA\Attendance\Service\NotificationService;
 use OCA\Attendance\Service\PermissionService;
+use OCA\Attendance\Service\VisibilityService;
+use OCP\App\IAppManager;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
@@ -31,6 +33,8 @@ class AppointmentController extends Controller {
 	private PermissionService $permissionService;
 	private ExportService $exportService;
 	private NotificationService $notificationService;
+	private VisibilityService $visibilityService;
+	private IAppManager $appManager;
 	private IUserSession $userSession;
 	private ISecureRandom $secureRandom;
 
@@ -45,6 +49,8 @@ class AppointmentController extends Controller {
 		PermissionService $permissionService,
 		ExportService $exportService,
 		NotificationService $notificationService,
+		VisibilityService $visibilityService,
+		IAppManager $appManager,
 		IUserSession $userSession,
 		ISecureRandom $secureRandom,
 	) {
@@ -57,6 +63,8 @@ class AppointmentController extends Controller {
 		$this->permissionService = $permissionService;
 		$this->exportService = $exportService;
 		$this->notificationService = $notificationService;
+		$this->visibilityService = $visibilityService;
+		$this->appManager = $appManager;
 		$this->userSession = $userSession;
 		$this->secureRandom = $secureRandom;
 	}
@@ -120,7 +128,7 @@ class AppointmentController extends Controller {
 	 * @param ?string $calendarUri URI of the source calendar (when imported from calendar)
 	 * @param ?string $calendarEventUid UID of the source calendar event
 	 * @param list<int> $attachments File IDs to attach to the appointment
-	 * @return DataResponse<Http::STATUS_OK, AttendanceAppointmentData, array{}>|DataResponse<Http::STATUS_BAD_REQUEST, array{error: string}, array{}>|DataResponse<Http::STATUS_UNAUTHORIZED, array{error: string}, array{}>|DataResponse<Http::STATUS_FORBIDDEN, array{error: string}, array{}>
+	 * @return DataResponse<Http::STATUS_CREATED, AttendanceAppointmentData, array{}>|DataResponse<Http::STATUS_BAD_REQUEST, array{error: string}, array{}>|DataResponse<Http::STATUS_UNAUTHORIZED, array{error: string}, array{}>|DataResponse<Http::STATUS_FORBIDDEN, array{error: string}, array{}>
 	 */
 	#[NoAdminRequired]
 	#[NoCSRFRequired]
@@ -177,7 +185,7 @@ class AppointmentController extends Controller {
 	 * @param list<AttendanceBulkAppointmentItem> $appointments List of appointments to create
 	 * @param bool $sendNotification Whether to send a batch notification to affected users
 	 * @param list<int> $attachments File IDs to attach to all created appointments
-	 * @return DataResponse<Http::STATUS_OK, array{created: list<int>, errors: list<array{index: int, name: string, error: string}>}, array{}>|DataResponse<Http::STATUS_UNAUTHORIZED, array{error: string}, array{}>|DataResponse<Http::STATUS_FORBIDDEN, array{error: string}, array{}>
+	 * @return DataResponse<Http::STATUS_CREATED, array{created: list<int>, errors: list<array{index: int, name: string, error: string}>}, array{}>|DataResponse<Http::STATUS_UNAUTHORIZED, array{error: string}, array{}>|DataResponse<Http::STATUS_FORBIDDEN, array{error: string}, array{}>
 	 */
 	#[NoAdminRequired]
 	#[NoCSRFRequired]
@@ -373,7 +381,7 @@ class AppointmentController extends Controller {
 	 *
 	 * @param int $id Appointment ID
 	 * @param string $scope Series delete scope: single, future, or all
-	 * @return DataResponse<Http::STATUS_OK, array{success: bool, deletedCount: int}, array{}>|DataResponse<Http::STATUS_BAD_REQUEST, array{error: string}, array{}>|DataResponse<Http::STATUS_UNAUTHORIZED, array{error: string}, array{}>|DataResponse<Http::STATUS_FORBIDDEN, array{error: string}, array{}>|DataResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>
+	 * @return DataResponse<Http::STATUS_OK, AttendanceDeleteResult, array{}>|DataResponse<Http::STATUS_BAD_REQUEST, array{error: string}, array{}>|DataResponse<Http::STATUS_UNAUTHORIZED, array{error: string}, array{}>|DataResponse<Http::STATUS_FORBIDDEN, array{error: string}, array{}>|DataResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>
 	 */
 	#[NoAdminRequired]
 	#[NoCSRFRequired]
@@ -397,16 +405,16 @@ class AppointmentController extends Controller {
 		try {
 			if (($scope === 'future' || $scope === 'all') && $appointment->getSeriesId() !== null) {
 				$deletedCount = $this->appointmentService->deleteSeriesAppointments($id, $scope, $user->getUID());
-				return new DataResponse(['success' => true, 'deletedCount' => $deletedCount]);
+				return new DataResponse(['deletedCount' => $deletedCount]);
 			}
 
 			if ($scope === 'single' && $appointment->getSeriesId() !== null) {
 				$deletedCount = $this->appointmentService->deleteSeriesAppointments($id, 'single', $user->getUID());
-				return new DataResponse(['success' => true, 'deletedCount' => $deletedCount]);
+				return new DataResponse(['deletedCount' => $deletedCount]);
 			}
 
 			$this->appointmentService->deleteAppointment($id, $user->getUID());
-			return new DataResponse(['success' => true, 'deletedCount' => 1]);
+			return new DataResponse(['deletedCount' => 1]);
 		} catch (\Exception $e) {
 			return new DataResponse(['error' => $e->getMessage()], 400);
 		}
@@ -541,7 +549,7 @@ class AppointmentController extends Controller {
 	 * Reset all check-in data for an appointment
 	 *
 	 * @param int $id Appointment ID
-	 * @return DataResponse<Http::STATUS_OK, array{success: bool}, array{}>|DataResponse<Http::STATUS_BAD_REQUEST, array{error: string}, array{}>|DataResponse<Http::STATUS_UNAUTHORIZED, array{error: string}, array{}>|DataResponse<Http::STATUS_FORBIDDEN, array{error: string}, array{}>
+	 * @return DataResponse<Http::STATUS_OK, array<string, mixed>, array{}>|DataResponse<Http::STATUS_BAD_REQUEST, array{error: string}, array{}>|DataResponse<Http::STATUS_UNAUTHORIZED, array{error: string}, array{}>|DataResponse<Http::STATUS_FORBIDDEN, array{error: string}, array{}>
 	 */
 	#[NoAdminRequired]
 	#[NoCSRFRequired]
@@ -565,16 +573,16 @@ class AppointmentController extends Controller {
 
 		try {
 			$this->checkinService->resetCheckin($id);
-			return new DataResponse(['success' => true]);
+			return new DataResponse([]);
 		} catch (\Exception $e) {
 			return new DataResponse(['error' => $e->getMessage()], 400);
 		}
 	}
 
 	/**
-	 * Get the current user's permissions and app capabilities
+	 * Get the current user's permissions
 	 *
-	 * @return DataResponse<Http::STATUS_OK, array{canManageAppointments: bool, canCheckin: bool, canSeeResponseOverview: bool, canSeeComments: bool, calendarAvailable: bool, calendarSyncEnabled: bool, displayOrder: string}, array{}>|DataResponse<Http::STATUS_UNAUTHORIZED, array{error: string}, array{}>
+	 * @return DataResponse<Http::STATUS_OK, AttendanceUserPermissions, array{}>|DataResponse<Http::STATUS_UNAUTHORIZED, array{error: string}, array{}>
 	 */
 	#[NoAdminRequired]
 	#[NoCSRFRequired]
@@ -591,8 +599,37 @@ class AppointmentController extends Controller {
 			'canSeeResponseOverview' => $this->permissionService->canSeeResponseOverview($user->getUID()),
 			'canSeeComments' => $this->permissionService->canSeeComments($user->getUID()),
 			'canSelfCheckin' => $this->permissionService->canSelfCheckin($user->getUID()),
+		]);
+	}
+
+	/**
+	 * Get system-wide capabilities
+	 *
+	 * @return DataResponse<Http::STATUS_OK, AttendanceCapabilities, array{}>
+	 */
+	#[NoAdminRequired]
+	#[NoCSRFRequired]
+	#[OpenAPI]
+	public function getCapabilities(): DataResponse {
+		return new DataResponse([
 			'calendarAvailable' => $this->calendarService->isCalendarAvailable(),
 			'calendarSyncEnabled' => $this->configService->isCalendarSyncEnabled(),
+			'teamsAvailable' => $this->visibilityService->isTeamsAvailable(),
+			'calendarSyncAvailable' => \OCP\Util::getVersion()[0] >= 32,
+			'notificationsAppEnabled' => $this->appManager->isEnabledForUser('notifications'),
+		]);
+	}
+
+	/**
+	 * Get user-relevant app configuration
+	 *
+	 * @return DataResponse<Http::STATUS_OK, AttendanceUserConfig, array{}>
+	 */
+	#[NoAdminRequired]
+	#[NoCSRFRequired]
+	#[OpenAPI]
+	public function getUserConfig(): DataResponse {
+		return new DataResponse([
 			'displayOrder' => $this->configService->getDisplayOrder(),
 		]);
 	}
@@ -632,7 +669,7 @@ class AppointmentController extends Controller {
 	 * @param ?string $startDate Start date filter in Y-m-d format
 	 * @param ?string $endDate End date filter in Y-m-d format
 	 * @param bool $includeComments Whether to include user comments in the export
-	 * @return DataResponse<Http::STATUS_OK, array{success: bool, path: string, filename: string}, array{}>|DataResponse<Http::STATUS_BAD_REQUEST, array{error: string}, array{}>|DataResponse<Http::STATUS_UNAUTHORIZED, array{error: string}, array{}>|DataResponse<Http::STATUS_FORBIDDEN, array{error: string}, array{}>
+	 * @return DataResponse<Http::STATUS_OK, AttendanceExportResult, array{}>|DataResponse<Http::STATUS_BAD_REQUEST, array{error: string}, array{}>|DataResponse<Http::STATUS_UNAUTHORIZED, array{error: string}, array{}>|DataResponse<Http::STATUS_FORBIDDEN, array{error: string}, array{}>
 	 */
 	#[NoAdminRequired]
 	#[NoCSRFRequired]
@@ -664,7 +701,6 @@ class AppointmentController extends Controller {
 		try {
 			$result = $this->exportService->exportToOds($user->getUID(), $appointmentIds, $startDate, $endDate, $includeComments);
 			return new DataResponse([
-				'success' => true,
 				'path' => $result['path'],
 				'filename' => $result['filename'],
 			]);

--- a/lib/Controller/SelfCheckinController.php
+++ b/lib/Controller/SelfCheckinController.php
@@ -52,7 +52,7 @@ class SelfCheckinController extends Controller {
 	 *
 	 * Returns active appointments the current user can self-check into right now.
 	 *
-	 * @return DataResponse<Http::STATUS_OK, list<array<string, mixed>>, array{}>|DataResponse<Http::STATUS_UNAUTHORIZED, array{error: string}, array{}>|DataResponse<Http::STATUS_FORBIDDEN, array{error: string}, array{}>|DataResponse<Http::STATUS_INTERNAL_SERVER_ERROR, array{error: string}, array{}>
+	 * @return DataResponse<Http::STATUS_OK, list<AttendanceSelfCheckinAppointment>, array{}>|DataResponse<Http::STATUS_UNAUTHORIZED, array{error: string}, array{}>|DataResponse<Http::STATUS_FORBIDDEN, array{error: string}, array{}>|DataResponse<Http::STATUS_INTERNAL_SERVER_ERROR, array{error: string}, array{}>
 	 */
 	#[NoAdminRequired]
 	#[NoCSRFRequired]
@@ -84,7 +84,7 @@ class SelfCheckinController extends Controller {
 	 * Self-check-in to a specific appointment
 	 *
 	 * @param int $appointmentId ID of the appointment to check into
-	 * @return DataResponse<Http::STATUS_OK, array<string, mixed>, array{}>|DataResponse<Http::STATUS_BAD_REQUEST, array{error: string}, array{}>|DataResponse<Http::STATUS_UNAUTHORIZED, array{error: string}, array{}>|DataResponse<Http::STATUS_FORBIDDEN, array{error: string}, array{}>|DataResponse<Http::STATUS_INTERNAL_SERVER_ERROR, array{error: string}, array{}>
+	 * @return DataResponse<Http::STATUS_OK, AttendanceSelfCheckinResult, array{}>|DataResponse<Http::STATUS_BAD_REQUEST, array{error: string}, array{}>|DataResponse<Http::STATUS_UNAUTHORIZED, array{error: string}, array{}>|DataResponse<Http::STATUS_FORBIDDEN, array{error: string}, array{}>|DataResponse<Http::STATUS_INTERNAL_SERVER_ERROR, array{error: string}, array{}>
 	 */
 	#[NoAdminRequired]
 	#[NoCSRFRequired]

--- a/lib/ResponseDefinitions.php
+++ b/lib/ResponseDefinitions.php
@@ -103,15 +103,77 @@ namespace OCA\Attendance;
  * @psalm-type AttendanceGroupOption = array{id: string, displayName: string}
  * @psalm-type AttendanceTeamOption = array{id: string, displayName: string}
  * @psalm-type AttendancePermissionSettings = array<string, list<string>>
- * @psalm-type AttendanceReminderSettings = array{
+ * @psalm-type AttendanceUserPermissions = array{
+ *   canManageAppointments: bool,
+ *   canCheckin: bool,
+ *   canSeeResponseOverview: bool,
+ *   canSeeComments: bool,
+ *   canSelfCheckin: bool,
+ * }
+ * @psalm-type AttendanceCapabilities = array{
+ *   calendarAvailable: bool,
+ *   calendarSyncEnabled: bool,
+ *   teamsAvailable: bool,
+ *   calendarSyncAvailable: bool,
+ *   notificationsAppEnabled: bool,
+ * }
+ * @psalm-type AttendanceUserConfig = array{
+ *   displayOrder: string,
+ * }
+ * @psalm-type AttendanceAdminReminderConfig = array{
  *   enabled: bool,
  *   reminderDays: int,
  *   reminderFrequency: int,
- *   notificationsAppEnabled: bool,
+ * }
+ * @psalm-type AttendanceAdminCalendarSyncConfig = array{
+ *   enabled: bool,
+ * }
+ * @psalm-type AttendanceAdminConfig = array{
+ *   whitelistedGroups: list<string>,
+ *   whitelistedTeams: list<AttendanceTeamOption>,
+ *   permissions: AttendancePermissionSettings,
+ *   reminders: AttendanceAdminReminderConfig,
+ *   calendarSync: AttendanceAdminCalendarSyncConfig,
+ *   displayOrder: string,
+ * }
+ * @psalm-type AttendanceAdminStatus = array{
  *   nextAppointment: ?array{name: string, startDatetime: string},
  *   nextReminderRun: ?string,
  * }
- * @psalm-type AttendanceCalendarSyncSettings = array{enabled: bool, available: bool}
+ * @psalm-type AttendanceSelfCheckinAppointment = array{
+ *   id: int,
+ *   name: string,
+ *   description: string,
+ *   startDatetime: string,
+ *   endDatetime: string,
+ *   createdBy: string,
+ *   createdAt: string,
+ *   updatedAt: string,
+ *   isActive: int,
+ *   visibleUsers: list<string>,
+ *   visibleGroups: list<string>,
+ *   visibleTeams: list<string>,
+ *   calendarUri: ?string,
+ *   calendarEventUid: ?string,
+ *   seriesId: ?string,
+ *   seriesPosition: ?int,
+ *   alreadyCheckedIn: bool,
+ *   checkinState: ?string,
+ *   checkinAt: ?string,
+ * }
+ * @psalm-type AttendanceSelfCheckinResult = array{
+ *   appointment: AttendanceAppointmentData,
+ *   checkinState: string,
+ *   checkinAt: ?string,
+ *   alreadyCheckedIn: bool,
+ * }
+ * @psalm-type AttendanceDeleteResult = array{
+ *   deletedCount: int,
+ * }
+ * @psalm-type AttendanceExportResult = array{
+ *   path: string,
+ *   filename: string,
+ * }
  */
 class ResponseDefinitions {
 }

--- a/openapi-administration.json
+++ b/openapi-administration.json
@@ -20,17 +20,127 @@
             }
         },
         "schemas": {
-            "CalendarSyncSettings": {
+            "AdminCalendarSyncConfig": {
+                "type": "object",
+                "required": [
+                    "enabled"
+                ],
+                "properties": {
+                    "enabled": {
+                        "type": "boolean"
+                    }
+                }
+            },
+            "AdminConfig": {
+                "type": "object",
+                "required": [
+                    "whitelistedGroups",
+                    "whitelistedTeams",
+                    "permissions",
+                    "reminders",
+                    "calendarSync",
+                    "displayOrder"
+                ],
+                "properties": {
+                    "whitelistedGroups": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "whitelistedTeams": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/TeamOption"
+                        }
+                    },
+                    "permissions": {
+                        "$ref": "#/components/schemas/PermissionSettings"
+                    },
+                    "reminders": {
+                        "$ref": "#/components/schemas/AdminReminderConfig"
+                    },
+                    "calendarSync": {
+                        "$ref": "#/components/schemas/AdminCalendarSyncConfig"
+                    },
+                    "displayOrder": {
+                        "type": "string"
+                    }
+                }
+            },
+            "AdminReminderConfig": {
                 "type": "object",
                 "required": [
                     "enabled",
-                    "available"
+                    "reminderDays",
+                    "reminderFrequency"
                 ],
                 "properties": {
                     "enabled": {
                         "type": "boolean"
                     },
-                    "available": {
+                    "reminderDays": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "reminderFrequency": {
+                        "type": "integer",
+                        "format": "int64"
+                    }
+                }
+            },
+            "AdminStatus": {
+                "type": "object",
+                "required": [
+                    "nextAppointment",
+                    "nextReminderRun"
+                ],
+                "properties": {
+                    "nextAppointment": {
+                        "type": "object",
+                        "nullable": true,
+                        "required": [
+                            "name",
+                            "startDatetime"
+                        ],
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "startDatetime": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "nextReminderRun": {
+                        "type": "string",
+                        "nullable": true
+                    }
+                }
+            },
+            "Capabilities": {
+                "type": "object",
+                "required": [
+                    "calendarAvailable",
+                    "calendarSyncEnabled",
+                    "teamsAvailable",
+                    "calendarSyncAvailable",
+                    "notificationsAppEnabled"
+                ],
+                "properties": {
+                    "calendarAvailable": {
+                        "type": "boolean"
+                    },
+                    "calendarSyncEnabled": {
+                        "type": "boolean"
+                    },
+                    "teamsAvailable": {
+                        "type": "boolean"
+                    },
+                    "calendarSyncAvailable": {
+                        "type": "boolean"
+                    },
+                    "notificationsAppEnabled": {
                         "type": "boolean"
                     }
                 }
@@ -59,53 +169,6 @@
                     }
                 }
             },
-            "ReminderSettings": {
-                "type": "object",
-                "required": [
-                    "enabled",
-                    "reminderDays",
-                    "reminderFrequency",
-                    "notificationsAppEnabled",
-                    "nextAppointment",
-                    "nextReminderRun"
-                ],
-                "properties": {
-                    "enabled": {
-                        "type": "boolean"
-                    },
-                    "reminderDays": {
-                        "type": "integer",
-                        "format": "int64"
-                    },
-                    "reminderFrequency": {
-                        "type": "integer",
-                        "format": "int64"
-                    },
-                    "notificationsAppEnabled": {
-                        "type": "boolean"
-                    },
-                    "nextAppointment": {
-                        "type": "object",
-                        "nullable": true,
-                        "required": [
-                            "name",
-                            "startDatetime"
-                        ],
-                        "properties": {
-                            "name": {
-                                "type": "string"
-                            },
-                            "startDatetime": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "nextReminderRun": {
-                        "type": "string",
-                        "nullable": true
-                    }
-                }
-            },
             "TeamOption": {
                 "type": "object",
                 "required": [
@@ -127,8 +190,8 @@
         "/index.php/apps/attendance/api/admin/settings": {
             "get": {
                 "operationId": "admin-get-settings",
-                "summary": "Get admin settings data (groups and current whitelist)",
-                "description": "This endpoint requires admin access",
+                "summary": "Get admin settings data",
+                "description": "Returns admin-editable configuration, computed status, and available groups. System-wide capabilities (teamsAvailable, calendarSyncAvailable, notificationsAppEnabled) are available via GET /api/capabilities.\nThis endpoint requires admin access",
                 "tags": [
                     "admin"
                 ],
@@ -146,75 +209,26 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "anyOf": [
-                                        {
-                                            "type": "object",
-                                            "required": [
-                                                "success",
-                                                "groups",
-                                                "whitelistedGroups",
-                                                "whitelistedTeams",
-                                                "teamsAvailable",
-                                                "permissions",
-                                                "reminders",
-                                                "calendarSync",
-                                                "displayOrder"
-                                            ],
-                                            "properties": {
-                                                "success": {
-                                                    "type": "boolean"
-                                                },
-                                                "groups": {
-                                                    "type": "array",
-                                                    "items": {
-                                                        "$ref": "#/components/schemas/GroupOption"
-                                                    }
-                                                },
-                                                "whitelistedGroups": {
-                                                    "type": "array",
-                                                    "items": {
-                                                        "type": "string"
-                                                    }
-                                                },
-                                                "whitelistedTeams": {
-                                                    "type": "array",
-                                                    "items": {
-                                                        "$ref": "#/components/schemas/TeamOption"
-                                                    }
-                                                },
-                                                "teamsAvailable": {
-                                                    "type": "boolean"
-                                                },
-                                                "permissions": {
-                                                    "$ref": "#/components/schemas/PermissionSettings"
-                                                },
-                                                "reminders": {
-                                                    "$ref": "#/components/schemas/ReminderSettings"
-                                                },
-                                                "calendarSync": {
-                                                    "$ref": "#/components/schemas/CalendarSyncSettings"
-                                                },
-                                                "displayOrder": {
-                                                    "type": "string"
-                                                }
-                                            }
+                                    "type": "object",
+                                    "required": [
+                                        "config",
+                                        "status",
+                                        "groups"
+                                    ],
+                                    "properties": {
+                                        "config": {
+                                            "$ref": "#/components/schemas/AdminConfig"
                                         },
-                                        {
-                                            "type": "object",
-                                            "required": [
-                                                "success",
-                                                "error"
-                                            ],
-                                            "properties": {
-                                                "success": {
-                                                    "type": "boolean"
-                                                },
-                                                "error": {
-                                                    "type": "string"
-                                                }
+                                        "status": {
+                                            "$ref": "#/components/schemas/AdminStatus"
+                                        },
+                                        "groups": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/components/schemas/GroupOption"
                                             }
                                         }
-                                    ]
+                                    }
                                 }
                             }
                         }
@@ -228,13 +242,9 @@
                                         {
                                             "type": "object",
                                             "required": [
-                                                "success",
                                                 "error"
                                             ],
                                             "properties": {
-                                                "success": {
-                                                    "type": "boolean"
-                                                },
                                                 "error": {
                                                     "type": "string"
                                                 }
@@ -265,13 +275,9 @@
                                         {
                                             "type": "object",
                                             "required": [
-                                                "success",
                                                 "error"
                                             ],
                                             "properties": {
-                                                "success": {
-                                                    "type": "boolean"
-                                                },
                                                 "error": {
                                                     "type": "string"
                                                 }
@@ -289,6 +295,24 @@
                                             }
                                         }
                                     ]
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    }
                                 }
                             }
                         }
@@ -389,34 +413,10 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "anyOf": [
-                                        {
-                                            "type": "object",
-                                            "required": [
-                                                "success"
-                                            ],
-                                            "properties": {
-                                                "success": {
-                                                    "type": "boolean"
-                                                }
-                                            }
-                                        },
-                                        {
-                                            "type": "object",
-                                            "required": [
-                                                "success",
-                                                "error"
-                                            ],
-                                            "properties": {
-                                                "success": {
-                                                    "type": "boolean"
-                                                },
-                                                "error": {
-                                                    "type": "string"
-                                                }
-                                            }
-                                        }
-                                    ]
+                                    "type": "object",
+                                    "additionalProperties": {
+                                        "type": "object"
+                                    }
                                 }
                             }
                         }
@@ -430,13 +430,9 @@
                                         {
                                             "type": "object",
                                             "required": [
-                                                "success",
                                                 "error"
                                             ],
                                             "properties": {
-                                                "success": {
-                                                    "type": "boolean"
-                                                },
                                                 "error": {
                                                     "type": "string"
                                                 }
@@ -467,13 +463,9 @@
                                         {
                                             "type": "object",
                                             "required": [
-                                                "success",
                                                 "error"
                                             ],
                                             "properties": {
-                                                "success": {
-                                                    "type": "boolean"
-                                                },
                                                 "error": {
                                                     "type": "string"
                                                 }
@@ -491,6 +483,24 @@
                                             }
                                         }
                                     ]
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    }
                                 }
                             }
                         }

--- a/openapi-full.json
+++ b/openapi-full.json
@@ -20,6 +20,104 @@
             }
         },
         "schemas": {
+            "AdminCalendarSyncConfig": {
+                "type": "object",
+                "required": [
+                    "enabled"
+                ],
+                "properties": {
+                    "enabled": {
+                        "type": "boolean"
+                    }
+                }
+            },
+            "AdminConfig": {
+                "type": "object",
+                "required": [
+                    "whitelistedGroups",
+                    "whitelistedTeams",
+                    "permissions",
+                    "reminders",
+                    "calendarSync",
+                    "displayOrder"
+                ],
+                "properties": {
+                    "whitelistedGroups": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "whitelistedTeams": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/TeamOption"
+                        }
+                    },
+                    "permissions": {
+                        "$ref": "#/components/schemas/PermissionSettings"
+                    },
+                    "reminders": {
+                        "$ref": "#/components/schemas/AdminReminderConfig"
+                    },
+                    "calendarSync": {
+                        "$ref": "#/components/schemas/AdminCalendarSyncConfig"
+                    },
+                    "displayOrder": {
+                        "type": "string"
+                    }
+                }
+            },
+            "AdminReminderConfig": {
+                "type": "object",
+                "required": [
+                    "enabled",
+                    "reminderDays",
+                    "reminderFrequency"
+                ],
+                "properties": {
+                    "enabled": {
+                        "type": "boolean"
+                    },
+                    "reminderDays": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "reminderFrequency": {
+                        "type": "integer",
+                        "format": "int64"
+                    }
+                }
+            },
+            "AdminStatus": {
+                "type": "object",
+                "required": [
+                    "nextAppointment",
+                    "nextReminderRun"
+                ],
+                "properties": {
+                    "nextAppointment": {
+                        "type": "object",
+                        "nullable": true,
+                        "required": [
+                            "name",
+                            "startDatetime"
+                        ],
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "startDatetime": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "nextReminderRun": {
+                        "type": "string",
+                        "nullable": true
+                    }
+                }
+            },
             "AppointmentData": {
                 "type": "object",
                 "required": [
@@ -268,17 +366,29 @@
                     }
                 }
             },
-            "CalendarSyncSettings": {
+            "Capabilities": {
                 "type": "object",
                 "required": [
-                    "enabled",
-                    "available"
+                    "calendarAvailable",
+                    "calendarSyncEnabled",
+                    "teamsAvailable",
+                    "calendarSyncAvailable",
+                    "notificationsAppEnabled"
                 ],
                 "properties": {
-                    "enabled": {
+                    "calendarAvailable": {
                         "type": "boolean"
                     },
-                    "available": {
+                    "calendarSyncEnabled": {
+                        "type": "boolean"
+                    },
+                    "teamsAvailable": {
+                        "type": "boolean"
+                    },
+                    "calendarSyncAvailable": {
+                        "type": "boolean"
+                    },
+                    "notificationsAppEnabled": {
                         "type": "boolean"
                     }
                 }
@@ -308,6 +418,33 @@
                         "items": {
                             "type": "string"
                         }
+                    }
+                }
+            },
+            "DeleteResult": {
+                "type": "object",
+                "required": [
+                    "deletedCount"
+                ],
+                "properties": {
+                    "deletedCount": {
+                        "type": "integer",
+                        "format": "int64"
+                    }
+                }
+            },
+            "ExportResult": {
+                "type": "object",
+                "required": [
+                    "path",
+                    "filename"
+                ],
+                "properties": {
+                    "path": {
+                        "type": "string"
+                    },
+                    "filename": {
+                        "type": "string"
                     }
                 }
             },
@@ -376,53 +513,6 @@
                     "type": "array",
                     "items": {
                         "type": "string"
-                    }
-                }
-            },
-            "ReminderSettings": {
-                "type": "object",
-                "required": [
-                    "enabled",
-                    "reminderDays",
-                    "reminderFrequency",
-                    "notificationsAppEnabled",
-                    "nextAppointment",
-                    "nextReminderRun"
-                ],
-                "properties": {
-                    "enabled": {
-                        "type": "boolean"
-                    },
-                    "reminderDays": {
-                        "type": "integer",
-                        "format": "int64"
-                    },
-                    "reminderFrequency": {
-                        "type": "integer",
-                        "format": "int64"
-                    },
-                    "notificationsAppEnabled": {
-                        "type": "boolean"
-                    },
-                    "nextAppointment": {
-                        "type": "object",
-                        "nullable": true,
-                        "required": [
-                            "name",
-                            "startDatetime"
-                        ],
-                        "properties": {
-                            "name": {
-                                "type": "string"
-                            },
-                            "startDatetime": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "nextReminderRun": {
-                        "type": "string",
-                        "nullable": true
                     }
                 }
             },
@@ -567,6 +657,131 @@
                     }
                 }
             },
+            "SelfCheckinAppointment": {
+                "type": "object",
+                "required": [
+                    "id",
+                    "name",
+                    "description",
+                    "startDatetime",
+                    "endDatetime",
+                    "createdBy",
+                    "createdAt",
+                    "updatedAt",
+                    "isActive",
+                    "visibleUsers",
+                    "visibleGroups",
+                    "visibleTeams",
+                    "calendarUri",
+                    "calendarEventUid",
+                    "seriesId",
+                    "seriesPosition",
+                    "alreadyCheckedIn",
+                    "checkinState",
+                    "checkinAt"
+                ],
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "startDatetime": {
+                        "type": "string"
+                    },
+                    "endDatetime": {
+                        "type": "string"
+                    },
+                    "createdBy": {
+                        "type": "string"
+                    },
+                    "createdAt": {
+                        "type": "string"
+                    },
+                    "updatedAt": {
+                        "type": "string"
+                    },
+                    "isActive": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "visibleUsers": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "visibleGroups": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "visibleTeams": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "calendarUri": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "calendarEventUid": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "seriesId": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "seriesPosition": {
+                        "type": "integer",
+                        "format": "int64",
+                        "nullable": true
+                    },
+                    "alreadyCheckedIn": {
+                        "type": "boolean"
+                    },
+                    "checkinState": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "checkinAt": {
+                        "type": "string",
+                        "nullable": true
+                    }
+                }
+            },
+            "SelfCheckinResult": {
+                "type": "object",
+                "required": [
+                    "appointment",
+                    "checkinState",
+                    "checkinAt",
+                    "alreadyCheckedIn"
+                ],
+                "properties": {
+                    "appointment": {
+                        "$ref": "#/components/schemas/AppointmentData"
+                    },
+                    "checkinState": {
+                        "type": "string"
+                    },
+                    "checkinAt": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "alreadyCheckedIn": {
+                        "type": "boolean"
+                    }
+                }
+            },
             "TeamOption": {
                 "type": "object",
                 "required": [
@@ -579,6 +794,44 @@
                     },
                     "displayName": {
                         "type": "string"
+                    }
+                }
+            },
+            "UserConfig": {
+                "type": "object",
+                "required": [
+                    "displayOrder"
+                ],
+                "properties": {
+                    "displayOrder": {
+                        "type": "string"
+                    }
+                }
+            },
+            "UserPermissions": {
+                "type": "object",
+                "required": [
+                    "canManageAppointments",
+                    "canCheckin",
+                    "canSeeResponseOverview",
+                    "canSeeComments",
+                    "canSelfCheckin"
+                ],
+                "properties": {
+                    "canManageAppointments": {
+                        "type": "boolean"
+                    },
+                    "canCheckin": {
+                        "type": "boolean"
+                    },
+                    "canSeeResponseOverview": {
+                        "type": "boolean"
+                    },
+                    "canSeeComments": {
+                        "type": "boolean"
+                    },
+                    "canSelfCheckin": {
+                        "type": "boolean"
                     }
                 }
             }
@@ -759,7 +1012,7 @@
                     }
                 },
                 "responses": {
-                    "200": {
+                    "201": {
                         "description": "",
                         "content": {
                             "application/json": {
@@ -893,7 +1146,7 @@
                     }
                 },
                 "responses": {
-                    "200": {
+                    "201": {
                         "description": "",
                         "content": {
                             "application/json": {
@@ -1496,20 +1749,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "type": "object",
-                                    "required": [
-                                        "success",
-                                        "deletedCount"
-                                    ],
-                                    "properties": {
-                                        "success": {
-                                            "type": "boolean"
-                                        },
-                                        "deletedCount": {
-                                            "type": "integer",
-                                            "format": "int64"
-                                        }
-                                    }
+                                    "$ref": "#/components/schemas/DeleteResult"
                                 }
                             }
                         }
@@ -2101,13 +2341,8 @@
                             "application/json": {
                                 "schema": {
                                     "type": "object",
-                                    "required": [
-                                        "success"
-                                    ],
-                                    "properties": {
-                                        "success": {
-                                            "type": "boolean"
-                                        }
+                                    "additionalProperties": {
+                                        "type": "object"
                                     }
                                 }
                             }
@@ -2188,7 +2423,7 @@
         "/index.php/apps/attendance/api/user/permissions": {
             "get": {
                 "operationId": "appointment-get-permissions",
-                "summary": "Get the current user's permissions and app capabilities",
+                "summary": "Get the current user's permissions",
                 "tags": [
                     "appointment"
                 ],
@@ -2206,39 +2441,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "type": "object",
-                                    "required": [
-                                        "canManageAppointments",
-                                        "canCheckin",
-                                        "canSeeResponseOverview",
-                                        "canSeeComments",
-                                        "calendarAvailable",
-                                        "calendarSyncEnabled",
-                                        "displayOrder"
-                                    ],
-                                    "properties": {
-                                        "canManageAppointments": {
-                                            "type": "boolean"
-                                        },
-                                        "canCheckin": {
-                                            "type": "boolean"
-                                        },
-                                        "canSeeResponseOverview": {
-                                            "type": "boolean"
-                                        },
-                                        "canSeeComments": {
-                                            "type": "boolean"
-                                        },
-                                        "calendarAvailable": {
-                                            "type": "boolean"
-                                        },
-                                        "calendarSyncEnabled": {
-                                            "type": "boolean"
-                                        },
-                                        "displayOrder": {
-                                            "type": "string"
-                                        }
-                                    }
+                                    "$ref": "#/components/schemas/UserPermissions"
                                 }
                             }
                         }
@@ -2272,6 +2475,100 @@
                                             }
                                         }
                                     ]
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/index.php/apps/attendance/api/user/config": {
+            "get": {
+                "operationId": "appointment-get-user-config",
+                "summary": "Get user-relevant app configuration",
+                "tags": [
+                    "appointment"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/UserConfig"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Current user is not logged in",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "message"
+                                    ],
+                                    "properties": {
+                                        "message": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/index.php/apps/attendance/api/capabilities": {
+            "get": {
+                "operationId": "appointment-get-capabilities",
+                "summary": "Get system-wide capabilities",
+                "tags": [
+                    "appointment"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Capabilities"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Current user is not logged in",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "message"
+                                    ],
+                                    "properties": {
+                                        "message": {
+                                            "type": "string"
+                                        }
+                                    }
                                 }
                             }
                         }
@@ -2471,23 +2768,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "type": "object",
-                                    "required": [
-                                        "success",
-                                        "path",
-                                        "filename"
-                                    ],
-                                    "properties": {
-                                        "success": {
-                                            "type": "boolean"
-                                        },
-                                        "path": {
-                                            "type": "string"
-                                        },
-                                        "filename": {
-                                            "type": "string"
-                                        }
-                                    }
+                                    "$ref": "#/components/schemas/ExportResult"
                                 }
                             }
                         }
@@ -3137,10 +3418,7 @@
                                 "schema": {
                                     "type": "array",
                                     "items": {
-                                        "type": "object",
-                                        "additionalProperties": {
-                                            "type": "object"
-                                        }
+                                        "$ref": "#/components/schemas/SelfCheckinAppointment"
                                     }
                                 }
                             }
@@ -3259,10 +3537,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "type": "object",
-                                    "additionalProperties": {
-                                        "type": "object"
-                                    }
+                                    "$ref": "#/components/schemas/SelfCheckinResult"
                                 }
                             }
                         }
@@ -3360,8 +3635,8 @@
         "/index.php/apps/attendance/api/admin/settings": {
             "get": {
                 "operationId": "admin-get-settings",
-                "summary": "Get admin settings data (groups and current whitelist)",
-                "description": "This endpoint requires admin access",
+                "summary": "Get admin settings data",
+                "description": "Returns admin-editable configuration, computed status, and available groups. System-wide capabilities (teamsAvailable, calendarSyncAvailable, notificationsAppEnabled) are available via GET /api/capabilities.\nThis endpoint requires admin access",
                 "tags": [
                     "admin"
                 ],
@@ -3379,75 +3654,26 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "anyOf": [
-                                        {
-                                            "type": "object",
-                                            "required": [
-                                                "success",
-                                                "groups",
-                                                "whitelistedGroups",
-                                                "whitelistedTeams",
-                                                "teamsAvailable",
-                                                "permissions",
-                                                "reminders",
-                                                "calendarSync",
-                                                "displayOrder"
-                                            ],
-                                            "properties": {
-                                                "success": {
-                                                    "type": "boolean"
-                                                },
-                                                "groups": {
-                                                    "type": "array",
-                                                    "items": {
-                                                        "$ref": "#/components/schemas/GroupOption"
-                                                    }
-                                                },
-                                                "whitelistedGroups": {
-                                                    "type": "array",
-                                                    "items": {
-                                                        "type": "string"
-                                                    }
-                                                },
-                                                "whitelistedTeams": {
-                                                    "type": "array",
-                                                    "items": {
-                                                        "$ref": "#/components/schemas/TeamOption"
-                                                    }
-                                                },
-                                                "teamsAvailable": {
-                                                    "type": "boolean"
-                                                },
-                                                "permissions": {
-                                                    "$ref": "#/components/schemas/PermissionSettings"
-                                                },
-                                                "reminders": {
-                                                    "$ref": "#/components/schemas/ReminderSettings"
-                                                },
-                                                "calendarSync": {
-                                                    "$ref": "#/components/schemas/CalendarSyncSettings"
-                                                },
-                                                "displayOrder": {
-                                                    "type": "string"
-                                                }
-                                            }
+                                    "type": "object",
+                                    "required": [
+                                        "config",
+                                        "status",
+                                        "groups"
+                                    ],
+                                    "properties": {
+                                        "config": {
+                                            "$ref": "#/components/schemas/AdminConfig"
                                         },
-                                        {
-                                            "type": "object",
-                                            "required": [
-                                                "success",
-                                                "error"
-                                            ],
-                                            "properties": {
-                                                "success": {
-                                                    "type": "boolean"
-                                                },
-                                                "error": {
-                                                    "type": "string"
-                                                }
+                                        "status": {
+                                            "$ref": "#/components/schemas/AdminStatus"
+                                        },
+                                        "groups": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/components/schemas/GroupOption"
                                             }
                                         }
-                                    ]
+                                    }
                                 }
                             }
                         }
@@ -3461,13 +3687,9 @@
                                         {
                                             "type": "object",
                                             "required": [
-                                                "success",
                                                 "error"
                                             ],
                                             "properties": {
-                                                "success": {
-                                                    "type": "boolean"
-                                                },
                                                 "error": {
                                                     "type": "string"
                                                 }
@@ -3498,13 +3720,9 @@
                                         {
                                             "type": "object",
                                             "required": [
-                                                "success",
                                                 "error"
                                             ],
                                             "properties": {
-                                                "success": {
-                                                    "type": "boolean"
-                                                },
                                                 "error": {
                                                     "type": "string"
                                                 }
@@ -3522,6 +3740,24 @@
                                             }
                                         }
                                     ]
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    }
                                 }
                             }
                         }
@@ -3622,34 +3858,10 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "anyOf": [
-                                        {
-                                            "type": "object",
-                                            "required": [
-                                                "success"
-                                            ],
-                                            "properties": {
-                                                "success": {
-                                                    "type": "boolean"
-                                                }
-                                            }
-                                        },
-                                        {
-                                            "type": "object",
-                                            "required": [
-                                                "success",
-                                                "error"
-                                            ],
-                                            "properties": {
-                                                "success": {
-                                                    "type": "boolean"
-                                                },
-                                                "error": {
-                                                    "type": "string"
-                                                }
-                                            }
-                                        }
-                                    ]
+                                    "type": "object",
+                                    "additionalProperties": {
+                                        "type": "object"
+                                    }
                                 }
                             }
                         }
@@ -3663,13 +3875,9 @@
                                         {
                                             "type": "object",
                                             "required": [
-                                                "success",
                                                 "error"
                                             ],
                                             "properties": {
-                                                "success": {
-                                                    "type": "boolean"
-                                                },
                                                 "error": {
                                                     "type": "string"
                                                 }
@@ -3700,13 +3908,9 @@
                                         {
                                             "type": "object",
                                             "required": [
-                                                "success",
                                                 "error"
                                             ],
                                             "properties": {
-                                                "success": {
-                                                    "type": "boolean"
-                                                },
                                                 "error": {
                                                     "type": "string"
                                                 }
@@ -3724,6 +3928,24 @@
                                             }
                                         }
                                     ]
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    }
                                 }
                             }
                         }

--- a/openapi.json
+++ b/openapi.json
@@ -268,6 +268,33 @@
                     }
                 }
             },
+            "Capabilities": {
+                "type": "object",
+                "required": [
+                    "calendarAvailable",
+                    "calendarSyncEnabled",
+                    "teamsAvailable",
+                    "calendarSyncAvailable",
+                    "notificationsAppEnabled"
+                ],
+                "properties": {
+                    "calendarAvailable": {
+                        "type": "boolean"
+                    },
+                    "calendarSyncEnabled": {
+                        "type": "boolean"
+                    },
+                    "teamsAvailable": {
+                        "type": "boolean"
+                    },
+                    "calendarSyncAvailable": {
+                        "type": "boolean"
+                    },
+                    "notificationsAppEnabled": {
+                        "type": "boolean"
+                    }
+                }
+            },
             "CheckinData": {
                 "type": "object",
                 "required": [
@@ -293,6 +320,33 @@
                         "items": {
                             "type": "string"
                         }
+                    }
+                }
+            },
+            "DeleteResult": {
+                "type": "object",
+                "required": [
+                    "deletedCount"
+                ],
+                "properties": {
+                    "deletedCount": {
+                        "type": "integer",
+                        "format": "int64"
+                    }
+                }
+            },
+            "ExportResult": {
+                "type": "object",
+                "required": [
+                    "path",
+                    "filename"
+                ],
+                "properties": {
+                    "path": {
+                        "type": "string"
+                    },
+                    "filename": {
+                        "type": "string"
                     }
                 }
             },
@@ -480,6 +534,169 @@
                         }
                     }
                 }
+            },
+            "SelfCheckinAppointment": {
+                "type": "object",
+                "required": [
+                    "id",
+                    "name",
+                    "description",
+                    "startDatetime",
+                    "endDatetime",
+                    "createdBy",
+                    "createdAt",
+                    "updatedAt",
+                    "isActive",
+                    "visibleUsers",
+                    "visibleGroups",
+                    "visibleTeams",
+                    "calendarUri",
+                    "calendarEventUid",
+                    "seriesId",
+                    "seriesPosition",
+                    "alreadyCheckedIn",
+                    "checkinState",
+                    "checkinAt"
+                ],
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "startDatetime": {
+                        "type": "string"
+                    },
+                    "endDatetime": {
+                        "type": "string"
+                    },
+                    "createdBy": {
+                        "type": "string"
+                    },
+                    "createdAt": {
+                        "type": "string"
+                    },
+                    "updatedAt": {
+                        "type": "string"
+                    },
+                    "isActive": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "visibleUsers": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "visibleGroups": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "visibleTeams": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "calendarUri": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "calendarEventUid": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "seriesId": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "seriesPosition": {
+                        "type": "integer",
+                        "format": "int64",
+                        "nullable": true
+                    },
+                    "alreadyCheckedIn": {
+                        "type": "boolean"
+                    },
+                    "checkinState": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "checkinAt": {
+                        "type": "string",
+                        "nullable": true
+                    }
+                }
+            },
+            "SelfCheckinResult": {
+                "type": "object",
+                "required": [
+                    "appointment",
+                    "checkinState",
+                    "checkinAt",
+                    "alreadyCheckedIn"
+                ],
+                "properties": {
+                    "appointment": {
+                        "$ref": "#/components/schemas/AppointmentData"
+                    },
+                    "checkinState": {
+                        "type": "string"
+                    },
+                    "checkinAt": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "alreadyCheckedIn": {
+                        "type": "boolean"
+                    }
+                }
+            },
+            "UserConfig": {
+                "type": "object",
+                "required": [
+                    "displayOrder"
+                ],
+                "properties": {
+                    "displayOrder": {
+                        "type": "string"
+                    }
+                }
+            },
+            "UserPermissions": {
+                "type": "object",
+                "required": [
+                    "canManageAppointments",
+                    "canCheckin",
+                    "canSeeResponseOverview",
+                    "canSeeComments",
+                    "canSelfCheckin"
+                ],
+                "properties": {
+                    "canManageAppointments": {
+                        "type": "boolean"
+                    },
+                    "canCheckin": {
+                        "type": "boolean"
+                    },
+                    "canSeeResponseOverview": {
+                        "type": "boolean"
+                    },
+                    "canSeeComments": {
+                        "type": "boolean"
+                    },
+                    "canSelfCheckin": {
+                        "type": "boolean"
+                    }
+                }
             }
         }
     },
@@ -658,7 +875,7 @@
                     }
                 },
                 "responses": {
-                    "200": {
+                    "201": {
                         "description": "",
                         "content": {
                             "application/json": {
@@ -792,7 +1009,7 @@
                     }
                 },
                 "responses": {
-                    "200": {
+                    "201": {
                         "description": "",
                         "content": {
                             "application/json": {
@@ -1395,20 +1612,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "type": "object",
-                                    "required": [
-                                        "success",
-                                        "deletedCount"
-                                    ],
-                                    "properties": {
-                                        "success": {
-                                            "type": "boolean"
-                                        },
-                                        "deletedCount": {
-                                            "type": "integer",
-                                            "format": "int64"
-                                        }
-                                    }
+                                    "$ref": "#/components/schemas/DeleteResult"
                                 }
                             }
                         }
@@ -2000,13 +2204,8 @@
                             "application/json": {
                                 "schema": {
                                     "type": "object",
-                                    "required": [
-                                        "success"
-                                    ],
-                                    "properties": {
-                                        "success": {
-                                            "type": "boolean"
-                                        }
+                                    "additionalProperties": {
+                                        "type": "object"
                                     }
                                 }
                             }
@@ -2087,7 +2286,7 @@
         "/index.php/apps/attendance/api/user/permissions": {
             "get": {
                 "operationId": "appointment-get-permissions",
-                "summary": "Get the current user's permissions and app capabilities",
+                "summary": "Get the current user's permissions",
                 "tags": [
                     "appointment"
                 ],
@@ -2105,39 +2304,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "type": "object",
-                                    "required": [
-                                        "canManageAppointments",
-                                        "canCheckin",
-                                        "canSeeResponseOverview",
-                                        "canSeeComments",
-                                        "calendarAvailable",
-                                        "calendarSyncEnabled",
-                                        "displayOrder"
-                                    ],
-                                    "properties": {
-                                        "canManageAppointments": {
-                                            "type": "boolean"
-                                        },
-                                        "canCheckin": {
-                                            "type": "boolean"
-                                        },
-                                        "canSeeResponseOverview": {
-                                            "type": "boolean"
-                                        },
-                                        "canSeeComments": {
-                                            "type": "boolean"
-                                        },
-                                        "calendarAvailable": {
-                                            "type": "boolean"
-                                        },
-                                        "calendarSyncEnabled": {
-                                            "type": "boolean"
-                                        },
-                                        "displayOrder": {
-                                            "type": "string"
-                                        }
-                                    }
+                                    "$ref": "#/components/schemas/UserPermissions"
                                 }
                             }
                         }
@@ -2171,6 +2338,100 @@
                                             }
                                         }
                                     ]
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/index.php/apps/attendance/api/user/config": {
+            "get": {
+                "operationId": "appointment-get-user-config",
+                "summary": "Get user-relevant app configuration",
+                "tags": [
+                    "appointment"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/UserConfig"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Current user is not logged in",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "message"
+                                    ],
+                                    "properties": {
+                                        "message": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/index.php/apps/attendance/api/capabilities": {
+            "get": {
+                "operationId": "appointment-get-capabilities",
+                "summary": "Get system-wide capabilities",
+                "tags": [
+                    "appointment"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Capabilities"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Current user is not logged in",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "message"
+                                    ],
+                                    "properties": {
+                                        "message": {
+                                            "type": "string"
+                                        }
+                                    }
                                 }
                             }
                         }
@@ -2370,23 +2631,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "type": "object",
-                                    "required": [
-                                        "success",
-                                        "path",
-                                        "filename"
-                                    ],
-                                    "properties": {
-                                        "success": {
-                                            "type": "boolean"
-                                        },
-                                        "path": {
-                                            "type": "string"
-                                        },
-                                        "filename": {
-                                            "type": "string"
-                                        }
-                                    }
+                                    "$ref": "#/components/schemas/ExportResult"
                                 }
                             }
                         }
@@ -3036,10 +3281,7 @@
                                 "schema": {
                                     "type": "array",
                                     "items": {
-                                        "type": "object",
-                                        "additionalProperties": {
-                                            "type": "object"
-                                        }
+                                        "$ref": "#/components/schemas/SelfCheckinAppointment"
                                     }
                                 }
                             }
@@ -3158,10 +3400,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "type": "object",
-                                    "additionalProperties": {
-                                        "type": "object"
-                                    }
+                                    "$ref": "#/components/schemas/SelfCheckinResult"
                                 }
                             }
                         }

--- a/src/App.vue
+++ b/src/App.vue
@@ -181,8 +181,8 @@
                 :mode="currentView"
                 :appointment-id="formAppointmentId"
                 :notifications-app-enabled="notificationsAppEnabled"
-                :calendar-available="permissions.calendarAvailable"
-                :calendar-sync-enabled="permissions.calendarSyncEnabled"
+                :calendar-available="capabilities.calendarAvailable"
+                :calendar-sync-enabled="capabilities.calendarSyncEnabled"
                 @saved="handleFormSaved"
                 @cancelled="handleFormCancelled"
             />
@@ -311,7 +311,7 @@ const notificationsAppEnabled = ref(false);
 const pastAppointmentsExpanded = ref(false);
 
 // Use the shared permissions composable
-const { permissions, loadPermissions } = usePermissions();
+const { permissions, capabilities, config, loadPermissions } = usePermissions();
 
 // Computed property for unanswered appointments
 const unansweredAppointments = computed(() => {
@@ -469,7 +469,7 @@ const formatAppointmentDisplay = (appointment) => {
         return appointment.name;
     }
     const dateTimeStr = formatDateTime(appointment.startDatetime);
-    if (permissions.displayOrder === "date_first") {
+    if (config.displayOrder === "date_first") {
         return `${dateTimeStr}\n${appointment.name}`;
     }
     return `${appointment.name}\n${dateTimeStr}`;

--- a/src/components/ExportDialog.vue
+++ b/src/components/ExportDialog.vue
@@ -322,21 +322,17 @@ const handleExport = async () => {
             exportData,
         );
 
-        if (response.data.success) {
-            showSuccess(
-                t("attendance", "Export created: {filename}", {
-                    filename: response.data.filename,
-                }),
-            );
+        showSuccess(
+            t("attendance", "Export created: {filename}", {
+                filename: response.data.filename,
+            }),
+        );
 
-            // Redirect to Files app to show the exported file
-            const filesUrl = generateUrl("/apps/files/?dir=/Attendance");
-            window.location.href = filesUrl;
+        // Redirect to Files app to show the exported file
+        const filesUrl = generateUrl("/apps/files/?dir=/Attendance");
+        window.location.href = filesUrl;
 
-            emit("close");
-        } else {
-            showError(t("attendance", "Failed to export appointments"));
-        }
+        emit("close");
     } catch (error) {
         console.error("Failed to export appointments:", error);
         const errorMessage =

--- a/src/components/SingleAppointmentExportDialog.vue
+++ b/src/components/SingleAppointmentExportDialog.vue
@@ -79,17 +79,13 @@ const handleExport = async () => {
 			includeComments: includeComments.value,
 		})
 
-		if (response.data.success) {
-			showSuccess(t('attendance', 'Export created: {filename}', { filename: response.data.filename }))
+		showSuccess(t('attendance', 'Export created: {filename}', { filename: response.data.filename }))
 
-			// Redirect to Files app to show the exported file
-			const filesUrl = generateUrl('/apps/files/?dir=/Attendance')
-			window.location.href = filesUrl
+		// Redirect to Files app to show the exported file
+		const filesUrl = generateUrl('/apps/files/?dir=/Attendance')
+		window.location.href = filesUrl
 
-			emit('close')
-		} else {
-			showError(t('attendance', 'Failed to export appointment'))
-		}
+		emit('close')
 	} catch (error) {
 		console.error('Failed to export appointment:', error)
 		const errorMessage = error.response?.data?.error || t('attendance', 'Failed to export appointment')

--- a/src/composables/usePermissions.js
+++ b/src/composables/usePermissions.js
@@ -9,8 +9,15 @@ const state = reactive({
 		canSeeResponseOverview: false,
 		canSeeComments: false,
 		canSelfCheckin: false,
+	},
+	capabilities: {
 		calendarAvailable: false,
 		calendarSyncEnabled: false,
+		teamsAvailable: false,
+		calendarSyncAvailable: false,
+		notificationsAppEnabled: false,
+	},
+	config: {
 		displayOrder: 'name_first',
 	},
 	loading: false,
@@ -19,13 +26,13 @@ const state = reactive({
 })
 
 /**
- * Composable for managing user permissions
- * Loads permissions only once and shares them across all components
+ * Composable for managing user permissions, capabilities, and config
+ * Loads data only once and shares it across all components
  */
 export function usePermissions() {
 	/**
-	 * Load permissions from the server
-	 * Will only make the API call once unless force=true
+	 * Load permissions, capabilities, and config from the server
+	 * Will only make the API calls once unless force=true
 	 * @param force
 	 */
 	const loadPermissions = async (force = false) => {
@@ -41,17 +48,25 @@ export function usePermissions() {
 		state.error = null
 
 		try {
-			const url = generateUrl('/apps/attendance/api/user/permissions')
-			const response = await axios.get(url)
+			const [permissionsRes, capabilitiesRes, configRes] = await Promise.all([
+				axios.get(generateUrl('/apps/attendance/api/user/permissions')),
+				axios.get(generateUrl('/apps/attendance/api/capabilities')),
+				axios.get(generateUrl('/apps/attendance/api/user/config')),
+			])
 
-			state.permissions.canManageAppointments = response.data.canManageAppointments || false
-			state.permissions.canCheckin = response.data.canCheckin || false
-			state.permissions.canSeeResponseOverview = response.data.canSeeResponseOverview || false
-			state.permissions.canSeeComments = response.data.canSeeComments || false
-			state.permissions.canSelfCheckin = response.data.canSelfCheckin || false
-			state.permissions.calendarAvailable = response.data.calendarAvailable || false
-			state.permissions.calendarSyncEnabled = response.data.calendarSyncEnabled || false
-			state.permissions.displayOrder = response.data.displayOrder || 'name_first'
+			state.permissions.canManageAppointments = permissionsRes.data.canManageAppointments || false
+			state.permissions.canCheckin = permissionsRes.data.canCheckin || false
+			state.permissions.canSeeResponseOverview = permissionsRes.data.canSeeResponseOverview || false
+			state.permissions.canSeeComments = permissionsRes.data.canSeeComments || false
+			state.permissions.canSelfCheckin = permissionsRes.data.canSelfCheckin || false
+
+			state.capabilities.calendarAvailable = capabilitiesRes.data.calendarAvailable || false
+			state.capabilities.calendarSyncEnabled = capabilitiesRes.data.calendarSyncEnabled || false
+			state.capabilities.teamsAvailable = capabilitiesRes.data.teamsAvailable || false
+			state.capabilities.calendarSyncAvailable = capabilitiesRes.data.calendarSyncAvailable || false
+			state.capabilities.notificationsAppEnabled = capabilitiesRes.data.notificationsAppEnabled !== false
+
+			state.config.displayOrder = configRes.data.displayOrder || 'name_first'
 
 			state.loaded = true
 		} catch (error) {
@@ -63,9 +78,12 @@ export function usePermissions() {
 			state.permissions.canSeeResponseOverview = false
 			state.permissions.canSeeComments = false
 			state.permissions.canSelfCheckin = false
-			state.permissions.calendarAvailable = false
-			state.permissions.calendarSyncEnabled = false
-			state.permissions.displayOrder = 'name_first'
+			state.capabilities.calendarAvailable = false
+			state.capabilities.calendarSyncEnabled = false
+			state.capabilities.teamsAvailable = false
+			state.capabilities.calendarSyncAvailable = false
+			state.capabilities.notificationsAppEnabled = false
+			state.config.displayOrder = 'name_first'
 		} finally {
 			state.loading = false
 		}
@@ -90,6 +108,8 @@ export function usePermissions() {
 
 	return {
 		permissions: readonly(state.permissions),
+		capabilities: readonly(state.capabilities),
+		config: readonly(state.config),
 		loading: readonly(state.loading),
 		loaded: readonly(state.loaded),
 		error: readonly(state.error),

--- a/src/views/AdminSettings.vue
+++ b/src/views/AdminSettings.vue
@@ -378,66 +378,61 @@ const loadSettings = async () => {
 	loadingData.value = true
 
 	try {
-		const response = await axios.get(
-			generateUrl('/apps/attendance/api/admin/settings'),
-		)
+		const [settingsRes, capabilitiesRes] = await Promise.all([
+			axios.get(generateUrl('/apps/attendance/api/admin/settings')),
+			axios.get(generateUrl('/apps/attendance/api/capabilities')),
+		])
 
-		if (response.data.groups) {
-			availableGroups.value = response.data.groups
-			// Convert selected IDs to selected group objects for NcSelect, preserving database order
-			selectedGroups.value = response.data.whitelistedGroups
-				.map(id => response.data.groups.find(group => group.id === id))
-				.filter(group => group !== undefined)
+		const { config, status, groups } = settingsRes.data
+		const caps = capabilitiesRes.data
 
-			// Load teams settings
-			teamsAvailable.value = response.data.teamsAvailable || false
-			if (response.data.whitelistedTeams) {
-				selectedTeams.value = response.data.whitelistedTeams
-				// Also add to search results so they appear in the dropdown
-				teamSearchResults.value = [...response.data.whitelistedTeams]
-			}
+		availableGroups.value = groups
+		// Convert selected IDs to selected group objects for NcSelect, preserving database order
+		selectedGroups.value = config.whitelistedGroups
+			.map(id => groups.find(group => group.id === id))
+			.filter(group => group !== undefined)
 
-			// Load permission settings, preserving database order
-			if (response.data.permissions) {
-				selectedManageAppointmentsRoles.value = response.data.permissions.manage_appointments
-					.map(id => response.data.groups.find(group => group.id === id))
-					.filter(group => group !== undefined)
-				selectedCheckinRoles.value = response.data.permissions.checkin
-					.map(id => response.data.groups.find(group => group.id === id))
-					.filter(group => group !== undefined)
-				selectedSeeResponseOverviewRoles.value = (response.data.permissions.see_response_overview || [])
-					.map(id => response.data.groups.find(group => group.id === id))
-					.filter(group => group !== undefined)
-				selectedSeeCommentsRoles.value = (response.data.permissions.see_comments || [])
-					.map(id => response.data.groups.find(group => group.id === id))
-					.filter(group => group !== undefined)
-				selectedSelfCheckinRoles.value = (response.data.permissions.self_checkin || [])
-					.map(id => response.data.groups.find(group => group.id === id))
-					.filter(group => group !== undefined)
-			}
-
-			// Load reminder settings
-			if (response.data.reminders) {
-				remindersEnabled.value = response.data.reminders.enabled || false
-				reminderDays.value = response.data.reminders.reminderDays || 7
-				reminderFrequency.value = response.data.reminders.reminderFrequency || 0
-				notificationsAppEnabled.value = response.data.reminders.notificationsAppEnabled !== false
-				nextAppointment.value = response.data.reminders.nextAppointment || null
-				nextReminderRun.value = response.data.reminders.nextReminderRun || null
-			}
-
-			// Load calendar sync settings
-			if (response.data.calendarSync) {
-				calendarSyncEnabled.value = response.data.calendarSync.enabled || false
-				calendarSyncAvailable.value = response.data.calendarSync.available || false
-			}
-
-			// Load display order
-			displayOrder.value = response.data.displayOrder || 'name_first'
-		} else {
-			showError(window.t('attendance', 'Failed to load settings')
-				+ (response.data.error ? ': ' + response.data.error : ''))
+		// Load teams settings
+		teamsAvailable.value = caps.teamsAvailable || false
+		if (config.whitelistedTeams) {
+			selectedTeams.value = config.whitelistedTeams
+			// Also add to search results so they appear in the dropdown
+			teamSearchResults.value = [...config.whitelistedTeams]
 		}
+
+		// Load permission settings, preserving database order
+		if (config.permissions) {
+			selectedManageAppointmentsRoles.value = config.permissions.manage_appointments
+				.map(id => groups.find(group => group.id === id))
+				.filter(group => group !== undefined)
+			selectedCheckinRoles.value = config.permissions.checkin
+				.map(id => groups.find(group => group.id === id))
+				.filter(group => group !== undefined)
+			selectedSeeResponseOverviewRoles.value = (config.permissions.see_response_overview || [])
+				.map(id => groups.find(group => group.id === id))
+				.filter(group => group !== undefined)
+			selectedSeeCommentsRoles.value = (config.permissions.see_comments || [])
+				.map(id => groups.find(group => group.id === id))
+				.filter(group => group !== undefined)
+			selectedSelfCheckinRoles.value = (config.permissions.self_checkin || [])
+				.map(id => groups.find(group => group.id === id))
+				.filter(group => group !== undefined)
+		}
+
+		// Load reminder settings
+		remindersEnabled.value = config.reminders.enabled || false
+		reminderDays.value = config.reminders.reminderDays || 7
+		reminderFrequency.value = config.reminders.reminderFrequency || 0
+		notificationsAppEnabled.value = caps.notificationsAppEnabled !== false
+		nextAppointment.value = status.nextAppointment || null
+		nextReminderRun.value = status.nextReminderRun || null
+
+		// Load calendar sync settings
+		calendarSyncEnabled.value = config.calendarSync.enabled || false
+		calendarSyncAvailable.value = caps.calendarSyncAvailable || false
+
+		// Load display order
+		displayOrder.value = config.displayOrder || 'name_first'
 	} catch (error) {
 		console.error('Error loading settings:', error)
 		showError(window.t('attendance', 'Failed to load settings'))

--- a/src/views/AllAppointments.vue
+++ b/src/views/AllAppointments.vue
@@ -42,7 +42,7 @@
 					:can-checkin="permissions.canCheckin"
 					:can-see-response-overview="permissions.canSeeResponseOverview"
 					:can-see-comments="permissions.canSeeComments"
-					:display-order="permissions.displayOrder"
+					:display-order="config.displayOrder"
 					@start-checkin="startCheckin"
 					@edit="editAppointment"
 					@copy="copyAppointment"
@@ -111,7 +111,7 @@ const unansweredCount = computed(() => {
 const loading = ref(true)
 const responseComments = reactive({})
 
-const { permissions, loadPermissions } = usePermissions()
+const { permissions, config, loadPermissions } = usePermissions()
 
 // Use the shared response composable
 const { submitResponse: submitResponseApi } = useAppointmentResponse({

--- a/src/views/AppointmentDetail.vue
+++ b/src/views/AppointmentDetail.vue
@@ -25,7 +25,7 @@
 				:can-checkin="permissions.canCheckin"
 				:can-see-response-overview="permissions.canSeeResponseOverview"
 				:can-see-comments="permissions.canSeeComments"
-				:display-order="permissions.displayOrder"
+				:display-order="config.displayOrder"
 				@start-checkin="startCheckin"
 				@edit="editAppointment"
 				@copy="copyAppointment"
@@ -83,7 +83,7 @@ const exportDialogVisible = ref(false)
 const showDeleteDialog = ref(false)
 
 // Use the shared permissions composable
-const { permissions, loadPermissions } = usePermissions()
+const { permissions, config, loadPermissions } = usePermissions()
 
 // Use the shared response composable
 const { submitResponse: submitResponseApi } = useAppointmentResponse({

--- a/src/views/Checkin.vue
+++ b/src/views/Checkin.vue
@@ -19,7 +19,7 @@
 		</div>
 
 		<div v-if="!loading && !error && timeWarning && !timeWarningAccepted" class="time-warning-gate">
-			<CheckinAppointmentInfo :appointment="appointment" :display-order="permissions.displayOrder" />
+			<CheckinAppointmentInfo :appointment="appointment" :display-order="config.displayOrder" />
 			<NcNoteCard type="error" :heading="t('attendance', 'Caution')" :show-alert="true">
 				<p>{{ timeWarning }}</p>
 				<div class="time-warning-action">
@@ -31,7 +31,7 @@
 		</div>
 
 		<div v-if="!loading && !error && (!timeWarning || timeWarningAccepted)" class="checkin-content">
-			<CheckinAppointmentInfo :appointment="appointment" :display-order="permissions.displayOrder" />
+			<CheckinAppointmentInfo :appointment="appointment" :display-order="config.displayOrder" />
 
 			<CheckinStatus
 				:all-checked-in="checkinStatus.allCheckedIn"
@@ -201,7 +201,7 @@ const confirmMessage = ref('')
 const timeWarningAccepted = ref(false)
 const showResetDialog = ref(false)
 
-const { permissions, loadPermissions } = usePermissions()
+const { permissions, config, loadPermissions } = usePermissions()
 
 // Computed
 const TIME_THRESHOLD_MS = 8 * 60 * 60 * 1000


### PR DESCRIPTION
## Summary
- Split `GET /api/user/permissions` into three dedicated endpoints: `/api/user/permissions` (pure permissions), `/api/capabilities` (system-wide capabilities), `/api/user/config` (user config like displayOrder)
- Restructure `GET /api/admin/settings` response into `{config, status, groups}` — capabilities now served by shared `/api/capabilities` endpoint
- Remove redundant `{success: bool}` wrapping from delete, resetCheckin, export, and saveSettings responses
- Add typed psalm response definitions for self-checkin, delete, export, capabilities, and admin endpoints
- Fix OpenAPI docblocks: STATUS_OK → STATUS_CREATED for create/bulkCreate, JSONResponse → DataResponse for admin endpoints
- Update frontend: usePermissions fetches 3 endpoints in parallel, AdminSettings reads nested structure, export dialogs use try/catch
- Add `docs/api-migration.md` with before/after guide for Flutter app

## Test plan
- [x] `composer openapi` succeeds
- [x] `npm run build` succeeds
- [x] All 107 e2e tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)