### PR TITLE
feat: promote mobile apps in web UI and admin settings

### DIFF
--- a/l10n/de.js
+++ b/l10n/de.js
@@ -421,6 +421,21 @@ OC.L10N.register(
     "Subscription URL regenerated" : "Abonnement-URL wurde neu erstellt",
     "Failed to regenerate subscription URL" : "Die Abonnement-URL konnte nicht neu erstellt werden",
     "URL copied to clipboard" : "URL wurde in die Zwischenablage kopiert",
-    "Failed to copy URL" : "URL konnte nicht kopiert werden"
+    "Failed to copy URL" : "URL konnte nicht kopiert werden",
+    "Attendance is now on your phone" : "Anwesenheit gibt es jetzt auch auf deinem Smartphone",
+    "Get the mobile app for faster access and push notifications." : "Hol dir die mobile App für schnelleren Zugriff und Push-Benachrichtigungen.",
+    "App Store" : "App Store",
+    "Google Play" : "Google Play",
+    "Dismiss" : "Schließen",
+    "Mobile apps" : "Mobile Apps",
+    "Share these links with your colleagues to install the Attendance mobile app." : "Teile diese Links mit Kolleginnen und Kollegen, um die Anwesenheit-App auf dem Smartphone zu installieren.",
+    "App Store (iOS)" : "App Store (iOS)",
+    "Google Play (Android)" : "Google Play (Android)",
+    "Open" : "Öffnen",
+    "Mobile App promotion banner" : "Werbebanner für mobile App",
+    "Show a banner at the top of the web app advertising the mobile apps. Users can dismiss the banner, and users who already have a push device connected will not see it." : "Zeigt oben in der Web-App ein Banner, das auf die mobilen Apps hinweist. Nutzer können das Banner schließen; Nutzer mit bereits verbundenem Gerät sehen es gar nicht.",
+    "Show promotion banner" : "Werbebanner anzeigen",
+    "Link copied" : "Link kopiert",
+    "Failed to copy link" : "Link konnte nicht kopiert werden"
 },
 "nplurals=2; plural=(n != 1);");

--- a/l10n/de.json
+++ b/l10n/de.json
@@ -419,6 +419,21 @@
     "Subscription URL regenerated" : "Abonnement-URL wurde neu erstellt",
     "Failed to regenerate subscription URL" : "Die Abonnement-URL konnte nicht neu erstellt werden",
     "URL copied to clipboard" : "URL wurde in die Zwischenablage kopiert",
-    "Failed to copy URL" : "URL konnte nicht kopiert werden"
+    "Failed to copy URL" : "URL konnte nicht kopiert werden",
+    "Attendance is now on your phone" : "Anwesenheit gibt es jetzt auch auf deinem Smartphone",
+    "Get the mobile app for faster access and push notifications." : "Hol dir die mobile App für schnelleren Zugriff und Push-Benachrichtigungen.",
+    "App Store" : "App Store",
+    "Google Play" : "Google Play",
+    "Dismiss" : "Schließen",
+    "Mobile apps" : "Mobile Apps",
+    "Share these links with your colleagues to install the Attendance mobile app." : "Teile diese Links mit Kolleginnen und Kollegen, um die Anwesenheit-App auf dem Smartphone zu installieren.",
+    "App Store (iOS)" : "App Store (iOS)",
+    "Google Play (Android)" : "Google Play (Android)",
+    "Open" : "Öffnen",
+    "Mobile App promotion banner" : "Werbebanner für mobile App",
+    "Show a banner at the top of the web app advertising the mobile apps. Users can dismiss the banner, and users who already have a push device connected will not see it." : "Zeigt oben in der Web-App ein Banner, das auf die mobilen Apps hinweist. Nutzer können das Banner schließen; Nutzer mit bereits verbundenem Gerät sehen es gar nicht.",
+    "Show promotion banner" : "Werbebanner anzeigen",
+    "Link copied" : "Link kopiert",
+    "Failed to copy link" : "Link konnte nicht kopiert werden"
 },"pluralForm" :"nplurals=2; plural=(n != 1);"
 }

--- a/l10n/de_DE.js
+++ b/l10n/de_DE.js
@@ -421,6 +421,21 @@ OC.L10N.register(
     "Subscription URL regenerated" : "Abonnement-URL neu generiert",
     "Failed to regenerate subscription URL" : "Die Abonnement-URL konnte nicht neu generiert werden",
     "URL copied to clipboard" : "URL wurde in die Zwischenablage kopiert",
-    "Failed to copy URL" : "URL konnte nicht kopiert werden"
+    "Failed to copy URL" : "URL konnte nicht kopiert werden",
+    "Attendance is now on your phone" : "Anwesenheit gibt es jetzt auch auf Ihrem Smartphone",
+    "Get the mobile app for faster access and push notifications." : "Holen Sie sich die mobile App für schnelleren Zugriff und Push-Benachrichtigungen.",
+    "App Store" : "App Store",
+    "Google Play" : "Google Play",
+    "Dismiss" : "Schließen",
+    "Mobile apps" : "Mobile Apps",
+    "Share these links with your colleagues to install the Attendance mobile app." : "Teilen Sie diese Links mit Ihren Kolleginnen und Kollegen, um die Anwesenheit-App auf dem Smartphone zu installieren.",
+    "App Store (iOS)" : "App Store (iOS)",
+    "Google Play (Android)" : "Google Play (Android)",
+    "Open" : "Öffnen",
+    "Mobile App promotion banner" : "Werbebanner für mobile App",
+    "Show a banner at the top of the web app advertising the mobile apps. Users can dismiss the banner, and users who already have a push device connected will not see it." : "Zeigt oben in der Web-App ein Banner, das auf die mobilen Apps hinweist. Nutzer können das Banner schließen; Nutzer mit bereits verbundenem Gerät sehen es gar nicht.",
+    "Show promotion banner" : "Werbebanner anzeigen",
+    "Link copied" : "Link kopiert",
+    "Failed to copy link" : "Link konnte nicht kopiert werden"
 },
 "nplurals=2; plural=(n != 1);");

