### PR TITLE
feat(l10n): register translations for mobile licenses page

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -336,6 +336,10 @@ t('attendance', 'Terms of Service')
 t('attendance', 'Privacy Policy')
 t('attendance', 'By connecting, you agree to our {terms} and acknowledge our {privacy}.')
 
+t('attendance', 'About')
+t('attendance', 'Open source licenses')
+t('attendance', 'Version {version} ({build})')
+
 const currentView = ref(null) // 'current', 'past', 'unanswered', 'appointment', 'checkin', 'create', 'edit', 'copy', or null
 const checkinAppointmentId = ref(null)
 const appointmentDetailId = ref(null)


### PR DESCRIPTION
## Summary
- Register three new strings in `src/App.vue` so the translator export tool picks them up: `About`, `Open source licenses`, `Version {version} ({build})`.
- Consumed by the companion Flutter app, which now shows an **About → Open source licenses** tile in Settings (see [attendance-flutter#9](https://github.com/luflow/attendance-flutter/pull/9)).

## Test plan
- [ ] Verify these strings appear in the extracted translation template on the next l10n sync
- [ ] Confirm no runtime impact on the web app (strings are registration-only, not rendered)

🤖 Generated with [Claude Code](https://claude.com/claude-code)