### PR TITLE
fix: add post-migration repair step to heal missing appointment columns

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -106,4 +106,9 @@ Perfekt für Organisationen, Teams und Gemeinschaften, die die Anwesenheit bei M
 		<personal>OCA\Attendance\Settings\PersonalSettings</personal>
 		<personal-section>OCA\Attendance\Settings\PersonalSection</personal-section>
 	</settings>
+	<repair-steps>
+		<post-migration>
+			<step>OCA\Attendance\Repair\EnsureAppointmentSchema</step>
+		</post-migration>
+	</repair-steps>
 </info>

--- a/composer.json
+++ b/composer.json
@@ -39,6 +39,7 @@
 		"php": "^8.1"
 	},
 	"require-dev": {
+		"doctrine/dbal": "^4.0",
 		"nextcloud/ocp": "dev-stable33",
 		"nextcloud/openapi-extractor": "^1.8",
 		"roave/security-advisories": "dev-latest"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "dc054087cdb519ba5314524e3eab2e08",
+    "content-hash": "fafb664b67458c39d856112439dbf835",
     "packages": [
         {
             "name": "bamarni/composer-bin-plugin",
@@ -137,6 +137,160 @@
                 }
             ],
             "time": "2025-05-11T13:23:54+00:00"
+        },
+        {
+            "name": "doctrine/dbal",
+            "version": "4.2.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/dbal.git",
+                "reference": "acb68b388b2577bb211bb26dc22d20a8ad93d97d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/dbal/zipball/acb68b388b2577bb211bb26dc22d20a8ad93d97d",
+                "reference": "acb68b388b2577bb211bb26dc22d20a8ad93d97d",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/deprecations": "^0.5.3|^1",
+                "php": "^8.1",
+                "psr/cache": "^1|^2|^3",
+                "psr/log": "^1|^2|^3"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "13.0.0",
+                "fig/log-test": "^1",
+                "jetbrains/phpstorm-stubs": "2023.2",
+                "phpstan/phpstan": "2.1.17",
+                "phpstan/phpstan-phpunit": "2.0.6",
+                "phpstan/phpstan-strict-rules": "^2",
+                "phpunit/phpunit": "10.5.46",
+                "slevomat/coding-standard": "8.16.2",
+                "squizlabs/php_codesniffer": "3.13.1",
+                "symfony/cache": "^6.3.8|^7.0",
+                "symfony/console": "^5.4|^6.3|^7.0"
+            },
+            "suggest": {
+                "symfony/console": "For helpful console commands such as SQL execution and import of files."
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\DBAL\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                }
+            ],
+            "description": "Powerful PHP database abstraction layer (DBAL) with many features for database schema introspection and management.",
+            "homepage": "https://www.doctrine-project.org/projects/dbal.html",
+            "keywords": [
+                "abstraction",
+                "database",
+                "db2",
+                "dbal",
+                "mariadb",
+                "mssql",
+                "mysql",
+                "oci8",
+                "oracle",
+                "pdo",
+                "pgsql",
+                "postgresql",
+                "queryobject",
+                "sasql",
+                "sql",
+                "sqlite",
+                "sqlserver",
+                "sqlsrv"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/dbal/issues",
+                "source": "https://github.com/doctrine/dbal/tree/4.2.5"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Fdbal",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-06-26T22:51:46+00:00"
+        },
+        {
+            "name": "doctrine/deprecations",
+            "version": "1.1.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/deprecations.git",
+                "reference": "d4fe3e6fd9bb9e72557a19674f44d8ac7db4c6ca"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/d4fe3e6fd9bb9e72557a19674f44d8ac7db4c6ca",
+                "reference": "d4fe3e6fd9bb9e72557a19674f44d8ac7db4c6ca",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<=7.5 || >=14"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^9 || ^12 || ^14",
+                "phpstan/phpstan": "1.4.10 || 2.1.30",
+                "phpstan/phpstan-phpunit": "^1.0 || ^2",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.6 || ^10.5 || ^11.5 || ^12.4 || ^13.0",
+                "psr/log": "^1 || ^2 || ^3"
+            },
+            "suggest": {
+                "psr/log": "Allows logging deprecations via PSR-3 logger implementation"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Deprecations\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A small layer on top of trigger_error(E_USER_DEPRECATED) or PSR-3 logging with options to disable all deprecations or selectively for packages.",
+            "homepage": "https://www.doctrine-project.org/",
+            "support": {
+                "issues": "https://github.com/doctrine/deprecations/issues",
+                "source": "https://github.com/doctrine/deprecations/tree/1.1.6"
+            },
+            "time": "2026-02-07T07:09:04+00:00"
         },
         {
             "name": "nextcloud/ocp",
@@ -337,6 +491,55 @@
                 "source": "https://github.com/phpstan/phpdoc-parser/tree/2.3.2"
             },
             "time": "2026-01-25T14:56:51+00:00"