--- a/l10n/de_DE.json
+++ b/l10n/de_DE.json
@@ -419,6 +419,21 @@
     "Subscription URL regenerated" : "Abonnement-URL neu generiert",
     "Failed to regenerate subscription URL" : "Die Abonnement-URL konnte nicht neu generiert werden",
     "URL copied to clipboard" : "URL wurde in die Zwischenablage kopiert",
-    "Failed to copy URL" : "URL konnte nicht kopiert werden"
+    "Failed to copy URL" : "URL konnte nicht kopiert werden",
+    "Attendance is now on your phone" : "Anwesenheit gibt es jetzt auch auf Ihrem Smartphone",
+    "Get the mobile app for faster access and push notifications." : "Holen Sie sich die mobile App für schnelleren Zugriff und Push-Benachrichtigungen.",
+    "App Store" : "App Store",
+    "Google Play" : "Google Play",
+    "Dismiss" : "Schließen",
+    "Mobile apps" : "Mobile Apps",
+    "Share these links with your colleagues to install the Attendance mobile app." : "Teilen Sie diese Links mit Ihren Kolleginnen und Kollegen, um die Anwesenheit-App auf dem Smartphone zu installieren.",
+    "App Store (iOS)" : "App Store (iOS)",
+    "Google Play (Android)" : "Google Play (Android)",
+    "Open" : "Öffnen",
+    "Mobile App promotion banner" : "Werbebanner für mobile App",
+    "Show a banner at the top of the web app advertising the mobile apps. Users can dismiss the banner, and users who already have a push device connected will not see it." : "Zeigt oben in der Web-App ein Banner, das auf die mobilen Apps hinweist. Nutzer können das Banner schließen; Nutzer mit bereits verbundenem Gerät sehen es gar nicht.",
+    "Show promotion banner" : "Werbebanner anzeigen",
+    "Link copied" : "Link kopiert",
+    "Failed to copy link" : "Link konnte nicht kopiert werden"
 },"pluralForm" :"nplurals=2; plural=(n != 1);"
 }

--- a/lib/Controller/AdminController.php
+++ b/lib/Controller/AdminController.php
@@ -18,10 +18,8 @@ use OCP\AppFramework\Http\Attribute\OpenAPI;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\BackgroundJob\IJobList;
 use OCP\IConfig;
-use OCP\IDBConnection;
 use OCP\IRequest;
 use OCP\IUserSession;
