### PR TITLE
fix: nullify userResponse on detail endpoint when response is NULL

### DIFF
--- a/lib/Service/AppointmentService.php
+++ b/lib/Service/AppointmentService.php
@@ -317,7 +317,11 @@ class AppointmentService {
 		$appointmentData = $appointment->jsonSerialize();
 		$appointmentData = $this->enrichVisibilityData($appointmentData);
 		$appointmentData = $this->enrichSeriesCount($appointmentData, $appointment);
-		$appointmentData['userResponse'] = $this->getUserResponse($appointment->getId(), $userId);
+		// Only expose userResponse when the user actually answered yes/no/maybe.
+		// A row with response=NULL exists when an admin checked the user in
+		// before they ever responded; treat that as "no response" (matches list endpoint).
+		$userResponse = $this->getUserResponse($appointment->getId(), $userId);
+		$appointmentData['userResponse'] = ($userResponse && $userResponse->getResponse() !== null) ? $userResponse : null;
 		$appointmentData['responseSummary'] = $this->responseSummaryService->getResponseSummary($appointment->getId());
 		$appointmentData['attachments'] = $this->attachmentService->getAttachments($appointment->getId());
 


### PR DESCRIPTION
## Summary

Fixes a crash on the mobile app's appointment detail screen (`type 'Null' is not a subtype of type 'String' in type cast`) when an admin checked a user in before the user ever answered yes/no/maybe.

## Root cause

`CheckinService::checkin()` creates an `AttendanceResponse` row populating only the `checkin*` fields — `response` and `respondedAt` stay NULL.

- `getAppointmentsWithUserResponses` (the list endpoint) already guards against this and nullifies `userResponse` when `response` is NULL.
- `getAppointmentWithUserResponse` (the detail endpoint) returned the raw row, so the JSON contained `response: null` / `respondedAt: null`.

Mobile clients that deserialize `response` as a non-nullable String fail the cast, and the detail screen shows a red error state. The list screen is unaffected because of the existing guard.

## Change

Mirror the list-endpoint guard in the detail endpoint so both return the same shape. Single-line behavioral change (plus a comment explaining the case).

## Test plan

- [ ] Admin checks in a user who has never responded. User opens the appointment in the mobile app — detail screen loads without error and shows no prior response.
- [ ] User who responded yes/no/maybe still sees their response on the detail screen.
- [ ] Web frontend detail view unchanged (should already tolerate a null `userResponse`; confirm).

🤖 Generated with [Claude Code](https://claude.com/claude-code)