### PR TITLE
feat(l10n): register translations for mobile 404 helper

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -301,6 +301,13 @@ t('attendance', 'Not now')
 t('attendance', 'Server Update Available')
 t('attendance', "Your server's Attendance app may be outdated. Please update to version 1.34.0 or later for the best experience.")
 
+t('attendance', 'Attendance is not available')
+t('attendance', 'The Attendance app could not be reached on your Nextcloud server. This usually has one of two reasons:')
+t('attendance', 'The app is not installed on the server.')
+t('attendance', 'Ask an administrator to install the Attendance app from the Nextcloud app store.')
+t('attendance', 'The app is limited to specific groups.')
+t('attendance', 'Ask an administrator to allow your account under Administration settings → Apps → Attendance → "Limit to groups".')
+
 t('attendance', 'Checked in')
 t('attendance', 'Not checked in')
 t('attendance', 'Happening now')


### PR DESCRIPTION
## Summary

Adds six \`t('attendance', '…')\` calls in \`src/App.vue\` so the Nextcloud l10n extractor picks up the strings used by the new mobile-only 404 helper view and they get translated through Transifex.

## Context

Companion to [luflow/attendance-flutter#7](https://github.com/luflow/attendance-flutter/pull/7) — the Flutter app now shows a dedicated \"App not available\" screen when \`/apps/attendance/*\` returns 404 (app not installed, or restricted to groups the user isn't in), replacing the misleading \"Request failed (HTTP 404)\" + bogus \"Server outdated\" dialog.

Follows the same staged-block pattern as commit 34c6a8b (\"register Flutter-only translation strings for Transifex\").

## Strings added

- Attendance is not available
- The Attendance app could not be reached on your Nextcloud server. This usually has one of two reasons:
- The app is not installed on the server.
- Ask an administrator to install the Attendance app from the Nextcloud app store.
- The app is limited to specific groups.
- Ask an administrator to allow your account under Administration settings → Apps → Attendance → \"Limit to groups\".

## Test plan

- [ ] Translation extraction runs cleanly and the strings appear in Transifex.
- [ ] No change to the web app UI (strings not referenced from any template).

🤖 Generated with [Claude Code](https://claude.com/claude-code)