-use Psr\Log\LoggerInterface;
 
 class AdminController extends Controller {
 	private PermissionService $permissionService;
@@ -33,8 +31,6 @@ class AdminController extends Controller {
 	private NotificationService $notificationService;
 	private AppointmentMapper $appointmentMapper;
 	private IJobList $jobList;
-	private IDBConnection $db;
-	private LoggerInterface $logger;
 
 	public function __construct(
 		string $appName,
@@ -48,8 +44,6 @@ class AdminController extends Controller {
 		NotificationService $notificationService,
 		AppointmentMapper $appointmentMapper,
 		IJobList $jobList,
-		IDBConnection $db,
-		LoggerInterface $logger,
 	) {
 		parent::__construct($appName, $request);
 		$this->userSession = $userSession;
@@ -61,8 +55,6 @@ class AdminController extends Controller {
 		$this->notificationService = $notificationService;
 		$this->appointmentMapper = $appointmentMapper;
 		$this->jobList = $jobList;
-		$this->db = $db;
-		$this->logger = $logger;
 	}
 
 	/**
@@ -129,20 +121,7 @@ class AdminController extends Controller {
 				}
 			}
 
-			// Query push device registrations for current user
-			$pushDeviceCount = 0;
-			try {
-				$qb = $this->db->getQueryBuilder();
-				$qb->select($qb->func()->count('*', 'device_count'))
-					->from('notifications_pushhash')
-					->where($qb->expr()->eq('uid', $qb->createNamedParameter($user->getUID())));
-				$result = $qb->executeQuery();
-				$pushDeviceCount = (int)$result->fetchOne();
-				$result->closeCursor();
-			} catch (\Exception $e) {
-				// Table may not exist if notifications app is not installed
-				$this->logger->debug('Could not query push devices: ' . $e->getMessage());
-			}
+			$pushDeviceCount = $this->notificationService->countPushDevices($user->getUID());
 
 			return new DataResponse([
 				'config' => [
@@ -159,6 +138,7 @@ class AdminController extends Controller {
 					],
 					'displayOrder' => $this->configService->getDisplayOrder(),
 					'pushEnabled' => $this->configService->isPushEnabled(),
+					'mobileAppBannerEnabled' => $this->configService->isMobileAppBannerEnabled(),
 				],
 				'status' => [
 					'nextAppointment' => $nextAppointment,
@@ -182,6 +162,7 @@ class AdminController extends Controller {
 	 * @param array{enabled?: bool} $calendarSync Calendar sync settings
 	 * @param ?string $displayOrder Display order for appointments: chronological, name, or group
 	 * @param ?bool $pushEnabled Whether push notifications are enabled
+	 * @param ?bool $mobileAppBannerEnabled Whether the mobile app promotion banner is enabled
 	 * @return DataResponse<Http::STATUS_OK, array<string, mixed>, array{}>|DataResponse<Http::STATUS_UNAUTHORIZED, array{error: string}, array{}>|DataResponse<Http::STATUS_FORBIDDEN, array{error: string}, array{}>|DataResponse<Http::STATUS_INTERNAL_SERVER_ERROR, array{error: string}, array{}>
 	 */
 	#[NoCSRFRequired]
@@ -194,6 +175,7 @@ class AdminController extends Controller {
 		array $calendarSync = [],
 		?string $displayOrder = null,
 		?bool $pushEnabled = null,
+		?bool $mobileAppBannerEnabled = null,
 	): DataResponse {
 		// Get current user
 		$user = $this->userSession->getUser();
@@ -239,9 +221,12 @@ class AdminController extends Controller {
 				$this->configService->setDisplayOrder($displayOrder);
 			}
 
-			// Save push notifications enabled
 			if ($pushEnabled !== null) {
 				$this->configService->setPushEnabled($pushEnabled);
+			}
+
+			if ($mobileAppBannerEnabled !== null) {
+				$this->configService->setMobileAppBannerEnabled($mobileAppBannerEnabled);
 			}
 
 			return new DataResponse([]);

--- a/lib/Controller/AppointmentController.php
+++ b/lib/Controller/AppointmentController.php
@@ -646,8 +646,16 @@ class AppointmentController extends Controller {
 	#[NoCSRFRequired]
 	#[OpenAPI]
 	public function getUserConfig(): DataResponse {
+		$bannerEnabled = $this->configService->isMobileAppBannerEnabled();
+		$user = $this->userSession->getUser();
+		$hasPushDevice = $bannerEnabled && $user !== null
+			? $this->notificationService->hasPushDevice($user->getUID())
+			: false;
+
 		return new DataResponse([
 			'displayOrder' => $this->configService->getDisplayOrder(),
+			'mobileAppBannerEnabled' => $bannerEnabled,
+			'hasPushDevice' => $hasPushDevice,
 		]);
 	}
 

--- a/lib/ResponseDefinitions.php
+++ b/lib/ResponseDefinitions.php
@@ -121,6 +121,8 @@ namespace OCA\Attendance;
  * }
  * @psalm-type AttendanceUserConfig = array{
  *   displayOrder: string,
+ *   mobileAppBannerEnabled: bool,
+ *   hasPushDevice: bool,
  * }
  * @psalm-type AttendanceAdminReminderConfig = array{
  *   enabled: bool,
@@ -138,10 +140,12 @@ namespace OCA\Attendance;
  *   calendarSync: AttendanceAdminCalendarSyncConfig,
  *   displayOrder: string,
  *   pushEnabled: bool,
+ *   mobileAppBannerEnabled: bool,
  * }
  * @psalm-type AttendanceAdminStatus = array{
  *   nextAppointment: ?array{name: string, startDatetime: string},
  *   nextReminderRun: ?string,
+ *   pushDeviceCount: int,
  * }
  * @psalm-type AttendanceSelfCheckinAppointment = array{
  *   id: int,

--- a/lib/Service/ConfigService.php
+++ b/lib/Service/ConfigService.php
@@ -247,6 +247,24 @@ class ConfigService {
 	}
 
 	/**
+	 * Check if the mobile app promotion banner is enabled.
+	 *
+	 * @return bool True if the banner should be shown to users
+	 */
+	public function isMobileAppBannerEnabled(): bool {
+		return $this->config->getAppValue(self::APP_ID, 'mobile_app_banner_enabled', 'yes') === 'yes';
+	}
+
+	/**
+	 * Set the mobile app promotion banner enabled status.
+	 *
+	 * @param bool $enabled Whether the banner should be shown to users
+	 */
+	public function setMobileAppBannerEnabled(bool $enabled): void {
+		$this->config->setAppValue(self::APP_ID, 'mobile_app_banner_enabled', $enabled ? 'yes' : 'no');
+	}
+
+	/**
 	 * Get the display order for appointments.
 	 *
 	 * @return string 'name_first' or 'date_first'

--- a/lib/Service/NotificationService.php
+++ b/lib/Service/NotificationService.php
@@ -6,6 +6,7 @@ namespace OCA\Attendance\Service;
 
 use OCA\Attendance\Db\Appointment;
 use OCP\App\IAppManager;
+use OCP\IDBConnection;
 use OCP\IURLGenerator;
 use OCP\Notification\IManager as INotificationManager;
 use Psr\Log\LoggerInterface;
@@ -14,17 +15,20 @@ class NotificationService {
 	private INotificationManager $notificationManager;
 	private IAppManager $appManager;
 	private IURLGenerator $urlGenerator;
+	private IDBConnection $db;
 	private LoggerInterface $logger;
 
 	public function __construct(
 		INotificationManager $notificationManager,
 		IAppManager $appManager,
 		IURLGenerator $urlGenerator,
+		IDBConnection $db,
 		LoggerInterface $logger,
 	) {
 		$this->notificationManager = $notificationManager;
 		$this->appManager = $appManager;
 		$this->urlGenerator = $urlGenerator;
+		$this->db = $db;
 		$this->logger = $logger;
 	}
 
@@ -33,6 +37,47 @@ class NotificationService {
 	 */
 	public function isNotificationsAppEnabled(): bool {
 		return $this->appManager->isEnabledForUser('notifications');
+	}
+
+	/**
+	 * Count how many push devices (from the notifications app) are registered for a user.
+	 * Returns 0 if the notifications app is not installed or the query fails.
+	 */
+	public function countPushDevices(string $uid): int {
+		try {
+			$qb = $this->db->getQueryBuilder();
+			$qb->select($qb->func()->count('*', 'device_count'))
+				->from('notifications_pushhash')
+				->where($qb->expr()->eq('uid', $qb->createNamedParameter($uid)));
+			$result = $qb->executeQuery();
+			$count = (int)$result->fetchOne();
+			$result->closeCursor();
+			return $count;
+		} catch (\Exception $e) {
+			$this->logger->debug('Could not query push devices: ' . $e->getMessage());
+			return 0;
+		}
+	}
+
+	/**
+	 * Check whether a user has at least one push device registered.
+	 * Cheaper than counting when the caller only needs a boolean.
+	 */
+	public function hasPushDevice(string $uid): bool {
+		try {
+			$qb = $this->db->getQueryBuilder();
+			$qb->select('uid')
+				->from('notifications_pushhash')
+				->where($qb->expr()->eq('uid', $qb->createNamedParameter($uid)))
+				->setMaxResults(1);
+			$result = $qb->executeQuery();
+			$found = $result->fetchOne() !== false;
+			$result->closeCursor();
+			return $found;
+		} catch (\Exception $e) {
+			$this->logger->debug('Could not query push devices: ' . $e->getMessage());
+			return false;
+		}
 	}
 
 	/**

--- a/openapi-administration.json
+++ b/openapi-administration.json
@@ -40,7 +40,8 @@
                     "reminders",
                     "calendarSync",
                     "displayOrder",
-                    "pushEnabled"
+                    "pushEnabled",
+                    "mobileAppBannerEnabled"
                 ],
                 "properties": {
                     "whitelistedGroups": {
@@ -68,6 +69,9 @@
                         "type": "string"
                     },
                     "pushEnabled": {
+                        "type": "boolean"
+                    },
+                    "mobileAppBannerEnabled": {
                         "type": "boolean"
                     }
                 }
@@ -97,7 +101,8 @@
                 "type": "object",
                 "required": [
                     "nextAppointment",
-                    "nextReminderRun"
+                    "nextReminderRun",
+                    "pushDeviceCount"
                 ],
                 "properties": {
                     "nextAppointment": {
@@ -119,6 +124,10 @@
                     "nextReminderRun": {
                         "type": "string",
                         "nullable": true
+                    },
+                    "pushDeviceCount": {
+                        "type": "integer",
+                        "format": "int64"
                     }
                 }
             },
@@ -427,6 +436,12 @@
                                         "nullable": true,
                                         "default": null,
                                         "description": "Whether push notifications are enabled"
+                                    },
+                                    "mobileAppBannerEnabled": {
+                                        "type": "boolean",
+                                        "nullable": true,
+                                        "default": null,
+                                        "description": "Whether the mobile app promotion banner is enabled"
                                     }
                                 }
                             }

--- a/openapi-full.json
+++ b/openapi-full.json
@@ -40,7 +40,8 @@
                     "reminders",
                     "calendarSync",
                     "displayOrder",
-                    "pushEnabled"
+                    "pushEnabled",
+                    "mobileAppBannerEnabled"
                 ],
                 "properties": {
                     "whitelistedGroups": {
@@ -68,6 +69,9 @@
                         "type": "string"
                     },
                     "pushEnabled": {
+                        "type": "boolean"
+                    },
+                    "mobileAppBannerEnabled": {
                         "type": "boolean"
                     }
                 }
@@ -97,7 +101,8 @@
                 "type": "object",
                 "required": [
                     "nextAppointment",
-                    "nextReminderRun"
+                    "nextReminderRun",
+                    "pushDeviceCount"
                 ],
                 "properties": {
                     "nextAppointment": {
@@ -119,6 +124,10 @@
                     "nextReminderRun": {
                         "type": "string",
                         "nullable": true
+                    },
+                    "pushDeviceCount": {
+                        "type": "integer",
+                        "format": "int64"
                     }
                 }
             },
@@ -859,11 +868,19 @@
             "UserConfig": {
                 "type": "object",
                 "required": [
-                    "displayOrder"
+                    "displayOrder",
+                    "mobileAppBannerEnabled",
+                    "hasPushDevice"
                 ],
                 "properties": {
                     "displayOrder": {
                         "type": "string"
+                    },
+                    "mobileAppBannerEnabled": {
+                        "type": "boolean"
+                    },
+                    "hasPushDevice": {
+                        "type": "boolean"
                     }
                 }
             },
@@ -4188,6 +4205,12 @@
                                         "nullable": true,
                                         "default": null,
                                         "description": "Whether push notifications are enabled"
+                                    },
+                                    "mobileAppBannerEnabled": {
+                                        "type": "boolean",
+                                        "nullable": true,
+                                        "default": null,
+                                        "description": "Whether the mobile app promotion banner is enabled"
                                     }
                                 }
                             }

--- a/openapi.json
+++ b/openapi.json
@@ -702,11 +702,19 @@
             "UserConfig": {
                 "type": "object",
                 "required": [
-                    "displayOrder"
+                    "displayOrder",
+                    "mobileAppBannerEnabled",
+                    "hasPushDevice"
                 ],
                 "properties": {
                     "displayOrder": {
                         "type": "string"
+                    },
+                    "mobileAppBannerEnabled": {
+                        "type": "boolean"
+                    },
+                    "hasPushDevice": {
+                        "type": "boolean"
                     }
                 }
             },

--- a/src/App.vue
+++ b/src/App.vue
@@ -152,6 +152,9 @@
 
 		<!-- Main content area -->
 		<NcAppContent>
+			<MobileAppBanner
+				v-if="currentView !== 'checkin' && config.mobileAppBannerEnabled && !config.hasPushDevice" />
+
 			<!-- Check-in View -->
 			<CheckinView
 				v-if="currentView === 'checkin'"
@@ -227,6 +230,7 @@ import AppointmentDetail from './views/AppointmentDetail.vue'
 import AppointmentForm from './views/AppointmentForm.vue'
 import IcalFeedModal from './components/IcalFeedModal.vue'
 import ExportDialog from './components/ExportDialog.vue'
+import MobileAppBanner from './components/common/MobileAppBanner.vue'
 import {
 	NcContent,
 	NcAppNavigation,

--- a/src/components/appointment/AppointmentCard.vue
+++ b/src/components/appointment/AppointmentCard.vue
@@ -300,6 +300,7 @@ import {
 } from '@nextcloud/vue'
 import ResponseSummary from './ResponseSummary.vue'
 import { renderMarkdown, sanitizeHtml } from '../../utils/markdown.js'
+import { copyToClipboard } from '../../utils/clipboard.js'
 import { generateUrl } from '@nextcloud/router'
 import { showSuccess, showError } from '@nextcloud/dialogs'
 import axios from '@nextcloud/axios'
@@ -432,17 +433,13 @@ watch(
 	{ immediate: true, deep: true },
 )
 
-const copyShareLink = async () => {
+const copyShareLink = () => {
 	const appointmentUrl
         = window.location.origin
         + generateUrl(`/apps/attendance/appointment/${props.appointment.id}`)
-
-	try {
-		await navigator.clipboard.writeText(appointmentUrl)
-		showSuccess(t('attendance', 'Link copied to clipboard'))
-	} catch (error) {
-		console.error('Failed to copy link:', error)
-	}
+	return copyToClipboard(appointmentUrl, {
+		successMessage: t('attendance', 'Link copied to clipboard'),
+	})
 }
 
 const handleStartCheckin = () => {

--- a/src/components/common/MobileAppBanner.vue
+++ b/src/components/common/MobileAppBanner.vue
@@ -1,0 +1,123 @@
+<template>
+	<div v-if="visible" class="mobile-app-banner" data-test="mobile-app-banner">
+		<div class="mobile-app-banner__content">
+			<CellphoneIcon class="mobile-app-banner__icon" :size="28" />
+			<div class="mobile-app-banner__text">
+				<strong>{{ t('attendance', 'Attendance is now on your phone') }}</strong>
+				<span>{{ t('attendance', 'Get the mobile app for faster access and push notifications.') }}</span>
+			</div>
+		</div>
+		<div class="mobile-app-banner__actions">
+			<NcButton variant="secondary"
+				:href="APPLE_STORE_URL"
+				target="_blank"
+				rel="noopener"
+				data-test="mobile-app-banner-apple">
+				<template #icon>
+					<AppleIcon :size="20" />
+				</template>
+				{{ t('attendance', 'App Store') }}
+			</NcButton>
+			<NcButton variant="secondary"
+				:href="GOOGLE_STORE_URL"
+				target="_blank"
+				rel="noopener"
+				data-test="mobile-app-banner-google">
+				<template #icon>
+					<GoogleIcon :size="20" />
+				</template>
+				{{ t('attendance', 'Google Play') }}
+			</NcButton>
+			<NcButton variant="tertiary"
+				:aria-label="t('attendance', 'Dismiss')"
+				data-test="mobile-app-banner-dismiss"
+				@click="dismiss">
+				<template #icon>
+					<CloseIcon :size="20" />
+				</template>
+			</NcButton>
+		</div>
+	</div>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue'
+import { NcButton } from '@nextcloud/vue'
+import AppleIcon from 'vue-material-design-icons/Apple.vue'
+import GoogleIcon from 'vue-material-design-icons/Google.vue'
+import CloseIcon from 'vue-material-design-icons/Close.vue'
+import CellphoneIcon from 'vue-material-design-icons/Cellphone.vue'
+import { APPLE_STORE_URL, GOOGLE_STORE_URL } from '../../utils/mobileApp.js'
+
+const DISMISS_KEY = 'attendance:mobile-app-banner-dismissed'
+
+const visible = ref(false)
+
+const dismiss = () => {
+	visible.value = false
+	try {
+		window.localStorage.setItem(DISMISS_KEY, '1')
+	} catch (e) {
+		// localStorage may be unavailable (private mode, quota); dismissal is transient in that case
+	}
+}
+
+onMounted(() => {
+	try {
+		visible.value = window.localStorage.getItem(DISMISS_KEY) !== '1'
+	} catch (e) {
+		visible.value = true
+	}
+})
+</script>
+
+<style scoped>
+.mobile-app-banner {
+	display: flex;
+	align-items: center;
+	gap: 16px;
+	padding: 10px 16px;
+	margin: 12px auto 0;
+	max-width: 800px;
+	background-color: var(--color-primary-element-light, var(--color-background-hover));
+	border: 1px solid var(--color-border);
+	border-radius: var(--border-radius-large);
+	flex-wrap: wrap;
+}
+
+.mobile-app-banner__content {
+	display: flex;
+	align-items: center;
+	gap: 12px;
+	flex: 1 1 240px;
+	min-width: 0;
+}
+
+.mobile-app-banner__icon {
+	flex-shrink: 0;
+	color: var(--color-primary-element);
+}
+
+.mobile-app-banner__text {
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+	min-width: 0;
+}
+
+.mobile-app-banner__text strong {
+	font-weight: 600;
+}
+
+.mobile-app-banner__text span {
+	color: var(--color-text-maxcontrast);
+	font-size: 13px;
+}
+
+.mobile-app-banner__actions {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	flex-wrap: wrap;
+}
+</style>

--- a/src/composables/useIcalFeed.js
+++ b/src/composables/useIcalFeed.js
@@ -3,6 +3,7 @@ import axios from '@nextcloud/axios'
 import { generateUrl } from '@nextcloud/router'
 import { showSuccess, showError } from '@nextcloud/dialogs'
 import { translate as t } from '@nextcloud/l10n'
+import { copyToClipboard as copyTextToClipboard } from '../utils/clipboard.js'
 
 /**
  * Composable for managing iCal feed functionality
@@ -64,21 +65,14 @@ export function useIcalFeed() {
 		}
 	}
 
-	/**
-	 * Copy the feed URL to clipboard
-	 */
 	const copyToClipboard = async () => {
 		if (!feedUrl.value) {
 			return
 		}
-
-		try {
-			await navigator.clipboard.writeText(feedUrl.value)
-			showSuccess(t('attendance', 'URL copied to clipboard'))
-		} catch (err) {
-			console.error('Failed to copy to clipboard:', err)
-			showError(t('attendance', 'Failed to copy URL'))
-		}
+		await copyTextToClipboard(feedUrl.value, {
+			successMessage: t('attendance', 'URL copied to clipboard'),
+			errorMessage: t('attendance', 'Failed to copy URL'),
+		})
 	}
 
 	return {

--- a/src/composables/usePermissions.js
+++ b/src/composables/usePermissions.js
@@ -19,6 +19,8 @@ const state = reactive({
 	},
 	config: {
 		displayOrder: 'name_first',
+		mobileAppBannerEnabled: true,
+		hasPushDevice: false,
 	},
 	loading: false,
 	loaded: false,
@@ -67,6 +69,8 @@ export function usePermissions() {
 			state.capabilities.notificationsAppEnabled = capabilitiesRes.data.notificationsAppEnabled !== false
 
 			state.config.displayOrder = configRes.data.displayOrder || 'name_first'
+			state.config.mobileAppBannerEnabled = configRes.data.mobileAppBannerEnabled !== false
+			state.config.hasPushDevice = configRes.data.hasPushDevice === true
 
 			state.loaded = true
 		} catch (error) {
@@ -84,6 +88,8 @@ export function usePermissions() {
 			state.capabilities.calendarSyncAvailable = false
 			state.capabilities.notificationsAppEnabled = false
 			state.config.displayOrder = 'name_first'
+			state.config.mobileAppBannerEnabled = true
+			state.config.hasPushDevice = false
 		} finally {
 			state.loading = false
 		}

--- a/src/utils/clipboard.js
+++ b/src/utils/clipboard.js
@@ -1,0 +1,26 @@
+import { showSuccess, showError } from '@nextcloud/dialogs'
+
+/**
+ * Copy text to the clipboard and show a toast.
+ *
+ * @param {string} text - The text to copy.
+ * @param {object} [options]
+ * @param {string} [options.successMessage] - Toast shown on success. Omit to skip.
+ * @param {string} [options.errorMessage] - Toast shown on failure. Omit to skip.
+ * @return {Promise<boolean>} Whether the copy succeeded.
+ */
+export async function copyToClipboard(text, { successMessage, errorMessage } = {}) {
+	try {
+		await navigator.clipboard.writeText(text)
+		if (successMessage) {
+			showSuccess(successMessage)
+		}
+		return true
+	} catch (err) {
+		console.error('Failed to copy to clipboard:', err)
+		if (errorMessage) {
+			showError(errorMessage)
+		}
+		return false
+	}
+}

--- a/src/utils/mobileApp.js
+++ b/src/utils/mobileApp.js
@@ -1,0 +1,2 @@
+export const APPLE_STORE_URL = 'https://apps.apple.com/app/id6759988681'
+export const GOOGLE_STORE_URL = 'https://play.google.com/store/apps/details?id=de.krautnerds.attendance'

--- a/src/views/AdminSettings.vue
+++ b/src/views/AdminSettings.vue
@@ -254,40 +254,91 @@
 				</NcSettingsSection>
 			</div>
 
-			<NcSettingsSection :name="t('attendance', 'Push notifications')"
-				:description="t('attendance', 'Enable push notifications for the mobile app.')">
-				<NcCheckboxRadioSwitch
-					v-model="pushEnabled"
-					type="switch"
-					:disabled="loading"
-					data-test="switch-push-enabled">
-					{{ t('attendance', 'Enable push notifications') }}
-				</NcCheckboxRadioSwitch>
-
-				<template v-if="pushEnabled">
-					<div class="push-device-status">
-						<NcNoteCard v-if="pushDeviceCount === 0" type="warning">
-							<p>{{ t('attendance', 'No push device registered for your account. Connect the Attendance mobile app to receive push notifications.') }}</p>
-						</NcNoteCard>
-						<template v-else>
-							<p class="push-device-info">
-								<CellphoneCheck :size="20" />
-								{{ n('attendance', '{count} device registered for push notifications', '{count} devices registered for push notifications', pushDeviceCount, { count: pushDeviceCount }) }}
-							</p>
-							<NcButton
-								variant="tertiary"
-								:disabled="sendingTestReminder"
-								class="test-reminder-button"
-								data-test="button-test-push"
-								@click="sendTestReminder">
+			<NcSettingsSection :name="t('attendance', 'Mobile apps')"
+				:description="t('attendance', 'Share these links with your colleagues to install the Attendance mobile app.')">
+				<div class="mobile-app-links">
+					<div v-for="store in mobileAppStores" :key="store.id" class="mobile-app-link">
+						<label class="mobile-app-link__label">
+							<component :is="store.icon" :size="20" />
+							{{ store.label }}
+						</label>
+						<div class="mobile-app-link__row">
+							<code class="mobile-app-link__url" :data-test="`input-${store.id}-store-url`">{{ store.url }}</code>
+							<NcButton variant="secondary"
+								:aria-label="t('attendance', 'Copy URL')"
+								:data-test="`button-copy-${store.id}-url`"
+								@click="copyStoreUrl(store.url)">
 								<template #icon>
-									<BellRingIcon :size="20" />
+									<ContentCopy :size="20" />
 								</template>
-								{{ t('attendance', 'Send test notification') }}
+								{{ t('attendance', 'Copy') }}
 							</NcButton>
-						</template>
+							<NcButton variant="tertiary"
+								:href="store.url"
+								target="_blank"
+								rel="noopener"
+								:data-test="`button-open-${store.id}-url`">
+								<template #icon>
+									<OpenInNew :size="20" />
+								</template>
+								{{ t('attendance', 'Open') }}
+							</NcButton>
+						</div>
 					</div>
-				</template>
+				</div>
+
+				<div class="subsection">
+					<h4>{{ t('attendance', 'Mobile App promotion banner') }}</h4>
+					<p class="subsection-hint">
+						{{ t('attendance', 'Show a banner at the top of the web app advertising the mobile apps. Users can dismiss the banner, and users who already have a push device connected will not see it.') }}
+					</p>
+					<NcCheckboxRadioSwitch
+						v-model="mobileAppBannerEnabled"
+						type="switch"
+						:disabled="loading"
+						data-test="switch-mobile-app-banner-enabled">
+						{{ t('attendance', 'Show promotion banner') }}
+					</NcCheckboxRadioSwitch>
+				</div>
+
+				<div class="subsection">
+					<h4>{{ t('attendance', 'Push notifications') }}</h4>
+					<p class="subsection-hint">
+						{{ t('attendance', 'Enable push notifications for the mobile app.') }}
+					</p>
+					<NcCheckboxRadioSwitch
+						v-model="pushEnabled"
+						type="switch"
+						:disabled="loading"
+						data-test="switch-push-enabled">
+						{{ t('attendance', 'Enable push notifications') }}
+					</NcCheckboxRadioSwitch>
+
+					<template v-if="pushEnabled">
+						<div class="push-device-status">
+							<NcNoteCard v-if="pushDeviceCount === 0" type="warning">
+								<p>{{ t('attendance', 'No push device registered for your account. Connect the Attendance mobile app to receive push notifications.') }}</p>
+							</NcNoteCard>
+							<template v-else>
+								<p class="push-device-info">
+									<CellphoneCheck :size="20" />
+									{{ n('attendance', '{count} device registered for push notifications', '{count} devices registered for push notifications', pushDeviceCount, { count: pushDeviceCount }) }}
+								</p>
+								<NcButton
+									variant="tertiary"
+									:disabled="sendingTestReminder"
+									class="test-reminder-button"
+									data-test="button-test-push"
+									@click="sendTestReminder">
+									<template #icon>
+										<BellRingIcon :size="20" />
+									</template>
+									{{ t('attendance', 'Send test notification') }}
+								</NcButton>
+							</template>
+						</div>
+					</template>
+				</div>
 			</NcSettingsSection>
 
 			<NcSettingsSection :name="t('attendance', 'Display options')"
@@ -349,8 +400,19 @@ import {
 import AccountStar from 'vue-material-design-icons/AccountStar.vue'
 import BellRingIcon from 'vue-material-design-icons/BellRing.vue'
 import CellphoneCheck from 'vue-material-design-icons/CellphoneCheck.vue'
+import AppleIcon from 'vue-material-design-icons/Apple.vue'
+import GoogleIcon from 'vue-material-design-icons/Google.vue'
+import ContentCopy from 'vue-material-design-icons/ContentCopy.vue'
+import OpenInNew from 'vue-material-design-icons/OpenInNew.vue'
 import GroupSelect from '../components/common/GroupSelect.vue'
 import { formatDate, formatDateTimeMedium } from '../utils/datetime.js'
+import { APPLE_STORE_URL, GOOGLE_STORE_URL } from '../utils/mobileApp.js'
+import { copyToClipboard } from '../utils/clipboard.js'
+
+const mobileAppStores = [
+	{ id: 'apple', icon: AppleIcon, url: APPLE_STORE_URL, label: t('attendance', 'App Store (iOS)') },
+	{ id: 'google', icon: GoogleIcon, url: GOOGLE_STORE_URL, label: t('attendance', 'Google Play (Android)') },
+]
 
 // State
 const availableGroups = ref([])
@@ -373,6 +435,7 @@ const nextReminderRun = ref(null)
 const calendarSyncEnabled = ref(false)
 const calendarSyncAvailable = ref(false)
 const pushEnabled = ref(true)
+const mobileAppBannerEnabled = ref(true)
 const displayOrder = ref('name_first')
 const pushDeviceCount = ref(0)
 const loading = ref(false)
@@ -491,6 +554,9 @@ const loadSettings = async () => {
 		// Load push notifications
 		pushEnabled.value = config.pushEnabled !== false
 		pushDeviceCount.value = status.pushDeviceCount || 0
+
+		// Load mobile app banner setting
+		mobileAppBannerEnabled.value = config.mobileAppBannerEnabled !== false
 	} catch (error) {
 		console.error('Error loading settings:', error)
 		showError(window.t('attendance', 'Failed to load settings'))
@@ -554,6 +620,7 @@ const saveSettings = async () => {
 				},
 				displayOrder: displayOrder.value,
 				pushEnabled: pushEnabled.value,
+				mobileAppBannerEnabled: mobileAppBannerEnabled.value,
 			},
 		)
 
@@ -565,6 +632,11 @@ const saveSettings = async () => {
 		loading.value = false
 	}
 }
+
+const copyStoreUrl = (url) => copyToClipboard(url, {
+	successMessage: window.t('attendance', 'Link copied'),
+	errorMessage: window.t('attendance', 'Failed to copy link'),
+})
 
 const sendTestReminder = async () => {
 	sendingTestReminder.value = true
@@ -707,5 +779,38 @@ onMounted(async () => {
 	gap: 8px;
 	color: var(--color-success);
 	font-weight: 500;
+}
+
+.mobile-app-links {
+	display: flex;
+	flex-direction: column;
+	gap: 16px;
+}
+
+.mobile-app-link__label {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	margin-bottom: 6px;
+	font-weight: 600;
+}
+
+.mobile-app-link__row {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	flex-wrap: wrap;
+}
+
+.mobile-app-link__url {
+	flex: 1 1 300px;
+	padding: 8px 12px;
+	background-color: var(--color-background-dark);
+	border: 1px solid var(--color-border);
+	border-radius: var(--border-radius);
+	font-family: monospace;
+	font-size: 12px;
+	word-break: break-all;
+	user-select: all;
 }
 </style>


### PR DESCRIPTION
## Summary
- Adds a dismissible banner at the top of the web app advertising the iOS and Android companion apps. Users can dismiss it (stored per-browser in `localStorage`); it is also hidden when the admin disables it or the user already has a push device registered.
- New "Mobile apps" admin section with copyable App Store and Google Play links; the existing "Push notifications" settings are now a subsection of it, alongside a new toggle to enable/disable the promotion banner globally.
- Per-user `/api/user/config` now returns `mobileAppBannerEnabled` + `hasPushDevice`. Push-device lookup is extracted to `NotificationService` (shared with the admin settings query) and short-circuits when the banner is globally disabled, so the extra DB query is cheap on the hot path and skipped entirely when unused.
- Extracted `src/utils/clipboard.js`; the three existing copy-to-clipboard call sites (iCal feed, appointment share, the new store-URL buttons) now share it.
- Pre-filled `de` and `de_DE` translations for the new strings.

## Default behaviour
- `mobile_app_banner_enabled` defaults to `yes`.
- `push_enabled` already defaults to `yes`, so existing installs that never saved admin settings and all new installs have push enabled by default.

## Test plan
- [ ] Open the attendance app as a regular user: banner appears above the main content, below the header, capped to the appointment list width.
- [ ] Click the × on the banner: banner disappears and stays gone after reload.
- [ ] Admin settings → "Mobile apps": copy/open both store links; toggle "Show promotion banner" off; verify banner is hidden for all users after reload.
- [ ] Register a push device via the mobile app (or insert a row into `oc_notifications_pushhash` for your user): banner disappears without needing dismissal.
- [ ] "Push notifications" subsection still toggles push + shows the device count and test-notification button.
- [ ] Verify the banner is hidden inside the `/checkin/:id` kiosk view.
- [ ] Run `composer openapi` and confirm no further diff (spec is committed).