### PR TITLE
feat(#78): booking core — plan yes-responders in per appointment

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -45,6 +45,8 @@ return [
 		['name' => 'appointment#reopen', 'url' => '/api/appointments/{id}/reopen', 'verb' => 'POST'],
 		['name' => 'appointment#cancel', 'url' => '/api/appointments/{id}/cancel', 'verb' => 'POST'],
 		['name' => 'appointment#uncancel', 'url' => '/api/appointments/{id}/uncancel', 'verb' => 'POST'],
+		['name' => 'appointment#book', 'url' => '/api/appointments/{id}/book/{userId}', 'verb' => 'POST'],
+		['name' => 'appointment#unbook', 'url' => '/api/appointments/{id}/unbook/{userId}', 'verb' => 'POST'],
 
 		// Admin settings
 		['name' => 'admin#getSettings', 'url' => '/api/admin/settings', 'verb' => 'GET'],

--- a/lib/Controller/AdminController.php
+++ b/lib/Controller/AdminController.php
@@ -145,6 +145,7 @@ class AdminController extends Controller {
 					'displayOrder' => $this->configService->getDisplayOrder(),
 					'pushEnabled' => $this->configService->isPushEnabled(),
 					'mobileAppBannerEnabled' => $this->configService->isMobileAppBannerEnabled(),
+					'bookingEnabled' => $this->configService->isBookingEnabled(),
 					'guestsApp' => [
 						'enabled' => $this->guestService->isGuestsAppEnabled(),
 						'whitelistEnabled' => $this->guestService->isGuestsWhitelistEnabled(),
@@ -175,6 +176,7 @@ class AdminController extends Controller {
 	 * @param ?string $displayOrder Display order for appointments: chronological, name, or group
 	 * @param ?bool $pushEnabled Whether push notifications are enabled
 	 * @param ?bool $mobileAppBannerEnabled Whether the mobile app promotion banner is enabled
+	 * @param ?bool $bookingEnabled Whether the booking / planning feature is enabled
 	 * @return DataResponse<Http::STATUS_OK, array<string, mixed>, array{}>|DataResponse<Http::STATUS_UNAUTHORIZED, array{error: string}, array{}>|DataResponse<Http::STATUS_FORBIDDEN, array{error: string}, array{}>|DataResponse<Http::STATUS_INTERNAL_SERVER_ERROR, array{error: string}, array{}>
 	 */
 	#[NoCSRFRequired]
@@ -189,6 +191,7 @@ class AdminController extends Controller {
 		?string $displayOrder = null,
 		?bool $pushEnabled = null,
 		?bool $mobileAppBannerEnabled = null,
+		?bool $bookingEnabled = null,
 	): DataResponse {
 		// Get current user
 		$user = $this->userSession->getUser();
@@ -251,6 +254,10 @@ class AdminController extends Controller {
 
 			if ($mobileAppBannerEnabled !== null) {
 				$this->configService->setMobileAppBannerEnabled($mobileAppBannerEnabled);
+			}
+
+			if ($bookingEnabled !== null) {
+				$this->configService->setBookingEnabled($bookingEnabled);
 			}
 
 			return new DataResponse([]);

--- a/lib/Controller/AppointmentController.php
+++ b/lib/Controller/AppointmentController.php
@@ -6,6 +6,7 @@ namespace OCA\Attendance\Controller;
 
 use OCA\Attendance\Service\AppointmentService;
 use OCA\Attendance\Service\AttachmentService;
+use OCA\Attendance\Service\BookingService;
 use OCA\Attendance\Service\CalendarService;
 use OCA\Attendance\Service\CheckinService;
 use OCA\Attendance\Service\ConfigService;
@@ -40,6 +41,7 @@ class AppointmentController extends Controller {
 	private IUserSession $userSession;
 	private ISecureRandom $secureRandom;
 	private GuestService $guestService;
+	private BookingService $bookingService;
 
 	public function __construct(
 		string $appName,
@@ -57,6 +59,7 @@ class AppointmentController extends Controller {
 		IUserSession $userSession,
 		ISecureRandom $secureRandom,
 		GuestService $guestService,
+		BookingService $bookingService,
 	) {
 		parent::__construct($appName, $request);
 		$this->appointmentService = $appointmentService;
@@ -72,6 +75,7 @@ class AppointmentController extends Controller {
 		$this->userSession = $userSession;
 		$this->secureRandom = $secureRandom;
 		$this->guestService = $guestService;
+		$this->bookingService = $bookingService;
 	}
 
 	/**
@@ -496,6 +500,74 @@ class AppointmentController extends Controller {
 	}
 
 	/**
+	 * Mark a yes-responder as booked (planned in) for an appointment
+	 *
+	 * Requires the booking feature to be enabled instance-wide and the caller to
+	 * be a manager or the appointment's creator.
+	 *
+	 * @param int $id Appointment ID
+	 * @param string $userId The responder to book
+	 * @return DataResponse<Http::STATUS_OK, AttendanceResponseData, array{}>|DataResponse<Http::STATUS_UNAUTHORIZED, array{error: string}, array{}>|DataResponse<Http::STATUS_FORBIDDEN, array{error: string}, array{}>|DataResponse<Http::STATUS_BAD_REQUEST, array{error: string}, array{}>|DataResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>
+	 */
+	#[NoAdminRequired]
+	#[NoCSRFRequired]
+	#[OpenAPI]
+	public function book(int $id, string $userId): DataResponse {
+		return $this->setBooking($id, $userId, true);
+	}
+
+	/**
+	 * Clear a responder's booking for an appointment (back to open)
+	 *
+	 * @param int $id Appointment ID
+	 * @param string $userId The responder to unbook
+	 * @return DataResponse<Http::STATUS_OK, AttendanceResponseData, array{}>|DataResponse<Http::STATUS_UNAUTHORIZED, array{error: string}, array{}>|DataResponse<Http::STATUS_FORBIDDEN, array{error: string}, array{}>|DataResponse<Http::STATUS_BAD_REQUEST, array{error: string}, array{}>|DataResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>
+	 */
+	#[NoAdminRequired]
+	#[NoCSRFRequired]
+	#[OpenAPI]
+	public function unbook(int $id, string $userId): DataResponse {
+		return $this->setBooking($id, $userId, false);
+	}
+
+	/**
+	 * Shared book/unbook implementation: permission + feature gating, then
+	 * delegate to BookingService.
+	 */
+	private function setBooking(int $id, string $userId, bool $book): DataResponse {
+		$user = $this->userSession->getUser();
+		if (!$user) {
+			return new DataResponse(['error' => 'User not authenticated'], 401);
+		}
+
+		if (!$this->bookingService->isEnabled()) {
+			return new DataResponse(['error' => 'Booking is not enabled'], 400);
+		}
+
+		try {
+			$appointment = $this->appointmentService->getAppointment($id);
+			if (!$this->permissionService->canManageAppointments($user->getUID())
+				&& $appointment->getCreatedBy() !== $user->getUID()) {
+				return new DataResponse(['error' => 'Insufficient permissions to change bookings'], 403);
+			}
+		} catch (\Exception $e) {
+			return new DataResponse(['error' => 'Appointment not found'], 404);
+		}
+
+		try {
+			$updated = $book
+				? $this->bookingService->book($id, $userId)
+				: $this->bookingService->unbook($id, $userId);
+		} catch (\OCP\AppFramework\Db\DoesNotExistException $e) {
+			return new DataResponse(['error' => 'Response not found'], 404);
+		} catch (\InvalidArgumentException $e) {
+			return new DataResponse(['error' => $e->getMessage()], 400);
+		}
+
+		return new DataResponse($updated);
+	}
+
+	/**
 	 * Get a single appointment with user response
 	 *
 	 * @param int $id Appointment ID
@@ -771,6 +843,7 @@ class AppointmentController extends Controller {
 			// Older servers omit this flag → mobile clients hide close-inquiry UI.
 			'closing' => true,
 			'cancelling' => true,
+			'bookingEnabled' => $this->configService->isBookingEnabled(),
 			'remindMaybe' => true,
 			// Older servers reject response=null. Mobile clients gate the
 			// withdraw-response affordance on this flag.

--- a/lib/Db/AttendanceResponse.php
+++ b/lib/Db/AttendanceResponse.php
@@ -32,6 +32,12 @@ use OCP\AppFramework\Db\Entity;
  * @method void setResponseSource(?string $responseSource)
  * @method string|null getCheckinSource()
  * @method void setCheckinSource(?string $checkinSource)
+ * @method string|null getBookingStatus()
+ * @method void setBookingStatus(?string $bookingStatus)
+ * @method string|null getBookingNotifiedStatus()
+ * @method void setBookingNotifiedStatus(?string $bookingNotifiedStatus)
+ * @method string|null getBookingNotifiedAt()
+ * @method void setBookingNotifiedAt(?string $bookingNotifiedAt)
  */
 class AttendanceResponse extends Entity implements JsonSerializable {
 	use DatetimeFormatTrait;
@@ -46,6 +52,9 @@ class AttendanceResponse extends Entity implements JsonSerializable {
 	protected $checkinAt = '';
 	protected $responseSource = null;
 	protected $checkinSource = null;
+	protected $bookingStatus = null;
+	protected $bookingNotifiedStatus = null;
+	protected $bookingNotifiedAt = null;
 
 	public function __construct() {
 		$this->addType('id', 'integer');
@@ -60,6 +69,9 @@ class AttendanceResponse extends Entity implements JsonSerializable {
 		$this->addType('checkinAt', 'string');
 		$this->addType('responseSource', 'string');
 		$this->addType('checkinSource', 'string');
+		$this->addType('bookingStatus', 'string');
+		$this->addType('bookingNotifiedStatus', 'string');
+		$this->addType('bookingNotifiedAt', 'string');
 	}
 
 	public function jsonSerialize(): array {
@@ -77,6 +89,7 @@ class AttendanceResponse extends Entity implements JsonSerializable {
 			'isCheckedIn' => $this->isCheckedIn(),
 			'responseSource' => $this->getResponseSource(),
 			'checkinSource' => $this->getCheckinSource(),
+			'bookingStatus' => $this->getBookingStatus(),
 		];
 	}
 

--- a/lib/Migration/Version000016Date20260712130000.php
+++ b/lib/Migration/Version000016Date20260712130000.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\Attendance\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * Migration to add booking columns to att_responses.
+ *
+ * booking_status: per-response planning state — null (open / undecided),
+ * 'booked' (planned in) or 'declined'. Only meaningful for yes-responders.
+ * booking_notified_status / booking_notified_at: the last booking state that
+ * was communicated to the attendee, so re-closing an appointment doesn't send
+ * duplicate notifications (used by the close-time notification wave).
+ *
+ * All nullable and purely additive so older mobile clients keep working.
+ */
+class Version000016Date20260712130000 extends SimpleMigrationStep {
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		if ($schema->hasTable('att_responses')) {
+			$table = $schema->getTable('att_responses');
+
+			if (!$table->hasColumn('booking_status')) {
+				$table->addColumn('booking_status', 'string', [
+					'notnull' => false,
+					'length' => 16,
+				]);
+			}
+
+			if (!$table->hasColumn('booking_notified_status')) {
+				$table->addColumn('booking_notified_status', 'string', [
+					'notnull' => false,
+					'length' => 16,
+				]);
+			}
+
+			if (!$table->hasColumn('booking_notified_at')) {
+				$table->addColumn('booking_notified_at', 'datetime', [
+					'notnull' => false,
+				]);
+			}
+		}
+
+		return $schema;
+	}
+}

--- a/lib/ResponseDefinitions.php
+++ b/lib/ResponseDefinitions.php
@@ -41,6 +41,7 @@ namespace OCA\Attendance;
  *   isCheckedIn: bool,
  *   responseSource: ?string,
  *   checkinSource: ?string,
+ *   bookingStatus: ?string,
  * }
  * @psalm-type AttendanceResponseWithUser = array{
  *   id: int,
@@ -56,6 +57,7 @@ namespace OCA\Attendance;
  *   isCheckedIn: bool,
  *   responseSource: ?string,
  *   checkinSource: ?string,
+ *   bookingStatus: ?string,
  *   userName: string,
  *   userGroups: list<string>,
  *   isGuest: bool,
@@ -143,6 +145,7 @@ namespace OCA\Attendance;
  *   notificationsAppEnabled: bool,
  *   closing: bool,
  *   cancelling: bool,
+ *   bookingEnabled: bool,
  *   remindMaybe: bool,
  *   responseToggle: bool,
  *   guestInvitation: bool,
@@ -197,6 +200,7 @@ namespace OCA\Attendance;
  *   displayOrder: string,
  *   pushEnabled: bool,
  *   mobileAppBannerEnabled: bool,
+ *   bookingEnabled: bool,
  *   guestsApp: AttendanceGuestsAppStatus,
  * }
  * @psalm-type AttendanceAdminStatus = array{

--- a/lib/Service/BookingService.php
+++ b/lib/Service/BookingService.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\Attendance\Service;
+
+use OCA\Attendance\Db\AppointmentMapper;
+use OCA\Attendance\Db\AttendanceResponse;
+use OCA\Attendance\Db\AttendanceResponseMapper;
+use OCP\AppFramework\Db\DoesNotExistException;
+
+/**
+ * Booking / planning: a second, orthogonal dimension next to the yes/no/maybe
+ * response. Managers mark yes-responders as "booked" (planned in) for an
+ * appointment. The status lives per response.
+ *
+ * bookingStatus values:
+ *  - null       open / undecided (default; also a plain yes-responder)
+ *  - 'booked'   the person is planned in
+ *  - 'declined' the person was not planned in (set by the close-time wave)
+ */
+class BookingService {
+	public const STATUS_BOOKED = 'booked';
+	public const STATUS_DECLINED = 'declined';
+
+	public function __construct(
+		private AttendanceResponseMapper $responseMapper,
+		private AppointmentMapper $appointmentMapper,
+		private ConfigService $configService,
+	) {
+	}
+
+	/**
+	 * Whether the booking feature is enabled instance-wide.
+	 */
+	public function isEnabled(): bool {
+		return $this->configService->isBookingEnabled();
+	}
+
+	/**
+	 * Mark a yes-responder as booked (planned in) for an appointment.
+	 *
+	 * @throws DoesNotExistException if the user has no response on this appointment
+	 * @throws \InvalidArgumentException if the response is not a "yes"
+	 */
+	public function book(int $appointmentId, string $userId): AttendanceResponse {
+		return $this->setBookingStatus($appointmentId, $userId, self::STATUS_BOOKED);
+	}
+
+	/**
+	 * Clear a booking, returning the response to the open/undecided state.
+	 *
+	 * @throws DoesNotExistException if the user has no response on this appointment
+	 */
+	public function unbook(int $appointmentId, string $userId): AttendanceResponse {
+		return $this->setBookingStatus($appointmentId, $userId, null);
+	}
+
+	/**
+	 * Set the booking status of a single response. Only yes-responders may be
+	 * booked/declined; clearing (null) is always allowed. Returns the updated
+	 * response.
+	 *
+	 * @param ?string $status null, 'booked' or 'declined'
+	 * @throws DoesNotExistException if the user has no response on this appointment
+	 * @throws \InvalidArgumentException on an invalid status or a non-yes booking
+	 */
+	public function setBookingStatus(int $appointmentId, string $userId, ?string $status): AttendanceResponse {
+		if ($status !== null
+			&& $status !== self::STATUS_BOOKED
+			&& $status !== self::STATUS_DECLINED) {
+			throw new \InvalidArgumentException('Invalid booking status: ' . $status);
+		}
+
+		$response = $this->responseMapper->findByAppointmentAndUser($appointmentId, $userId);
+
+		// Booking only makes sense for people who said yes. Clearing is fine
+		// regardless (e.g. after they changed their answer away from yes).
+		if ($status !== null && $response->getResponse() !== 'yes') {
+			throw new \InvalidArgumentException('Only yes-responders can be booked');
+		}
+
+		if ($response->getBookingStatus() === $status) {
+			return $response;
+		}
+
+		$response->setBookingStatus($status);
+		return $this->responseMapper->update($response);
+	}
+}

--- a/lib/Service/ConfigService.php
+++ b/lib/Service/ConfigService.php
@@ -258,6 +258,26 @@ class ConfigService {
 	}
 
 	/**
+	 * Check if the booking / planning feature is enabled instance-wide. When
+	 * off, no booking UI is shown anywhere (the bookingEnabled capability is
+	 * false). Defaults to off so plain yes/no users never see it.
+	 *
+	 * @return bool True if booking is enabled
+	 */
+	public function isBookingEnabled(): bool {
+		return $this->config->getAppValue(self::APP_ID, 'booking_enabled', 'no') === 'yes';
+	}
+
+	/**
+	 * Set the booking / planning feature enabled status.
+	 *
+	 * @param bool $enabled Whether booking should be enabled
+	 */
+	public function setBookingEnabled(bool $enabled): void {
+		$this->config->setAppValue(self::APP_ID, 'booking_enabled', $enabled ? 'yes' : 'no');
+	}
+
+	/**
 	 * Get the push proxy server URL.
 	 * Configurable via occ: occ config:app:set attendance push_proxy_server --value="https://your-proxy.example.com"
 	 *

--- a/openapi-administration.json
+++ b/openapi-administration.json
@@ -58,6 +58,7 @@
                     "displayOrder",
                     "pushEnabled",
                     "mobileAppBannerEnabled",
+                    "bookingEnabled",
                     "guestsApp"
                 ],
                 "properties": {
@@ -92,6 +93,9 @@
                         "type": "boolean"
                     },
                     "mobileAppBannerEnabled": {
+                        "type": "boolean"
+                    },
+                    "bookingEnabled": {
                         "type": "boolean"
                     },
                     "guestsApp": {
@@ -168,6 +172,7 @@
                     "notificationsAppEnabled",
                     "closing",
                     "cancelling",
+                    "bookingEnabled",
                     "remindMaybe",
                     "responseToggle",
                     "guestInvitation",
@@ -193,6 +198,9 @@
                         "type": "boolean"
                     },
                     "cancelling": {
+                        "type": "boolean"
+                    },
+                    "bookingEnabled": {
                         "type": "boolean"
                     },
                     "remindMaybe": {
@@ -528,6 +536,12 @@
                                         "nullable": true,
                                         "default": null,
                                         "description": "Whether the mobile app promotion banner is enabled"
+                                    },
+                                    "bookingEnabled": {
+                                        "type": "boolean",
+                                        "nullable": true,
+                                        "default": null,
+                                        "description": "Whether the booking / planning feature is enabled"
                                     }
                                 }
                             }

--- a/openapi-full.json
+++ b/openapi-full.json
@@ -58,6 +58,7 @@
                     "displayOrder",
                     "pushEnabled",
                     "mobileAppBannerEnabled",
+                    "bookingEnabled",
                     "guestsApp"
                 ],
                 "properties": {
@@ -92,6 +93,9 @@
                         "type": "boolean"
                     },
                     "mobileAppBannerEnabled": {
+                        "type": "boolean"
+                    },
+                    "bookingEnabled": {
                         "type": "boolean"
                     },
                     "guestsApp": {
@@ -561,6 +565,7 @@
                     "notificationsAppEnabled",
                     "closing",
                     "cancelling",
+                    "bookingEnabled",
                     "remindMaybe",
                     "responseToggle",
                     "guestInvitation",
@@ -586,6 +591,9 @@
                         "type": "boolean"
                     },
                     "cancelling": {
+                        "type": "boolean"
+                    },
+                    "bookingEnabled": {
                         "type": "boolean"
                     },
                     "remindMaybe": {
@@ -827,7 +835,8 @@
                     "checkinAt",
                     "isCheckedIn",
                     "responseSource",
-                    "checkinSource"
+                    "checkinSource",
+                    "bookingStatus"
                 ],
                 "properties": {
                     "id": {
@@ -874,6 +883,10 @@
                     "checkinSource": {
                         "type": "string",
                         "nullable": true
+                    },
+                    "bookingStatus": {
+                        "type": "string",
+                        "nullable": true
                     }
                 }
             },
@@ -893,6 +906,7 @@
                     "isCheckedIn",
                     "responseSource",
                     "checkinSource",
+                    "bookingStatus",
                     "userName",
                     "userGroups",
                     "isGuest"
@@ -940,6 +954,10 @@
                         "nullable": true
                     },
                     "checkinSource": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "bookingStatus": {
                         "type": "string",
                         "nullable": true
                     },
@@ -3665,6 +3683,281 @@
                 }
             }
         },
+        "/index.php/apps/attendance/api/appointments/{id}/book/{userId}": {
+            "post": {
+                "operationId": "appointment-book",
+                "summary": "Mark a yes-responder as booked (planned in) for an appointment",
+                "description": "Requires the booking feature to be enabled instance-wide and the caller to be a manager or the appointment's creator.",
+                "tags": [
+                    "appointment"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "Appointment ID",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    },
+                    {
+                        "name": "userId",
+                        "in": "path",
+                        "description": "The responder to book",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ResponseData"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Current user is not logged in",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "anyOf": [
+                                        {
+                                            "type": "object",
+                                            "required": [
+                                                "error"
+                                            ],
+                                            "properties": {
+                                                "error": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        },
+                                        {
+                                            "type": "object",
+                                            "required": [
+                                                "message"
+                                            ],
+                                            "properties": {
+                                                "message": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/index.php/apps/attendance/api/appointments/{id}/unbook/{userId}": {
+            "post": {
+                "operationId": "appointment-unbook",
+                "summary": "Clear a responder's booking for an appointment (back to open)",
+                "tags": [
+                    "appointment"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "Appointment ID",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    },
+                    {
+                        "name": "userId",
+                        "in": "path",
+                        "description": "The responder to unbook",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ResponseData"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Current user is not logged in",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "anyOf": [
+                                        {
+                                            "type": "object",
+                                            "required": [
+                                                "error"
+                                            ],
+                                            "properties": {
+                                                "error": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        },
+                                        {
+                                            "type": "object",
+                                            "required": [
+                                                "message"
+                                            ],
+                                            "properties": {
+                                                "message": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/index.php/apps/attendance/api/user/permissions": {
             "get": {
                 "operationId": "appointment-get-permissions",
@@ -5481,6 +5774,12 @@
                                         "nullable": true,
                                         "default": null,
                                         "description": "Whether the mobile app promotion banner is enabled"
+                                    },
+                                    "bookingEnabled": {
+                                        "type": "boolean",
+                                        "nullable": true,
+                                        "default": null,
+                                        "description": "Whether the booking / planning feature is enabled"
                                     }
                                 }
                             }

--- a/openapi.json
+++ b/openapi.json
@@ -423,6 +423,7 @@
                     "notificationsAppEnabled",
                     "closing",
                     "cancelling",
+                    "bookingEnabled",
                     "remindMaybe",
                     "responseToggle",
                     "guestInvitation",
@@ -448,6 +449,9 @@
                         "type": "boolean"
                     },
                     "cancelling": {
+                        "type": "boolean"
+                    },
+                    "bookingEnabled": {
                         "type": "boolean"
                     },
                     "remindMaybe": {
@@ -646,7 +650,8 @@
                     "checkinAt",
                     "isCheckedIn",
                     "responseSource",
-                    "checkinSource"
+                    "checkinSource",
+                    "bookingStatus"
                 ],
                 "properties": {
                     "id": {
@@ -693,6 +698,10 @@
                     "checkinSource": {
                         "type": "string",
                         "nullable": true
+                    },
+                    "bookingStatus": {
+                        "type": "string",
+                        "nullable": true
                     }
                 }
             },
@@ -712,6 +721,7 @@
                     "isCheckedIn",
                     "responseSource",
                     "checkinSource",
+                    "bookingStatus",
                     "userName",
                     "userGroups",
                     "isGuest"
@@ -759,6 +769,10 @@
                         "nullable": true
                     },
                     "checkinSource": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "bookingStatus": {
                         "type": "string",
                         "nullable": true
                     },
@@ -3415,6 +3429,281 @@
                         }
                     },
                     "403": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/index.php/apps/attendance/api/appointments/{id}/book/{userId}": {
+            "post": {
+                "operationId": "appointment-book",
+                "summary": "Mark a yes-responder as booked (planned in) for an appointment",
+                "description": "Requires the booking feature to be enabled instance-wide and the caller to be a manager or the appointment's creator.",
+                "tags": [
+                    "appointment"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "Appointment ID",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    },
+                    {
+                        "name": "userId",
+                        "in": "path",
+                        "description": "The responder to book",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ResponseData"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Current user is not logged in",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "anyOf": [
+                                        {
+                                            "type": "object",
+                                            "required": [
+                                                "error"
+                                            ],
+                                            "properties": {
+                                                "error": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        },
+                                        {
+                                            "type": "object",
+                                            "required": [
+                                                "message"
+                                            ],
+                                            "properties": {
+                                                "message": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/index.php/apps/attendance/api/appointments/{id}/unbook/{userId}": {
+            "post": {
+                "operationId": "appointment-unbook",
+                "summary": "Clear a responder's booking for an appointment (back to open)",
+                "tags": [
+                    "appointment"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "Appointment ID",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    },
+                    {
+                        "name": "userId",
+                        "in": "path",
+                        "description": "The responder to unbook",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ResponseData"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Current user is not logged in",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "anyOf": [
+                                        {
+                                            "type": "object",
+                                            "required": [
+                                                "error"
+                                            ],
+                                            "properties": {
+                                                "error": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        },
+                                        {
+                                            "type": "object",
+                                            "required": [
+                                                "message"
+                                            ],
+                                            "properties": {
+                                                "message": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
                         "description": "",
                         "content": {
                             "application/json": {

--- a/src/components/appointment/AppointmentCard.vue
+++ b/src/components/appointment/AppointmentCard.vue
@@ -385,6 +385,7 @@
 			:can-see-comments="canSeeComments"
 			:can-manage-appointments="canManageAppointments"
 			:appointment-id="appointment.id"
+			:booking-enabled="capabilities.bookingEnabled"
 			:is-closed="isClosed" />
 
 		<!-- Remind target dialog -->

--- a/src/components/appointment/ResponseSummary.vue
+++ b/src/components/appointment/ResponseSummary.vue
@@ -126,6 +126,18 @@
 										</NcButton>
 									</div>
 								</NcPopover>
+								<NcButton
+									v-if="canManageBooking && response.response === 'yes'"
+									class="booking-toggle"
+									:variant="response.bookingStatus === 'booked' ? 'success' : 'tertiary'"
+									:disabled="togglingBooking.has(response.userId)"
+									:data-test="`booking-toggle-${response.userId}`"
+									@click="toggleBooking(response)">
+									<template #icon>
+										<CalendarCheckIcon :size="20" />
+									</template>
+									{{ response.bookingStatus === 'booked' ? t('attendance', 'Scheduled') : t('attendance', 'Schedule') }}
+								</NcButton>
 								</div>
 								<div
 									v-if="response.isCheckedIn"
@@ -270,6 +282,18 @@
 										</NcButton>
 									</div>
 								</NcPopover>
+								<NcButton
+									v-if="canManageBooking && response.response === 'yes'"
+									class="booking-toggle"
+									:variant="response.bookingStatus === 'booked' ? 'success' : 'tertiary'"
+									:disabled="togglingBooking.has(response.userId)"
+									:data-test="`booking-toggle-${response.userId}`"
+									@click="toggleBooking(response)">
+									<template #icon>
+										<CalendarCheckIcon :size="20" />
+									</template>
+									{{ response.bookingStatus === 'booked' ? t('attendance', 'Scheduled') : t('attendance', 'Schedule') }}
+								</NcButton>
 								</div>
 								<div
 									v-if="response.isCheckedIn"
@@ -403,6 +427,18 @@
 										</NcButton>
 									</div>
 								</NcPopover>
+								<NcButton
+									v-if="canManageBooking && response.response === 'yes'"
+									class="booking-toggle"
+									:variant="response.bookingStatus === 'booked' ? 'success' : 'tertiary'"
+									:disabled="togglingBooking.has(response.userId)"
+									:data-test="`booking-toggle-${response.userId}`"
+									@click="toggleBooking(response)">
+									<template #icon>
+										<CalendarCheckIcon :size="20" />
+									</template>
+									{{ response.bookingStatus === 'booked' ? t('attendance', 'Scheduled') : t('attendance', 'Schedule') }}
+								</NcButton>
 								</div>
 								<div
 									v-if="response.isCheckedIn"
@@ -463,6 +499,7 @@ import axios from '@nextcloud/axios'
 import AccountGroup from 'vue-material-design-icons/AccountGroup.vue'
 import AccountStar from 'vue-material-design-icons/AccountStar.vue'
 import BellRingOutlineIcon from 'vue-material-design-icons/BellRingOutline.vue'
+import CalendarCheckIcon from 'vue-material-design-icons/CalendarCheck.vue'
 import NonRespondingUserList from './NonRespondingUserList.vue'
 import { getResponseText, getResponseVariant } from '../../utils/response.js'
 import { formatGroupLabel } from '../../utils/groups.js'
@@ -488,15 +525,48 @@ const props = defineProps({
 		type: Boolean,
 		default: false,
 	},
+	// Instance-wide booking capability. Off = no booking UI anywhere.
+	bookingEnabled: {
+		type: Boolean,
+		default: false,
+	},
 })
 
 const canSendReminders = computed(
 	() => props.canManageAppointments && !props.isClosed,
 )
 
+// The per-person booking toggle only shows when the feature is on and the
+// viewer may manage the appointment; individual rows additionally require a
+// "yes" response (handled inline).
+const canManageBooking = computed(
+	() => props.canManageAppointments && props.bookingEnabled,
+)
+
 const expandedGroups = ref({})
 const remindingUsers = reactive(new Set())
+const togglingBooking = reactive(new Set())
 const openRemindPopover = ref(null)
+
+const toggleBooking = async (response) => {
+	if (!props.appointmentId || togglingBooking.has(response.userId)) return
+	const wantBook = response.bookingStatus !== 'booked'
+	togglingBooking.add(response.userId)
+	try {
+		const action = wantBook ? 'book' : 'unbook'
+		const { data } = await axios.post(
+			generateUrl(`/apps/attendance/api/appointments/${props.appointmentId}/${action}/${encodeURIComponent(response.userId)}`),
+		)
+		// Reflect the new state on the row in place (the summary object is shared
+		// with the parent, so the toggle updates without a refetch).
+		response.bookingStatus = data.bookingStatus ?? null
+	} catch (error) {
+		console.error('Failed to update booking:', error)
+		showError(t('attendance', 'Failed to update scheduling'))
+	} finally {
+		togglingBooking.delete(response.userId)
+	}
+}
 
 const remindUser = async (userId) => {
 	if (!props.appointmentId) return

--- a/src/composables/usePermissions.js
+++ b/src/composables/usePermissions.js
@@ -19,6 +19,7 @@ const state = reactive({
 		guestInvitation: false,
 		auditLog: false,
 		cancelling: false,
+		bookingEnabled: false,
 	},
 	config: {
 		displayOrder: 'name_first',
@@ -73,6 +74,7 @@ export function usePermissions() {
 			state.capabilities.guestInvitation = capabilitiesRes.data.guestInvitation === true
 			state.capabilities.auditLog = capabilitiesRes.data.auditLog === true
 			state.capabilities.cancelling = capabilitiesRes.data.cancelling === true
+			state.capabilities.bookingEnabled = capabilitiesRes.data.bookingEnabled === true
 
 			state.config.displayOrder = configRes.data.displayOrder || 'name_first'
 			state.config.mobileAppBannerEnabled = configRes.data.mobileAppBannerEnabled !== false
@@ -95,6 +97,7 @@ export function usePermissions() {
 			state.capabilities.notificationsAppEnabled = false
 			state.capabilities.auditLog = false
 			state.capabilities.cancelling = false
+			state.capabilities.bookingEnabled = false
 			state.config.displayOrder = 'name_first'
 			state.config.mobileAppBannerEnabled = true
 			state.config.hasPushDevice = false

--- a/src/views/AdminSettings.vue
+++ b/src/views/AdminSettings.vue
@@ -321,6 +321,16 @@
 				</NcSettingsSection>
 			</div>
 
+			<NcSettingsSection :name="t('attendance', 'Scheduling')"
+				:description="t('attendance', 'Let managers mark yes-responders as scheduled for an appointment. When off, no scheduling controls are shown anywhere.')">
+				<NcCheckboxRadioSwitch v-model="bookingEnabled"
+					type="switch"
+					:disabled="loading"
+					data-test="switch-booking-enabled">
+					{{ t('attendance', 'Enable scheduling') }}
+				</NcCheckboxRadioSwitch>
+			</NcSettingsSection>
+
 			<NcSettingsSection :name="t('attendance', 'Mobile apps')"
 				:description="t('attendance', 'Share these links with your colleagues to install the Attendance mobile app.')">
 				<div class="mobile-app-links">
@@ -572,6 +582,7 @@ const auditLogEnabled = ref(true)
 const auditLogVisibility = ref('managers')
 const pushEnabled = ref(true)
 const mobileAppBannerEnabled = ref(true)
+const bookingEnabled = ref(false)
 const displayOrder = ref('name_first')
 const pushDeviceCount = ref(0)
 const loading = ref(false)
@@ -719,6 +730,9 @@ const loadSettings = async () => {
 		// Load mobile app banner setting
 		mobileAppBannerEnabled.value = config.mobileAppBannerEnabled !== false
 
+		// Load planning / booking setting (opt-in, defaults off)
+		bookingEnabled.value = config.bookingEnabled === true
+
 		// Load guests app status (for whitelist warning)
 		if (config.guestsApp) {
 			guestsApp.value = config.guestsApp
@@ -792,6 +806,7 @@ const saveSettings = async () => {
 				displayOrder: displayOrder.value,
 				pushEnabled: pushEnabled.value,
 				mobileAppBannerEnabled: mobileAppBannerEnabled.value,
+				bookingEnabled: bookingEnabled.value,
 			},
 		)
 

--- a/tests/unit/Db/AttendanceResponseTest.php
+++ b/tests/unit/Db/AttendanceResponseTest.php
@@ -116,6 +116,15 @@ class AttendanceResponseTest extends TestCase {
 		$this->assertEquals('admin', $json['checkinBy']);
 		$this->assertEquals('2024-01-15T10:05:00Z', $json['checkinAt']);
 		$this->assertTrue($json['isCheckedIn']);
+		// bookingStatus is null (open) by default and surfaces in the payload.
+		$this->assertArrayHasKey('bookingStatus', $json);
+		$this->assertNull($json['bookingStatus']);
+	}
+
+	public function testBookingStatusSetGetAndSerialize(): void {
+		$this->response->setBookingStatus('booked');
+		$this->assertSame('booked', $this->response->getBookingStatus());
+		$this->assertSame('booked', $this->response->jsonSerialize()['bookingStatus']);
 	}
 
 	public function testDefaultValues(): void {
@@ -130,5 +139,6 @@ class AttendanceResponseTest extends TestCase {
 		$this->assertEquals('', $response->getCheckinComment());
 		$this->assertEquals('', $response->getCheckinBy());
 		$this->assertEquals('', $response->getCheckinAt());
+		$this->assertNull($response->getBookingStatus());
 	}
 }

--- a/tests/unit/Service/BookingServiceTest.php
+++ b/tests/unit/Service/BookingServiceTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\Attendance\Tests\Unit\Service;
+
+use OCA\Attendance\Db\AppointmentMapper;
+use OCA\Attendance\Db\AttendanceResponse;
+use OCA\Attendance\Db\AttendanceResponseMapper;
+use OCA\Attendance\Service\BookingService;
+use OCA\Attendance\Service\ConfigService;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class BookingServiceTest extends TestCase {
+	/** @var AttendanceResponseMapper|MockObject */
+	private $responseMapper;
+	/** @var AppointmentMapper|MockObject */
+	private $appointmentMapper;
+	/** @var ConfigService|MockObject */
+	private $configService;
+	private BookingService $service;
+
+	protected function setUp(): void {
+		$this->responseMapper = $this->createMock(AttendanceResponseMapper::class);
+		$this->appointmentMapper = $this->createMock(AppointmentMapper::class);
+		$this->configService = $this->createMock(ConfigService::class);
+		$this->service = new BookingService(
+			$this->responseMapper,
+			$this->appointmentMapper,
+			$this->configService,
+		);
+	}
+
+	private function yesResponse(): AttendanceResponse {
+		$r = new AttendanceResponse();
+		$r->setId(1);
+		$r->setAppointmentId(5);
+		$r->setUserId('alice');
+		$r->setResponse('yes');
+		return $r;
+	}
+
+	public function testBookMarksYesResponderAsBooked(): void {
+		$response = $this->yesResponse();
+		$this->responseMapper->method('findByAppointmentAndUser')
+			->with(5, 'alice')->willReturn($response);
+		$this->responseMapper->expects($this->once())
+			->method('update')->willReturnArgument(0);
+
+		$result = $this->service->book(5, 'alice');
+		$this->assertSame(BookingService::STATUS_BOOKED, $result->getBookingStatus());
+	}
+
+	public function testBookRejectsNonYesResponder(): void {
+		$response = $this->yesResponse();
+		$response->setResponse('no');
+		$this->responseMapper->method('findByAppointmentAndUser')->willReturn($response);
+		$this->responseMapper->expects($this->never())->method('update');
+
+		$this->expectException(\InvalidArgumentException::class);
+		$this->service->book(5, 'alice');
+	}
+
+	public function testUnbookClearsBookingStatus(): void {
+		$response = $this->yesResponse();
+		$response->setBookingStatus(BookingService::STATUS_BOOKED);
+		$this->responseMapper->method('findByAppointmentAndUser')->willReturn($response);
+		$this->responseMapper->expects($this->once())
+			->method('update')->willReturnArgument(0);
+
+		$result = $this->service->unbook(5, 'alice');
+		$this->assertNull($result->getBookingStatus());
+	}
+
+	public function testSetBookingStatusRejectsInvalidStatus(): void {
+		$this->expectException(\InvalidArgumentException::class);
+		$this->service->setBookingStatus(5, 'alice', 'planned');
+	}
+
+	public function testBookIsIdempotent(): void {
+		$response = $this->yesResponse();
+		$response->setBookingStatus(BookingService::STATUS_BOOKED);
+		$this->responseMapper->method('findByAppointmentAndUser')->willReturn($response);
+		$this->responseMapper->expects($this->never())->method('update');
+
+		$result = $this->service->book(5, 'alice');
+		$this->assertSame(BookingService::STATUS_BOOKED, $result->getBookingStatus());
+	}
+
+	public function testIsEnabledReflectsConfig(): void {
+		$this->configService->method('isBookingEnabled')->willReturn(true);
+		$this->assertTrue($this->service->isEnabled());
+	}
+}


### PR DESCRIPTION
Per-response bookingStatus (null/booked/declined) behind an instance-wide admin switch. BookingService + book/unbook endpoints (manager/creator, gated on the switch), capability `bookingEnabled`. Nullable migration on att_responses. Web: per-person Book toggle in the response overview (yes-responders, managers, only when enabled) + admin 'Planning' switch. +6 tests, OpenAPI regenerated.

Closes #78
Stacked on #81 (paired).