### PR TITLE
feat(#77): cancel appointments — a separate state next to closing

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -43,6 +43,8 @@ return [
 		// Close / re-open inquiry
 		['name' => 'appointment#close', 'url' => '/api/appointments/{id}/close', 'verb' => 'POST'],
 		['name' => 'appointment#reopen', 'url' => '/api/appointments/{id}/reopen', 'verb' => 'POST'],
+		['name' => 'appointment#cancel', 'url' => '/api/appointments/{id}/cancel', 'verb' => 'POST'],
+		['name' => 'appointment#uncancel', 'url' => '/api/appointments/{id}/uncancel', 'verb' => 'POST'],
 
 		// Admin settings
 		['name' => 'admin#getSettings', 'url' => '/api/admin/settings', 'verb' => 'GET'],

--- a/lib/Audit/Verb.php
+++ b/lib/Audit/Verb.php
@@ -21,6 +21,8 @@ final class Verb {
 	public const APPOINTMENT_UPDATED = 'appointment.updated';
 	public const APPOINTMENT_CLOSED = 'appointment.closed';
 	public const APPOINTMENT_REOPENED = 'appointment.reopened';
+	public const APPOINTMENT_CANCELLED = 'appointment.cancelled';
+	public const APPOINTMENT_UNCANCELLED = 'appointment.uncancelled';
 
 	public const ALL_RESPONSE = [
 		self::RESPONSE_SUBMITTED,
@@ -39,6 +41,8 @@ final class Verb {
 		self::APPOINTMENT_UPDATED,
 		self::APPOINTMENT_CLOSED,
 		self::APPOINTMENT_REOPENED,
+		self::APPOINTMENT_CANCELLED,
+		self::APPOINTMENT_UNCANCELLED,
 	];
 
 	public const ALL = [
@@ -52,6 +56,8 @@ final class Verb {
 		self::APPOINTMENT_UPDATED,
 		self::APPOINTMENT_CLOSED,
 		self::APPOINTMENT_REOPENED,
+		self::APPOINTMENT_CANCELLED,
+		self::APPOINTMENT_UNCANCELLED,
 	];
 
 	public const SOURCE_APP = 'app';

--- a/lib/Controller/AppointmentController.php
+++ b/lib/Controller/AppointmentController.php
@@ -433,6 +433,69 @@ class AppointmentController extends Controller {
 	}
 
 	/**
+	 * Cancel an appointment
+	 *
+	 * Marks the appointment as cancelled (the event will not take place). All
+	 * data/notes are kept, but the appointment drops out of the active lists,
+	 * gets no reminders and is not auto-closed. Addressed attendees are notified
+	 * and the calendar feed reflects the cancellation.
+	 *
+	 * @param int $id Appointment ID
+	 * @return DataResponse<Http::STATUS_OK, AttendanceAppointmentData, array{}>|DataResponse<Http::STATUS_UNAUTHORIZED, array{error: string}, array{}>|DataResponse<Http::STATUS_FORBIDDEN, array{error: string}, array{}>|DataResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>
+	 */
+	#[NoAdminRequired]
+	#[NoCSRFRequired]
+	#[OpenAPI]
+	public function cancel(int $id): DataResponse {
+		$user = $this->userSession->getUser();
+		if (!$user) {
+			return new DataResponse(['error' => 'User not authenticated'], 401);
+		}
+
+		try {
+			$appointment = $this->appointmentService->getAppointment($id);
+			if (!$this->permissionService->canManageAppointments($user->getUID())
+				&& $appointment->getCreatedBy() !== $user->getUID()) {
+				return new DataResponse(['error' => 'Insufficient permissions to cancel this appointment'], 403);
+			}
+		} catch (\Exception $e) {
+			return new DataResponse(['error' => 'Appointment not found'], 404);
+		}
+
+		$updated = $this->appointmentService->cancelAppointment($id, $user->getUID());
+		return new DataResponse($updated);
+	}
+
+	/**
+	 * Reactivate a cancelled appointment
+	 *
+	 * @param int $id Appointment ID
+	 * @return DataResponse<Http::STATUS_OK, AttendanceAppointmentData, array{}>|DataResponse<Http::STATUS_UNAUTHORIZED, array{error: string}, array{}>|DataResponse<Http::STATUS_FORBIDDEN, array{error: string}, array{}>|DataResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>
+	 */
+	#[NoAdminRequired]
+	#[NoCSRFRequired]
+	#[OpenAPI]
+	public function uncancel(int $id): DataResponse {
+		$user = $this->userSession->getUser();
+		if (!$user) {
+			return new DataResponse(['error' => 'User not authenticated'], 401);
+		}
+
+		try {
+			$appointment = $this->appointmentService->getAppointment($id);
+			if (!$this->permissionService->canManageAppointments($user->getUID())
+				&& $appointment->getCreatedBy() !== $user->getUID()) {
+				return new DataResponse(['error' => 'Insufficient permissions to reactivate this appointment'], 403);
+			}
+		} catch (\Exception $e) {
+			return new DataResponse(['error' => 'Appointment not found'], 404);
+		}
+
+		$updated = $this->appointmentService->uncancelAppointment($id);
+		return new DataResponse($updated);
+	}
+
+	/**
 	 * Get a single appointment with user response
 	 *
 	 * @param int $id Appointment ID
@@ -707,6 +770,7 @@ class AppointmentController extends Controller {
 			'notificationsAppEnabled' => $this->appManager->isEnabledForUser('notifications'),
 			// Older servers omit this flag → mobile clients hide close-inquiry UI.
 			'closing' => true,
+			'cancelling' => true,
 			'remindMaybe' => true,
 			// Older servers reject response=null. Mobile clients gate the
 			// withdraw-response affordance on this flag.

--- a/lib/Db/Appointment.php
+++ b/lib/Db/Appointment.php
@@ -44,6 +44,8 @@ use OCP\AppFramework\Db\Entity;
  * @method void setSendNotification(bool $sendNotification)
  * @method string|null getClosedAt()
  * @method void setClosedAt(?string $closedAt)
+ * @method string|null getCancelledAt()
+ * @method void setCancelledAt(?string $cancelledAt)
  * @method string|null getResponseDeadline()
  * @method void setResponseDeadline(?string $responseDeadline)
  */
@@ -66,6 +68,7 @@ class Appointment extends Entity implements JsonSerializable {
 	protected $seriesPosition = null;
 	protected $sendNotification = false;
 	protected $closedAt = null;
+	protected $cancelledAt = null;
 	protected $responseDeadline = null;
 
 	public function __construct() {
@@ -87,6 +90,7 @@ class Appointment extends Entity implements JsonSerializable {
 		$this->addType('seriesPosition', 'integer');
 		$this->addType('sendNotification', 'boolean');
 		$this->addType('closedAt', 'string');
+		$this->addType('cancelledAt', 'string');
 		$this->addType('responseDeadline', 'string');
 	}
 
@@ -110,12 +114,17 @@ class Appointment extends Entity implements JsonSerializable {
 			'seriesPosition' => $this->getSeriesPosition(),
 			'sendNotification' => (bool) $this->getSendNotification(),
 			'closedAt' => $this->formatDatetimeToUtc($this->getClosedAt()),
+			'cancelledAt' => $this->formatDatetimeToUtc($this->getCancelledAt()),
 			'responseDeadline' => $this->formatDatetimeToUtc($this->getResponseDeadline()),
 		];
 	}
 
 	public function isClosed(): bool {
 		return $this->getClosedAt() !== null;
+	}
+
+	public function isCancelled(): bool {
+		return $this->getCancelledAt() !== null;
 	}
 
 	/**

--- a/lib/Db/AppointmentMapper.php
+++ b/lib/Db/AppointmentMapper.php
@@ -254,6 +254,7 @@ class AppointmentMapper extends QBMapper {
 				$qb->expr()->andX(
 					$qb->expr()->eq('is_active', $qb->createNamedParameter(1, IQueryBuilder::PARAM_INT)),
 					$qb->expr()->isNull('closed_at'),
+					$qb->expr()->isNull('cancelled_at'),
 					$qb->expr()->orX(
 						$qb->expr()->andX(
 							$qb->expr()->isNotNull('response_deadline'),
@@ -290,6 +291,7 @@ class AppointmentMapper extends QBMapper {
 				$select->expr()->andX(
 					$select->expr()->eq('is_active', $select->createNamedParameter(1, IQueryBuilder::PARAM_INT)),
 					$select->expr()->isNull('closed_at'),
+					$select->expr()->isNull('cancelled_at'),
 					$select->expr()->orX(
 						$select->expr()->andX(
 							$select->expr()->isNotNull('response_deadline'),

--- a/lib/Migration/Version000015Date20260712120000.php
+++ b/lib/Migration/Version000015Date20260712120000.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\Attendance\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * Migration to add a nullable cancelled_at column to att_appointments.
+ * Marks an appointment as cancelled (the event does NOT take place), a separate
+ * state next to closed_at (the event happens, no more responses needed).
+ * Nullable and purely additive so older mobile clients keep working.
+ */
+class Version000015Date20260712120000 extends SimpleMigrationStep {
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		if ($schema->hasTable('att_appointments')) {
+			$table = $schema->getTable('att_appointments');
+
+			if (!$table->hasColumn('cancelled_at')) {
+				$table->addColumn('cancelled_at', 'datetime', [
+					'notnull' => false,
+				]);
+			}
+
+			if (!$table->hasIndex('att_appt_cancelled')) {
+				$table->addIndex(['cancelled_at'], 'att_appt_cancelled');
+			}
+		}
+
+		return $schema;
+	}
+}

--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -125,6 +125,26 @@ class Notifier implements INotifier {
 
 				return $notification;
 
+			case 'appointment_cancelled':
+				$parameters = $notification->getSubjectParameters();
+				$appointmentName = $parameters['name'] ?? 'Unknown';
+				$appointmentDate = $this->formatDateForUser(
+					$parameters['startDatetime'] ?? $parameters['date'] ?? '',
+					$notification->getUser()
+				);
+
+				$notification->setParsedSubject(
+					$l->t('Appointment cancelled: %1$s on %2$s', [$appointmentName, $appointmentDate])
+				);
+				$notification->setParsedMessage(
+					$l->t('This appointment will not take place.')
+				);
+				$notification->setIcon($this->urlGenerator->getAbsoluteURL(
+					$this->urlGenerator->imagePath('attendance', 'app-dark.svg')
+				));
+
+				return $notification;
+
 			case 'response_submitted':
 			case 'response_changed':
 			case 'response_rescinded':

--- a/lib/Repair/EnsureAppointmentSchema.php
+++ b/lib/Repair/EnsureAppointmentSchema.php
@@ -66,9 +66,19 @@ class EnsureAppointmentSchema implements IRepairStep {
 			$applied[] = 'column response_deadline';
 		}
 
+		if (!$table->hasColumn('cancelled_at')) {
+			$table->addColumn('cancelled_at', Types::DATETIME, ['notnull' => false]);
+			$applied[] = 'column cancelled_at';
+		}
+
 		if ($table->hasColumn('closed_at') && !$table->hasIndex('att_appt_closed')) {
 			$table->addIndex(['closed_at'], 'att_appt_closed');
 			$applied[] = 'index att_appt_closed';
+		}
+
+		if ($table->hasColumn('cancelled_at') && !$table->hasIndex('att_appt_cancelled')) {
+			$table->addIndex(['cancelled_at'], 'att_appt_cancelled');
+			$applied[] = 'index att_appt_cancelled';
 		}
 
 		if ($table->hasColumn('response_deadline') && !$table->hasIndex('att_appt_deadline')) {

--- a/lib/ResponseDefinitions.php
+++ b/lib/ResponseDefinitions.php
@@ -24,6 +24,7 @@ namespace OCA\Attendance;
  *   seriesPosition: ?int,
  *   sendNotification: bool,
  *   closedAt: ?string,
+ *   cancelledAt: ?string,
  *   responseDeadline: ?string,
  * }
  * @psalm-type AttendanceResponseData = array{
@@ -90,6 +91,7 @@ namespace OCA\Attendance;
  *   seriesPosition: ?int,
  *   sendNotification: bool,
  *   closedAt: ?string,
+ *   cancelledAt: ?string,
  *   responseDeadline: ?string,
  *   userResponse: AttendanceResponseData|null,
  *   responseSummary: array<string, int>,
@@ -103,6 +105,7 @@ namespace OCA\Attendance;
  *   seriesPosition: ?int,
  *   userResponse: ?array{response: string},
  *   closedAt: ?string,
+ *   cancelledAt: ?string,
  *   inAudience: bool,
  * }
  * @psalm-type AttendanceCheckinData = array{
@@ -139,6 +142,7 @@ namespace OCA\Attendance;
  *   calendarSyncAvailable: bool,
  *   notificationsAppEnabled: bool,
  *   closing: bool,
+ *   cancelling: bool,
  *   remindMaybe: bool,
  *   responseToggle: bool,
  *   guestInvitation: bool,
@@ -219,6 +223,7 @@ namespace OCA\Attendance;
  *   seriesPosition: ?int,
  *   sendNotification: bool,
  *   closedAt: ?string,
+ *   cancelledAt: ?string,
  *   responseDeadline: ?string,
  *   alreadyCheckedIn: bool,
  *   checkinState: ?string,

--- a/lib/Service/AppointmentService.php
+++ b/lib/Service/AppointmentService.php
@@ -265,6 +265,66 @@ class AppointmentService {
 	}
 
 	/**
+	 * Cancel an appointment: mark cancelledAt with the current UTC time. This is
+	 * a separate state next to closedAt — the event does NOT take place, but all
+	 * data/notes are kept. Cancelled appointments drop out of the active lists,
+	 * get no reminders and are not auto-closed. Addressed attendees are notified.
+	 * Idempotent: returns the existing appointment unchanged if already cancelled.
+	 *
+	 * @param int $id The appointment ID
+	 * @param string|null $actorId The user performing the cancellation; excluded
+	 *        from the notification wave (they already know they cancelled).
+	 */
+	public function cancelAppointment(int $id, ?string $actorId = null): Appointment {
+		$appointment = $this->appointmentMapper->find($id);
+		if ($appointment->isCancelled()) {
+			return $appointment;
+		}
+		$appointment->setCancelledAt(gmdate('Y-m-d H:i:s'));
+		$appointment->setUpdatedAt(gmdate('Y-m-d H:i:s'));
+		$updated = $this->appointmentMapper->update($appointment);
+
+		$this->auditEventService->recordAppointmentLifecycle(
+			\OCA\Attendance\Audit\Verb::APPOINTMENT_CANCELLED,
+			$id,
+			\OCA\Attendance\Audit\Verb::SOURCE_APP,
+		);
+
+		// Notify addressed attendees that the appointment will not take place.
+		$affectedUsers = $this->getAffectedUsers($updated);
+		if ($actorId !== null) {
+			$affectedUsers = array_filter($affectedUsers, fn ($userId) => $userId !== $actorId);
+		}
+		$this->notificationService->sendCancellationNotifications($updated, array_values($affectedUsers));
+
+		return $updated;
+	}
+
+	/**
+	 * Reactivate a previously cancelled appointment: clears cancelledAt. The
+	 * appointment returns to whatever state it had before (e.g. still closed if
+	 * it was closed). No notification is sent (mirrors reopen).
+	 * Idempotent: returns the existing appointment unchanged if not cancelled.
+	 */
+	public function uncancelAppointment(int $id): Appointment {
+		$appointment = $this->appointmentMapper->find($id);
+		if (!$appointment->isCancelled()) {
+			return $appointment;
+		}
+		$appointment->setCancelledAt(null);
+		$appointment->setUpdatedAt(gmdate('Y-m-d H:i:s'));
+		$updated = $this->appointmentMapper->update($appointment);
+
+		$this->auditEventService->recordAppointmentLifecycle(
+			\OCA\Attendance\Audit\Verb::APPOINTMENT_UNCANCELLED,
+			$id,
+			\OCA\Attendance\Audit\Verb::SOURCE_APP,
+		);
+
+		return $updated;
+	}
+
+	/**
 	 * Delete an appointment (soft delete).
 	 */
 	public function deleteAppointment(int $id, string $userId): void {
@@ -678,6 +738,7 @@ class AppointmentService {
 					? ['response' => $userResponse->getResponse()]
 					: null,
 				'closedAt' => $this->formatDatetimeToUtc($appointment->getClosedAt()),
+				'cancelledAt' => $this->formatDatetimeToUtc($appointment->getCancelledAt()),
 				'inAudience' => $withAudience
 					&& $this->visibilityService->isUserTargetAttendee($appointment, $userId),
 			];
@@ -726,7 +787,7 @@ class AppointmentService {
 			if ($onlyForMe && !$this->visibilityService->isUserTargetAttendee($appointment, $userId)) {
 				continue;
 			}
-			if ($unansweredOnly && $appointment->isClosed()) {
+			if ($unansweredOnly && ($appointment->isClosed() || $appointment->isCancelled())) {
 				continue;
 			}
 
@@ -762,6 +823,9 @@ class AppointmentService {
 		foreach ($appointments as $appointment) {
 			if ($count >= $limit) {
 				break;
+			}
+			if ($appointment->isCancelled()) {
+				continue;
 			}
 			if (!$this->visibilityService->isUserTargetAttendee($appointment, $userId)) {
 				continue;

--- a/lib/Service/IcalService.php
+++ b/lib/Service/IcalService.php
@@ -226,6 +226,16 @@ class IcalService {
 		// Build summary with response suffix
 		$summary = $appointment->getName() . ' (' . $l->t('Me') . ': ' . $responseLabel . ')';
 
+		// Cancelled appointments: the event will not take place. This is the one
+		// case where iCal STATUS:CANCELLED is semantically correct. Mark the title
+		// and free up the slot (TRANSPARENT). The feed is regenerated on every
+		// poll, so this flows through to subscribers automatically.
+		if ($appointment->isCancelled()) {
+			$status = 'CANCELLED';
+			$transp = 'TRANSPARENT';
+			$summary = $l->t('Cancelled') . ': ' . $summary;
+		}
+
 		// Build description (use double quotes for actual newlines)
 		$descriptionParts = [];
 

--- a/lib/Service/NotificationService.php
+++ b/lib/Service/NotificationService.php
@@ -173,6 +173,59 @@ class NotificationService {
 	}
 
 	/**
+	 * Notify addressed attendees that an appointment has been cancelled (the
+	 * event will not take place). Mirrors sendNewAppointmentNotifications.
+	 *
+	 * @param Appointment $appointment The cancelled appointment
+	 * @param list<string> $userIds Addressed attendees to notify
+	 */
+	public function sendCancellationNotifications(Appointment $appointment, array $userIds): void {
+		if (!$this->isNotificationsAppEnabled()) {
+			$this->logger->warning('Cannot send notifications - notifications app is not enabled');
+			return;
+		}
+
+		if (empty($userIds)) {
+			return;
+		}
+
+		$appointmentUrl = $this->urlGenerator->linkToRouteAbsolute(
+			'attendance.page.appointment',
+			['id' => $appointment->getId()]
+		);
+
+		$shouldFlush = $this->notificationManager->defer();
+
+		foreach ($userIds as $userId) {
+			try {
+				$notification = $this->notificationManager->createNotification();
+				$notification->setApp('attendance')
+					->setUser($userId)
+					->setDateTime(new \DateTime())
+					->setObject('appointment', (string)$appointment->getId())
+					->setSubject('appointment_cancelled', [
+						'appointmentId' => $appointment->getId(),
+						'name' => $appointment->getName(),
+						'startDatetime' => $appointment->getStartDatetime(),
+					])
+					->setLink($appointmentUrl);
+
+				$this->notificationManager->notify($notification);
+			} catch (\Exception $e) {
+				$this->logger->error('Failed to send cancellation notification', [
+					'userId' => $userId,
+					'appointmentId' => $appointment->getId(),
+					'error' => $e->getMessage(),
+				]);
+			}
+		}
+
+		if ($shouldFlush) {
+			$this->notificationManager->flush();
+		}
+	}
+
+	/**
 	 * Send an appointment reminder notification to a single user.
 	 * Uses the same notification format as ReminderJob but does NOT write to ReminderLogMapper.
 	 *

--- a/openapi-administration.json
+++ b/openapi-administration.json
@@ -167,6 +167,7 @@
                     "calendarSyncAvailable",
                     "notificationsAppEnabled",
                     "closing",
+                    "cancelling",
                     "remindMaybe",
                     "responseToggle",
                     "guestInvitation",
@@ -189,6 +190,9 @@
                         "type": "boolean"
                     },
                     "closing": {
+                        "type": "boolean"
+                    },
+                    "cancelling": {
                         "type": "boolean"
                     },
                     "remindMaybe": {

--- a/openapi-full.json
+++ b/openapi-full.json
@@ -179,6 +179,7 @@
                     "seriesPosition",
                     "sendNotification",
                     "closedAt",
+                    "cancelledAt",
                     "responseDeadline"
                 ],
                 "properties": {
@@ -253,6 +254,10 @@
                         "type": "string",
                         "nullable": true
                     },
+                    "cancelledAt": {
+                        "type": "string",
+                        "nullable": true
+                    },
                     "responseDeadline": {
                         "type": "string",
                         "nullable": true
@@ -280,6 +285,7 @@
                     "seriesPosition",
                     "sendNotification",
                     "closedAt",
+                    "cancelledAt",
                     "responseDeadline",
                     "userResponse",
                     "responseSummary",
@@ -354,6 +360,10 @@
                         "type": "boolean"
                     },
                     "closedAt": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "cancelledAt": {
                         "type": "string",
                         "nullable": true
                     },
@@ -550,6 +560,7 @@
                     "calendarSyncAvailable",
                     "notificationsAppEnabled",
                     "closing",
+                    "cancelling",
                     "remindMaybe",
                     "responseToggle",
                     "guestInvitation",
@@ -572,6 +583,9 @@
                         "type": "boolean"
                     },
                     "closing": {
+                        "type": "boolean"
+                    },
+                    "cancelling": {
                         "type": "boolean"
                     },
                     "remindMaybe": {
@@ -714,6 +728,7 @@
                     "seriesPosition",
                     "userResponse",
                     "closedAt",
+                    "cancelledAt",
                     "inAudience"
                 ],
                 "properties": {
@@ -749,6 +764,10 @@
                         }
                     },
                     "closedAt": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "cancelledAt": {
                         "type": "string",
                         "nullable": true
                     },
@@ -959,6 +978,7 @@
                     "seriesPosition",
                     "sendNotification",
                     "closedAt",
+                    "cancelledAt",
                     "responseDeadline",
                     "alreadyCheckedIn",
                     "checkinState",
@@ -1033,6 +1053,10 @@
                         "type": "boolean"
                     },
                     "closedAt": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "cancelledAt": {
                         "type": "string",
                         "nullable": true
                     },
@@ -3314,6 +3338,227 @@
             "post": {
                 "operationId": "appointment-reopen",
                 "summary": "Re-open a closed appointment inquiry",
+                "tags": [
+                    "appointment"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "Appointment ID",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AppointmentData"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Current user is not logged in",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "anyOf": [
+                                        {
+                                            "type": "object",
+                                            "required": [
+                                                "error"
+                                            ],
+                                            "properties": {
+                                                "error": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        },
+                                        {
+                                            "type": "object",
+                                            "required": [
+                                                "message"
+                                            ],
+                                            "properties": {
+                                                "message": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/index.php/apps/attendance/api/appointments/{id}/cancel": {
+            "post": {
+                "operationId": "appointment-cancel",
+                "summary": "Cancel an appointment",
+                "description": "Marks the appointment as cancelled (the event will not take place). All data/notes are kept, but the appointment drops out of the active lists, gets no reminders and is not auto-closed. Addressed attendees are notified and the calendar feed reflects the cancellation.",
+                "tags": [
+                    "appointment"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "Appointment ID",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AppointmentData"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Current user is not logged in",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "anyOf": [
+                                        {
+                                            "type": "object",
+                                            "required": [
+                                                "error"
+                                            ],
+                                            "properties": {
+                                                "error": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        },
+                                        {
+                                            "type": "object",
+                                            "required": [
+                                                "message"
+                                            ],
+                                            "properties": {
+                                                "message": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/index.php/apps/attendance/api/appointments/{id}/uncancel": {
+            "post": {
+                "operationId": "appointment-uncancel",
+                "summary": "Reactivate a cancelled appointment",
                 "tags": [
                     "appointment"
                 ],

--- a/openapi.json
+++ b/openapi.json
@@ -41,6 +41,7 @@
                     "seriesPosition",
                     "sendNotification",
                     "closedAt",
+                    "cancelledAt",
                     "responseDeadline"
                 ],
                 "properties": {
@@ -115,6 +116,10 @@
                         "type": "string",
                         "nullable": true
                     },
+                    "cancelledAt": {
+                        "type": "string",
+                        "nullable": true
+                    },
                     "responseDeadline": {
                         "type": "string",
                         "nullable": true
@@ -142,6 +147,7 @@
                     "seriesPosition",
                     "sendNotification",
                     "closedAt",
+                    "cancelledAt",
                     "responseDeadline",
                     "userResponse",
                     "responseSummary",
@@ -216,6 +222,10 @@
                         "type": "boolean"
                     },
                     "closedAt": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "cancelledAt": {
                         "type": "string",
                         "nullable": true
                     },
@@ -412,6 +422,7 @@
                     "calendarSyncAvailable",
                     "notificationsAppEnabled",
                     "closing",
+                    "cancelling",
                     "remindMaybe",
                     "responseToggle",
                     "guestInvitation",
@@ -434,6 +445,9 @@
                         "type": "boolean"
                     },
                     "closing": {
+                        "type": "boolean"
+                    },
+                    "cancelling": {
                         "type": "boolean"
                     },
                     "remindMaybe": {
@@ -542,6 +556,7 @@
                     "seriesPosition",
                     "userResponse",
                     "closedAt",
+                    "cancelledAt",
                     "inAudience"
                 ],
                 "properties": {
@@ -577,6 +592,10 @@
                         }
                     },
                     "closedAt": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "cancelledAt": {
                         "type": "string",
                         "nullable": true
                     },
@@ -778,6 +797,7 @@
                     "seriesPosition",
                     "sendNotification",
                     "closedAt",
+                    "cancelledAt",
                     "responseDeadline",
                     "alreadyCheckedIn",
                     "checkinState",
@@ -852,6 +872,10 @@
                         "type": "boolean"
                     },
                     "closedAt": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "cancelledAt": {
                         "type": "string",
                         "nullable": true
                     },
@@ -3102,6 +3126,227 @@
             "post": {
                 "operationId": "appointment-reopen",
                 "summary": "Re-open a closed appointment inquiry",
+                "tags": [
+                    "appointment"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "Appointment ID",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AppointmentData"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Current user is not logged in",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "anyOf": [
+                                        {
+                                            "type": "object",
+                                            "required": [
+                                                "error"
+                                            ],
+                                            "properties": {
+                                                "error": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        },
+                                        {
+                                            "type": "object",
+                                            "required": [
+                                                "message"
+                                            ],
+                                            "properties": {
+                                                "message": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/index.php/apps/attendance/api/appointments/{id}/cancel": {
+            "post": {
+                "operationId": "appointment-cancel",
+                "summary": "Cancel an appointment",
+                "description": "Marks the appointment as cancelled (the event will not take place). All data/notes are kept, but the appointment drops out of the active lists, gets no reminders and is not auto-closed. Addressed attendees are notified and the calendar feed reflects the cancellation.",
+                "tags": [
+                    "appointment"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "Appointment ID",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AppointmentData"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Current user is not logged in",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "anyOf": [
+                                        {
+                                            "type": "object",
+                                            "required": [
+                                                "error"
+                                            ],
+                                            "properties": {
+                                                "error": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        },
+                                        {
+                                            "type": "object",
+                                            "required": [
+                                                "message"
+                                            ],
+                                            "properties": {
+                                                "message": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/index.php/apps/attendance/api/appointments/{id}/uncancel": {
+            "post": {
+                "operationId": "appointment-uncancel",
+                "summary": "Reactivate a cancelled appointment",
                 "tags": [
                     "appointment"
                 ],

--- a/src/components/appointment/AppointmentCard.vue
+++ b/src/components/appointment/AppointmentCard.vue
@@ -58,6 +58,13 @@
 						</a>
 					</span>
 				</template>
+				<NcChip
+					v-if="isCancelled"
+					class="cancelled-badge"
+					:text="t('attendance', 'Cancelled')"
+					variant="error"
+					no-close
+					data-test="cancelled-badge" />
 			</div>
 			<div class="appointment-actions">
 				<NcActions
@@ -107,6 +114,22 @@
 							isClosed
 								? t("attendance", "Reopen inquiry")
 								: t("attendance", "Close inquiry")
+						}}
+					</NcActionButton>
+					<NcActionButton
+						v-if="canCancel"
+						:close-after-click="true"
+						:disabled="togglingCancelled"
+						:data-test="isCancelled ? 'action-reactivate-appointment' : 'action-cancel-appointment'"
+						@click="handleToggleCancelled">
+						<template #icon>
+							<CalendarRefreshIcon v-if="isCancelled" :size="20" />
+							<CalendarRemoveIcon v-else :size="20" />
+						</template>
+						{{
+							isCancelled
+								? t("attendance", "Reactivate appointment")
+								: t("attendance", "Cancel appointment")
 						}}
 					</NcActionButton>
 					<NcActionButton
@@ -432,12 +455,17 @@ import CalendarSyncIcon from 'vue-material-design-icons/CalendarSync.vue'
 import RepeatIcon from 'vue-material-design-icons/Repeat.vue'
 import LockIcon from 'vue-material-design-icons/Lock.vue'
 import LockOpenIcon from 'vue-material-design-icons/LockOpen.vue'
+import CalendarRemoveIcon from 'vue-material-design-icons/CalendarRemove.vue'
+import CalendarRefreshIcon from 'vue-material-design-icons/CalendarRefresh.vue'
 import ClockIcon from 'vue-material-design-icons/Clock.vue'
 import HistoryIcon from 'vue-material-design-icons/History.vue'
 import { formatDateRange, formatDateTime } from '../../utils/datetime.js'
 import { getResponseText, getResponseVariant } from '../../utils/response.js'
 import { formatClosedLabel } from '../../utils/appointment.js'
 import { useAppointmentResponse, useResponseCooldown } from '../../composables/useAppointmentResponse.js'
+import { usePermissions } from '../../composables/usePermissions.js'
+
+const { capabilities } = usePermissions()
 
 const currentUserUid = window.OC?.getCurrentUser?.()?.uid || window.OC?.currentUser || null
 
@@ -511,6 +539,12 @@ const canToggleClosed = computed(() => {
 	if (props.canManageAppointments) return true
 	return Boolean(currentUserUid) && props.appointment.createdBy === currentUserUid
 })
+
+const isCancelled = computed(() => Boolean(props.appointment.cancelledAt))
+
+// Cancelling is a manager/creator action gated behind the server capability, so
+// instances (and older servers) that don't offer it never show the UI.
+const canCancel = computed(() => capabilities.cancelling && canToggleClosed.value)
 
 const formattedClosedAt = computed(() =>
 	props.appointment.closedAt ? formatDateTime(props.appointment.closedAt) : '',
@@ -663,6 +697,37 @@ const handleToggleClosed = async () => {
 		)
 	} finally {
 		togglingClosed.value = false
+	}
+}
+
+const togglingCancelled = ref(false)
+
+const handleToggleCancelled = async () => {
+	if (togglingCancelled.value) return
+	togglingCancelled.value = true
+	const wantsCancel = !isCancelled.value
+	const url = generateUrl(
+		`/apps/attendance/api/appointments/${props.appointment.id}/${wantsCancel ? 'cancel' : 'uncancel'}`,
+	)
+	try {
+		const response = await axios.post(url)
+		showSuccess(
+			wantsCancel
+				? t('attendance', 'Appointment cancelled')
+				: t('attendance', 'Appointment reactivated'),
+		)
+		// Reuse the closedToggled channel: the parent merges the full updated
+		// appointment (incl. cancelledAt) reactively, so no extra wiring needed.
+		emit('closedToggled', response.data)
+	} catch (error) {
+		console.error('Failed to toggle cancelled state:', error)
+		showError(
+			wantsCancel
+				? t('attendance', 'Failed to cancel appointment')
+				: t('attendance', 'Failed to reactivate appointment'),
+		)
+	} finally {
+		togglingCancelled.value = false
 	}
 }
 

--- a/src/components/appointment/AuditTimeline.vue
+++ b/src/components/appointment/AuditTimeline.vue
@@ -75,6 +75,8 @@ import CalendarPlus from 'vue-material-design-icons/CalendarPlus.vue'
 import CalendarEditOutline from 'vue-material-design-icons/CalendarEditOutline.vue'
 import LockOutline from 'vue-material-design-icons/LockOutline.vue'
 import LockOpenVariantOutline from 'vue-material-design-icons/LockOpenVariantOutline.vue'
+import CalendarRemoveOutline from 'vue-material-design-icons/CalendarRemoveOutline.vue'
+import CalendarRefreshOutline from 'vue-material-design-icons/CalendarRefreshOutline.vue'
 import Information from 'vue-material-design-icons/Information.vue'
 import History from 'vue-material-design-icons/History.vue'
 import AlertCircle from 'vue-material-design-icons/AlertCircle.vue'
@@ -109,6 +111,8 @@ const iconMap = {
 	CalendarEditOutline,
 	LockOutline,
 	LockOpenVariantOutline,
+	CalendarRemoveOutline,
+	CalendarRefreshOutline,
 	Information,
 }
 

--- a/src/composables/usePermissions.js
+++ b/src/composables/usePermissions.js
@@ -18,6 +18,7 @@ const state = reactive({
 		notificationsAppEnabled: false,
 		guestInvitation: false,
 		auditLog: false,
+		cancelling: false,
 	},
 	config: {
 		displayOrder: 'name_first',
@@ -71,6 +72,7 @@ export function usePermissions() {
 			state.capabilities.notificationsAppEnabled = capabilitiesRes.data.notificationsAppEnabled !== false
 			state.capabilities.guestInvitation = capabilitiesRes.data.guestInvitation === true
 			state.capabilities.auditLog = capabilitiesRes.data.auditLog === true
+			state.capabilities.cancelling = capabilitiesRes.data.cancelling === true
 
 			state.config.displayOrder = configRes.data.displayOrder || 'name_first'
 			state.config.mobileAppBannerEnabled = configRes.data.mobileAppBannerEnabled !== false
@@ -92,6 +94,7 @@ export function usePermissions() {
 			state.capabilities.calendarSyncAvailable = false
 			state.capabilities.notificationsAppEnabled = false
 			state.capabilities.auditLog = false
+			state.capabilities.cancelling = false
 			state.config.displayOrder = 'name_first'
 			state.config.mobileAppBannerEnabled = true
 			state.config.hasPushDevice = false

--- a/src/utils/auditFormat.js
+++ b/src/utils/auditFormat.js
@@ -182,6 +182,18 @@ export function formatAuditEvent(event) {
 			iconVariant: 'default',
 			segments: textOnly(t('attendance', '{actor} re-opened the inquiry', { actor })),
 		}
+	case 'appointment.cancelled':
+		return {
+			icon: 'CalendarRemoveOutline',
+			iconVariant: 'default',
+			segments: textOnly(t('attendance', '{actor} cancelled the appointment', { actor })),
+		}
+	case 'appointment.uncancelled':
+		return {
+			icon: 'CalendarRefreshOutline',
+			iconVariant: 'default',
+			segments: textOnly(t('attendance', '{actor} reactivated the appointment', { actor })),
+		}
 	default:
 		return {
 			icon: 'Information',

--- a/src/views/AllAppointments.vue
+++ b/src/views/AllAppointments.vue
@@ -227,7 +227,7 @@ const F = Object.freeze({
 	AUDIENCE: 'audience',
 })
 const RESPONSE = Object.freeze({ YES: 'yes', MAYBE: 'maybe', NO: 'no', NONE: 'none' })
-const STATUS = Object.freeze({ OPEN: 'open', CLOSED: 'closed' })
+const STATUS = Object.freeze({ OPEN: 'open', CLOSED: 'closed', CANCELLED: 'cancelled' })
 const AUDIENCE = Object.freeze({ ME: 'me' })
 
 const filterDefs = computed(() => [
@@ -249,6 +249,7 @@ const filterDefs = computed(() => [
 		options: [
 			{ id: STATUS.OPEN, label: t('attendance', 'Opened') },
 			{ id: STATUS.CLOSED, label: t('attendance', 'Closed') },
+			{ id: STATUS.CANCELLED, label: t('attendance', 'Cancelled') },
 		],
 	},
 	{
@@ -321,16 +322,17 @@ const visibleAppointments = computed(() => {
 	const query = props.searchQuery.trim().toLowerCase()
 	const status = filterValues.value[F.STATUS]
 	const response = filterValues.value[F.RESPONSE]
-	if (!query && !status && !response) {
-		return appointments.value
-	}
 	return appointments.value.filter((appointment) => {
+		// Cancelled appointments drop out of the active lists — they are only
+		// reachable on the "All" view (own section + cancelled status filter).
+		if (!props.showAll && appointment.cancelledAt) return false
 		if (query) {
 			const haystack = `${appointment.name} ${appointment.description ?? ''}`.toLowerCase()
 			if (!haystack.includes(query)) return false
 		}
-		if (status === STATUS.OPEN && appointment.closedAt) return false
-		if (status === STATUS.CLOSED && !appointment.closedAt) return false
+		if (status === STATUS.OPEN && (appointment.closedAt || appointment.cancelledAt)) return false
+		if (status === STATUS.CLOSED && (!appointment.closedAt || appointment.cancelledAt)) return false
+		if (status === STATUS.CANCELLED && !appointment.cancelledAt) return false
 		if (response) {
 			const userResponse = appointment.userResponse?.response ?? null
 			if (response === RESPONSE.NONE && userResponse !== null) return false
@@ -346,11 +348,16 @@ const visibleSections = computed(() => {
 	if (!props.showAll) {
 		return [{ key: 'all', label: '', items: visibleAppointments.value }]
 	}
-	const upcoming = visibleAppointments.value.filter(a => !a._isPast)
-	const past = visibleAppointments.value.filter(a => a._isPast)
+	// Cancelled appointments get their own section at the bottom, regardless of
+	// past/upcoming, so they stay visible but clearly set apart.
+	const active = visibleAppointments.value.filter(a => !a.cancelledAt)
+	const cancelled = visibleAppointments.value.filter(a => a.cancelledAt)
+	const upcoming = active.filter(a => !a._isPast)
+	const past = active.filter(a => a._isPast)
 	return [
 		upcoming.length && { key: 'upcoming', label: t('attendance', 'Upcoming'), items: upcoming },
 		past.length && { key: 'past', label: t('attendance', 'Past'), items: past },
+		cancelled.length && { key: 'cancelled', label: t('attendance', 'Cancelled'), items: cancelled },
 	].filter(Boolean)
 })
 

--- a/tests/unit/Service/AppointmentServiceTest.php
+++ b/tests/unit/Service/AppointmentServiceTest.php
@@ -243,6 +243,97 @@ class AppointmentServiceTest extends TestCase {
 		$this->assertNull($result->getClosedAt());
 	}
 
+	public function testCancelAppointmentRecordsAuditEventAndNotifies(): void {
+		$appointment = new Appointment();
+		$appointment->setId(8);
+		$appointment->setVisibleUsers(json_encode(['alice']));
+
+		$this->appointmentMapper->expects($this->once())
+			->method('find')
+			->with(8)
+			->willReturn($appointment);
+		$this->appointmentMapper->expects($this->once())
+			->method('update')
+			->willReturnArgument(0);
+
+		$this->auditEventService->expects($this->once())
+			->method('recordAppointmentLifecycle')
+			->with(Verb::APPOINTMENT_CANCELLED, 8, Verb::SOURCE_APP);
+
+		$this->notificationService->expects($this->once())
+			->method('sendCancellationNotifications')
+			->with($appointment, ['alice']);
+
+		$result = $this->service->cancelAppointment(8, 'admin');
+		$this->assertNotNull($result->getCancelledAt());
+	}
+
+	public function testCancelAppointmentExcludesActorFromNotification(): void {
+		$appointment = new Appointment();
+		$appointment->setId(8);
+		$appointment->setVisibleUsers(json_encode(['admin', 'alice']));
+
+		$this->appointmentMapper->method('find')->with(8)->willReturn($appointment);
+		$this->appointmentMapper->method('update')->willReturnArgument(0);
+
+		$this->notificationService->expects($this->once())
+			->method('sendCancellationNotifications')
+			->with($appointment, ['alice']);
+
+		$this->service->cancelAppointment(8, 'admin');
+	}
+
+	public function testCancelAppointmentIsIdempotentForAlreadyCancelled(): void {
+		$appointment = new Appointment();
+		$appointment->setId(8);
+		$appointment->setCancelledAt('2026-01-01 12:00:00');
+
+		$this->appointmentMapper->expects($this->once())
+			->method('find')
+			->with(8)
+			->willReturn($appointment);
+		$this->appointmentMapper->expects($this->never())->method('update');
+		$this->auditEventService->expects($this->never())->method('recordAppointmentLifecycle');
+		$this->notificationService->expects($this->never())->method('sendCancellationNotifications');
+
+		$this->service->cancelAppointment(8, 'admin');
+	}
+
+	public function testUncancelAppointmentRecordsAuditEvent(): void {
+		$appointment = new Appointment();
+		$appointment->setId(9);
+		$appointment->setCancelledAt('2026-01-01 12:00:00');
+
+		$this->appointmentMapper->expects($this->once())
+			->method('find')
+			->with(9)
+			->willReturn($appointment);
+		$this->appointmentMapper->expects($this->once())
+			->method('update')
+			->willReturnArgument(0);
+
+		$this->auditEventService->expects($this->once())
+			->method('recordAppointmentLifecycle')
+			->with(Verb::APPOINTMENT_UNCANCELLED, 9, Verb::SOURCE_APP);
+
+		$result = $this->service->uncancelAppointment(9);
+		$this->assertNull($result->getCancelledAt());
+	}
+
+	public function testUncancelAppointmentIsIdempotentForNotCancelled(): void {
+		$appointment = new Appointment();
+		$appointment->setId(9);
+
+		$this->appointmentMapper->expects($this->once())
+			->method('find')
+			->with(9)
+			->willReturn($appointment);
+		$this->appointmentMapper->expects($this->never())->method('update');
+		$this->auditEventService->expects($this->never())->method('recordAppointmentLifecycle');
+
+		$this->service->uncancelAppointment(9);
+	}
+
 	public function testGetAppointment(): void {
 		$appointmentId = 1;
 		$appointment = new Appointment();


### PR DESCRIPTION
Additive cancelledAt state: cancel/reactivate endpoints (manager/creator), cancellation notification, ICS STATUS:CANCELLED + title marker, capability `cancelling`. Cancelled appointments keep all data but drop out of active lists, get no reminders and no auto-close; surfaced in the All view via a dedicated section + status filter. Nullable migration (mobile-safe). +5 unit tests, OpenAPI regenerated.

Closes #77
Stacked on #75.