+        },
+        {
+            "name": "psr/cache",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/cache.git",
+                "reference": "aa5030cfa5405eccfdcb1083ce040c2cb8d253bf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/cache/zipball/aa5030cfa5405eccfdcb1083ce040c2cb8d253bf",
+                "reference": "aa5030cfa5405eccfdcb1083ce040c2cb8d253bf",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Cache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for caching libraries",
+            "keywords": [
+                "cache",
+                "psr",
+                "psr-6"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/cache/tree/3.0.0"
+            },
+            "time": "2021-02-03T23:26:27+00:00"
         },
         {
             "name": "psr/clock",
@@ -1606,5 +1809,5 @@
     "platform-overrides": {
         "php": "8.1"
     },
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/lib/Repair/EnsureAppointmentSchema.php
+++ b/lib/Repair/EnsureAppointmentSchema.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 namespace OCA\Attendance\Repair;
 
+use OCP\DB\Types;
 use OCP\IConfig;
 use OCP\IDBConnection;
 use OCP\Migration\IOutput;
 use OCP\Migration\IRepairStep;
 use Psr\Log\LoggerInterface;
+use Throwable;
 
 /**
  * Defensive repair step that re-applies the additive schema changes from
@@ -33,6 +35,16 @@ class EnsureAppointmentSchema implements IRepairStep {
 	}
 
 	public function run(IOutput $output): void {
+		if (!$this->connection->tableExists('att_appointments')) {
+			return;
+		}
+
+		// Cheap probe: if both columns are queryable, the bug didn't bite this
+		// install and we skip the expensive full-schema introspection below.
+		if ($this->columnsAreQueryable()) {
+			return;
+		}
+
 		$prefix = $this->config->getSystemValueString('dbtableprefix', 'oc_');
 		$tableName = $prefix . 'att_appointments';
 
@@ -45,12 +57,12 @@ class EnsureAppointmentSchema implements IRepairStep {
 		$applied = [];
 
 		if (!$table->hasColumn('closed_at')) {
-			$table->addColumn('closed_at', 'datetime', ['notnull' => false]);
+			$table->addColumn('closed_at', Types::DATETIME, ['notnull' => false]);
 			$applied[] = 'column closed_at';
 		}
 
 		if (!$table->hasColumn('response_deadline')) {
-			$table->addColumn('response_deadline', 'datetime', ['notnull' => false]);
+			$table->addColumn('response_deadline', Types::DATETIME, ['notnull' => false]);
 			$applied[] = 'column response_deadline';
 		}
 
@@ -80,5 +92,18 @@ class EnsureAppointmentSchema implements IRepairStep {
 			'app' => 'attendance',
 			'issue' => 'https://github.com/luflow/attendance/issues/68',
 		]);
+	}
+
+	private function columnsAreQueryable(): bool {
+		try {
+			$qb = $this->connection->getQueryBuilder();
+			$qb->select('closed_at', 'response_deadline')
+				->from('att_appointments')
+				->setMaxResults(0);
+			$qb->executeQuery()->closeCursor();
+			return true;
+		} catch (Throwable) {
+			return false;
+		}
 	}
 }

--- a/lib/Repair/EnsureAppointmentSchema.php
+++ b/lib/Repair/EnsureAppointmentSchema.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\Attendance\Repair;
+
+use OCP\IConfig;
+use OCP\IDBConnection;
+use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Defensive repair step that re-applies the additive schema changes from
+ * Version000012Date20260425120000 (closed_at, response_deadline + indexes)
+ * if they are missing. Works around the Nextcloud bug reported in
+ * https://github.com/luflow/attendance/issues/68 where the migration is
+ * recorded in oc_migrations without its DDL actually being executed.
+ *
+ * Idempotent: runs on every post-migration cycle and only touches the
+ * database when columns or indexes are missing.
+ */
+class EnsureAppointmentSchema implements IRepairStep {
+	public function __construct(
+		private IDBConnection $connection,
+		private IConfig $config,
+		private LoggerInterface $logger,
+	) {
+	}
+
+	public function getName(): string {
+		return 'Ensure Attendance appointment schema integrity';
+	}
+
+	public function run(IOutput $output): void {
+		$prefix = $this->config->getSystemValueString('dbtableprefix', 'oc_');
+		$tableName = $prefix . 'att_appointments';
+
+		$schema = $this->connection->createSchema();
+		if (!$schema->hasTable($tableName)) {
+			return;
+		}
+
+		$table = $schema->getTable($tableName);
+		$applied = [];
+
+		if (!$table->hasColumn('closed_at')) {
+			$table->addColumn('closed_at', 'datetime', ['notnull' => false]);
+			$applied[] = 'column closed_at';
+		}
+
+		if (!$table->hasColumn('response_deadline')) {
+			$table->addColumn('response_deadline', 'datetime', ['notnull' => false]);
+			$applied[] = 'column response_deadline';
+		}
+
+		if ($table->hasColumn('closed_at') && !$table->hasIndex('att_appt_closed')) {
+			$table->addIndex(['closed_at'], 'att_appt_closed');
+			$applied[] = 'index att_appt_closed';
+		}
+
+		if ($table->hasColumn('response_deadline') && !$table->hasIndex('att_appt_deadline')) {
+			$table->addIndex(['response_deadline'], 'att_appt_deadline');
+			$applied[] = 'index att_appt_deadline';
+		}
+
+		if ($applied === []) {
+			return;
+		}
+
+		$this->connection->migrateToSchema($schema);
+
+		$message = sprintf(
+			'Repaired Attendance schema on %s: applied missing %s.',
+			$tableName,
+			implode(', ', $applied),
+		);
+		$output->info($message);
+		$this->logger->warning($message, [
+			'app' => 'attendance',
+			'issue' => 'https://github.com/luflow/attendance/issues/68',
+		]);
+	}
+}

--- a/tests/unit/Repair/EnsureAppointmentSchemaTest.php
+++ b/tests/unit/Repair/EnsureAppointmentSchemaTest.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\Attendance\Tests\Unit\Repair;
+
+use Doctrine\DBAL\Schema\Schema;
+use OCA\Attendance\Repair\EnsureAppointmentSchema;
+use OCP\IConfig;
+use OCP\IDBConnection;
+use OCP\Migration\IOutput;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+class EnsureAppointmentSchemaTest extends TestCase {
+	private IDBConnection|MockObject $connection;
+	private IConfig|MockObject $config;
+	private LoggerInterface|MockObject $logger;
+	private IOutput|MockObject $output;
+	private EnsureAppointmentSchema $repair;
+
+	protected function setUp(): void {
+		$this->connection = $this->createMock(IDBConnection::class);
+		$this->config = $this->createMock(IConfig::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
+		$this->output = $this->createMock(IOutput::class);
+
+		$this->config->method('getSystemValueString')
+			->with('dbtableprefix', 'oc_')
+			->willReturn('oc_');
+
+		$this->repair = new EnsureAppointmentSchema(
+			$this->connection,
+			$this->config,
+			$this->logger,
+		);
+	}
+
+	private function makeSchemaWithAppointments(bool $closedAt, bool $deadline, bool $closedIdx, bool $deadlineIdx): Schema {
+		$schema = new Schema();
+		$table = $schema->createTable('oc_att_appointments');
+		$table->addColumn('id', 'integer', ['autoincrement' => true, 'notnull' => true]);
+		$table->setPrimaryKey(['id']);
+		if ($closedAt) {
+			$table->addColumn('closed_at', 'datetime', ['notnull' => false]);
+		}
+		if ($deadline) {
+			$table->addColumn('response_deadline', 'datetime', ['notnull' => false]);
+		}
+		if ($closedIdx && $closedAt) {
+			$table->addIndex(['closed_at'], 'att_appt_closed');
+		}
+		if ($deadlineIdx && $deadline) {
+			$table->addIndex(['response_deadline'], 'att_appt_deadline');
+		}
+		return $schema;
+	}
+
+	public function testNoOpWhenTableMissing(): void {
+		$this->connection->method('createSchema')->willReturn(new Schema());
+		$this->connection->expects($this->never())->method('migrateToSchema');
+		$this->logger->expects($this->never())->method('warning');
+
+		$this->repair->run($this->output);
+	}
+
+	public function testNoOpWhenSchemaAlreadyComplete(): void {
+		$schema = $this->makeSchemaWithAppointments(true, true, true, true);
+		$this->connection->method('createSchema')->willReturn($schema);
+		$this->connection->expects($this->never())->method('migrateToSchema');
+		$this->logger->expects($this->never())->method('warning');
+
+		$this->repair->run($this->output);
+	}
+
+	public function testAddsMissingColumnsAndIndexes(): void {
+		$schema = $this->makeSchemaWithAppointments(false, false, false, false);
+		$this->connection->method('createSchema')->willReturn($schema);
+
+		$this->connection->expects($this->once())
+			->method('migrateToSchema')
+			->with($this->callback(function (Schema $applied): bool {
+				$table = $applied->getTable('oc_att_appointments');
+				return $table->hasColumn('closed_at')
+					&& $table->hasColumn('response_deadline')
+					&& $table->hasIndex('att_appt_closed')
+					&& $table->hasIndex('att_appt_deadline');
+			}));
+
+		$this->logger->expects($this->once())
+			->method('warning')
+			->with(
+				$this->stringContains('column closed_at'),
+				$this->callback(fn ($ctx) => ($ctx['app'] ?? null) === 'attendance'),
+			);
+
+		$this->output->expects($this->once())
+			->method('info')
+			->with($this->stringContains('Repaired Attendance schema'));
+
+		$this->repair->run($this->output);
+	}
+
+	public function testOnlyAddsMissingPieces(): void {
+		// closed_at exists with index, response_deadline column missing.
+		$schema = $this->makeSchemaWithAppointments(true, false, true, false);
+		$this->connection->method('createSchema')->willReturn($schema);
+
+		$this->connection->expects($this->once())
+			->method('migrateToSchema')
+			->with($this->callback(function (Schema $applied): bool {
+				$table = $applied->getTable('oc_att_appointments');
+				return $table->hasColumn('response_deadline')
+					&& $table->hasIndex('att_appt_deadline');
+			}));
+
+		$this->repair->run($this->output);
+	}
+
+	public function testHonoursCustomTablePrefix(): void {
+		$config = $this->createMock(IConfig::class);
+		$config->method('getSystemValueString')
+			->with('dbtableprefix', 'oc_')
+			->willReturn('nc_');
+
+		$repair = new EnsureAppointmentSchema($this->connection, $config, $this->logger);
+
+		$schema = new Schema();
+		$table = $schema->createTable('nc_att_appointments');
+		$table->addColumn('id', 'integer', ['autoincrement' => true, 'notnull' => true]);
+		$table->setPrimaryKey(['id']);
+
+		$this->connection->method('createSchema')->willReturn($schema);
+		$this->connection->expects($this->once())->method('migrateToSchema');
+
+		$repair->run($this->output);
+	}
+
+	public function testGetNameIsHumanReadable(): void {
+		$this->assertNotEmpty($this->repair->getName());
+	}
+}

--- a/tests/unit/Repair/EnsureAppointmentSchemaTest.php
+++ b/tests/unit/Repair/EnsureAppointmentSchemaTest.php
@@ -6,6 +6,8 @@ namespace OCA\Attendance\Tests\Unit\Repair;
 
 use Doctrine\DBAL\Schema\Schema;
 use OCA\Attendance\Repair\EnsureAppointmentSchema;
+use OCP\DB\Exception;
+use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IConfig;
 use OCP\IDBConnection;
 use OCP\Migration\IOutput;
@@ -37,37 +39,63 @@ class EnsureAppointmentSchemaTest extends TestCase {
 		);
 	}
 
-	private function makeSchemaWithAppointments(bool $closedAt, bool $deadline, bool $closedIdx, bool $deadlineIdx): Schema {
+	/**
+	 * @param array{closedAt?: bool, deadline?: bool, closedIdx?: bool, deadlineIdx?: bool} $present
+	 */
+	private function makeAppointmentsSchema(string $prefix = 'oc_', array $present = []): Schema {
+		$flags = $present + [
+			'closedAt' => true,
+			'deadline' => true,
+			'closedIdx' => true,
+			'deadlineIdx' => true,
+		];
+
 		$schema = new Schema();
-		$table = $schema->createTable('oc_att_appointments');
+		$table = $schema->createTable($prefix . 'att_appointments');
 		$table->addColumn('id', 'integer', ['autoincrement' => true, 'notnull' => true]);
 		$table->setPrimaryKey(['id']);
-		if ($closedAt) {
+		if ($flags['closedAt']) {
 			$table->addColumn('closed_at', 'datetime', ['notnull' => false]);
 		}
-		if ($deadline) {
+		if ($flags['deadline']) {
 			$table->addColumn('response_deadline', 'datetime', ['notnull' => false]);
 		}
-		if ($closedIdx && $closedAt) {
+		if ($flags['closedIdx'] && $flags['closedAt']) {
 			$table->addIndex(['closed_at'], 'att_appt_closed');
 		}
-		if ($deadlineIdx && $deadline) {
+		if ($flags['deadlineIdx'] && $flags['deadline']) {
 			$table->addIndex(['response_deadline'], 'att_appt_deadline');
 		}
 		return $schema;
 	}
 
+	private function expectColumnProbe(bool $columnsExist): void {
+		$qb = $this->createMock(IQueryBuilder::class);
+		$qb->method('select')->willReturnSelf();
+		$qb->method('from')->willReturnSelf();
+		$qb->method('setMaxResults')->willReturnSelf();
+		if ($columnsExist) {
+			$result = $this->createMock(\OCP\DB\IResult::class);
+			$qb->method('executeQuery')->willReturn($result);
+		} else {
+			$qb->method('executeQuery')->willThrowException(new Exception('Unknown column closed_at'));
+		}
+		$this->connection->method('getQueryBuilder')->willReturn($qb);
+	}
+
 	public function testNoOpWhenTableMissing(): void {
-		$this->connection->method('createSchema')->willReturn(new Schema());
+		$this->connection->method('tableExists')->with('att_appointments')->willReturn(false);
+		$this->connection->expects($this->never())->method('createSchema');
 		$this->connection->expects($this->never())->method('migrateToSchema');
-		$this->logger->expects($this->never())->method('warning');
 
 		$this->repair->run($this->output);
 	}
 
-	public function testNoOpWhenSchemaAlreadyComplete(): void {
-		$schema = $this->makeSchemaWithAppointments(true, true, true, true);
-		$this->connection->method('createSchema')->willReturn($schema);
+	public function testSkipsSchemaIntrospectionWhenColumnProbeSucceeds(): void {
+		$this->connection->method('tableExists')->willReturn(true);
+		$this->expectColumnProbe(columnsExist: true);
+
+		$this->connection->expects($this->never())->method('createSchema');
 		$this->connection->expects($this->never())->method('migrateToSchema');
 		$this->logger->expects($this->never())->method('warning');
 
@@ -75,7 +103,15 @@ class EnsureAppointmentSchemaTest extends TestCase {
 	}
 
 	public function testAddsMissingColumnsAndIndexes(): void {
-		$schema = $this->makeSchemaWithAppointments(false, false, false, false);
+		$this->connection->method('tableExists')->willReturn(true);
+		$this->expectColumnProbe(columnsExist: false);
+
+		$schema = $this->makeAppointmentsSchema(present: [
+			'closedAt' => false,
+			'deadline' => false,
+			'closedIdx' => false,
+			'deadlineIdx' => false,
+		]);
 		$this->connection->method('createSchema')->willReturn($schema);
 
 		$this->connection->expects($this->once())
@@ -102,9 +138,15 @@ class EnsureAppointmentSchemaTest extends TestCase {
 		$this->repair->run($this->output);
 	}
 
-	public function testOnlyAddsMissingPieces(): void {
-		// closed_at exists with index, response_deadline column missing.
-		$schema = $this->makeSchemaWithAppointments(true, false, true, false);
+	public function testRepairsOnlyMissingDeadlinePieces(): void {
+		$this->connection->method('tableExists')->willReturn(true);
+		$this->expectColumnProbe(columnsExist: false);
+
+		// closed_at + its index are present, but response_deadline is missing entirely.
+		$schema = $this->makeAppointmentsSchema(present: [
+			'deadline' => false,
+			'deadlineIdx' => false,
+		]);
 		$this->connection->method('createSchema')->willReturn($schema);
 
 		$this->connection->expects($this->once())
@@ -126,18 +168,16 @@ class EnsureAppointmentSchemaTest extends TestCase {
 
 		$repair = new EnsureAppointmentSchema($this->connection, $config, $this->logger);
 
-		$schema = new Schema();
-		$table = $schema->createTable('nc_att_appointments');
-		$table->addColumn('id', 'integer', ['autoincrement' => true, 'notnull' => true]);
-		$table->setPrimaryKey(['id']);
-
-		$this->connection->method('createSchema')->willReturn($schema);
+		$this->connection->method('tableExists')->willReturn(true);
+		$this->expectColumnProbe(columnsExist: false);
+		$this->connection->method('createSchema')->willReturn($this->makeAppointmentsSchema('nc_', [
+			'closedAt' => false,
+			'deadline' => false,
+			'closedIdx' => false,
+			'deadlineIdx' => false,
+		]));
 		$this->connection->expects($this->once())->method('migrateToSchema');
 
 		$repair->run($this->output);
-	}
-
-	public function testGetNameIsHumanReadable(): void {
-		$this->assertNotEmpty($this->repair->getName());
 	}
 }


### PR DESCRIPTION
Some Nextcloud installs (#68) record migration 12 in oc_migrations
without applying its DDL, leaving att_appointments without closed_at /
response_deadline and breaking AutoCloseJob.

Re-apply those columns and indexes idempotently from a post-migration
repair step so app enable / occ upgrade self-heals affected installs.