### PR TITLE
fix: notification checkbox not shown for non-admin users when creating appointments

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "attendance",
-  "version": "1.28.2",
+  "version": "1.32.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "attendance",
-      "version": "1.28.2",
+      "version": "1.32.1",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@nextcloud/axios": "^2.5.1",

--- a/src/App.vue
+++ b/src/App.vue
@@ -180,7 +180,7 @@
                 "
                 :mode="currentView"
                 :appointment-id="formAppointmentId"
-                :notifications-app-enabled="notificationsAppEnabled"
+                :notifications-app-enabled="capabilities.notificationsAppEnabled"
                 :calendar-available="capabilities.calendarAvailable"
                 :calendar-sync-enabled="capabilities.calendarSyncEnabled"
                 @saved="handleFormSaved"
@@ -307,7 +307,7 @@ const currentAppointments = ref([]);
 const pastAppointments = ref([]);
 const showIcalFeedModal = ref(false);
 const showExportDialog = ref(false);
-const notificationsAppEnabled = ref(false);
+
 const pastAppointmentsExpanded = ref(false);
 
 // Use the shared permissions composable
@@ -382,20 +382,6 @@ const loadAppointments = async () => {
     }
 };
 
-const loadNotificationsAppStatus = async () => {
-    try {
-        const response = await axios.get(
-            generateUrl("/apps/attendance/api/admin/settings"),
-        );
-        if (response.data.reminders) {
-            notificationsAppEnabled.value =
-                response.data.reminders.notificationsAppEnabled !== false;
-        }
-    } catch (error) {
-        // If user doesn't have admin access, that's fine - notifications checkbox won't be shown
-        console.debug("Could not load notifications app status:", error);
-    }
-};
 
 const createNewAppointment = () => {
     currentView.value = "create";
@@ -535,7 +521,6 @@ watch(currentView, async (newView, oldView) => {
 onMounted(async () => {
     checkRouting();
     await loadPermissions();
-    await loadNotificationsAppStatus();
 
     // Skip loading appointments only for checkin view (no navigation sidebar)
     // All other views show navigation and need appointment data


### PR DESCRIPTION
The notificationsAppEnabled status was loaded from the admin-only endpoint
/api/admin/settings, which returns a 403 for non-admin users. This caused
the "Send notification" checkbox to never appear for regular users.

Now uses the capabilities data from usePermissions() composable, which
already loads notificationsAppEnabled from /api/capabilities (accessible
to all users).

Fixes #52

https://claude.ai/code/session_01TcJbdUZVYPvFwiReCDAP53