### PR TITLE
feat(#79): booking notification wave on close + confirmation dialog

### DIFF
--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -145,6 +145,34 @@ class Notifier implements INotifier {
 
 				return $notification;
 
+			case 'booking_confirmed':
+			case 'booking_declined':
+				$parameters = $notification->getSubjectParameters();
+				$appointmentName = $parameters['name'] ?? 'Unknown';
+				$appointmentDate = $this->formatDateForUser(
+					$parameters['startDatetime'] ?? $parameters['date'] ?? '',
+					$notification->getUser()
+				);
+				if ($notification->getSubject() === 'booking_confirmed') {
+					$notification->setParsedSubject(
+						$l->t('You are scheduled: %1$s on %2$s', [$appointmentName, $appointmentDate])
+					);
+					$notification->setParsedMessage(
+						$l->t('You have been scheduled for this appointment.')
+					);
+				} else {
+					$notification->setParsedSubject(
+						$l->t('Not scheduled: %1$s on %2$s', [$appointmentName, $appointmentDate])
+					);
+					$notification->setParsedMessage(
+						$l->t('You are not scheduled for this appointment this time.')
+					);
+				}
+				$notification->setIcon($this->urlGenerator->getAbsoluteURL(
+					$this->urlGenerator->imagePath('attendance', 'app-dark.svg')
+				));
+				return $notification;
+
 			case 'response_submitted':
 			case 'response_changed':
 			case 'response_rescinded':

--- a/lib/Service/AppointmentService.php
+++ b/lib/Service/AppointmentService.php
@@ -36,6 +36,7 @@ class AppointmentService {
 	private IAppManager $appManager;
 	private GuestService $guestService;
 	private AuditEventService $auditEventService;
+	private BookingService $bookingService;
 
 	public function __construct(
 		AppointmentMapper $appointmentMapper,
@@ -51,6 +52,7 @@ class AppointmentService {
 		IAppManager $appManager,
 		GuestService $guestService,
 		AuditEventService $auditEventService,
+		BookingService $bookingService,
 	) {
 		$this->appointmentMapper = $appointmentMapper;
 		$this->responseMapper = $responseMapper;
@@ -65,6 +67,7 @@ class AppointmentService {
 		$this->appManager = $appManager;
 		$this->guestService = $guestService;
 		$this->auditEventService = $auditEventService;
+		$this->bookingService = $bookingService;
 	}
 
 	/**
@@ -233,6 +236,11 @@ class AppointmentService {
 			$id,
 			\OCA\Attendance\Audit\Verb::SOURCE_APP,
 		);
+
+		// Booking wave: notify planned-in / not-planned-in yes-responders. No-op
+		// unless the feature is on AND at least one person is booked; reopen-safe
+		// (only diffs against the last communicated state).
+		$this->bookingService->notifyOnClose($updated);
 
 		return $updated;
 	}

--- a/lib/Service/BookingService.php
+++ b/lib/Service/BookingService.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace OCA\Attendance\Service;
 
+use OCA\Attendance\Db\Appointment;
 use OCA\Attendance\Db\AppointmentMapper;
 use OCA\Attendance\Db\AttendanceResponse;
 use OCA\Attendance\Db\AttendanceResponseMapper;
@@ -27,6 +28,7 @@ class BookingService {
 		private AttendanceResponseMapper $responseMapper,
 		private AppointmentMapper $appointmentMapper,
 		private ConfigService $configService,
+		private NotificationService $notificationService,
 	) {
 	}
 
@@ -72,6 +74,14 @@ class BookingService {
 			throw new \InvalidArgumentException('Invalid booking status: ' . $status);
 		}
 
+		// Scheduling is communicated by the close-time notification wave. Changing
+		// who is scheduled after the inquiry is closed would silently skip that
+		// wave, so block it — the manager must reopen the inquiry to make changes.
+		$appointment = $this->appointmentMapper->find($appointmentId);
+		if ($appointment->getClosedAt() !== null) {
+			throw new \InvalidArgumentException('Cannot change scheduling on a closed inquiry');
+		}
+
 		$response = $this->responseMapper->findByAppointmentAndUser($appointmentId, $userId);
 
 		// Booking only makes sense for people who said yes. Clearing is fine
@@ -86,5 +96,72 @@ class BookingService {
 
 		$response->setBookingStatus($status);
 		return $this->responseMapper->update($response);
+	}
+
+	/**
+	 * Notification wave triggered when an appointment is closed: tell booked
+	 * yes-responders they are planned in and the remaining yes-responders they
+	 * are not. Rules:
+	 *  - Only fires when at least one person is booked. Zero bookings → closing
+	 *    behaves exactly as before (no notification), protecting managers who
+	 *    don't use the feature even while it is enabled.
+	 *  - Reopen-safe: each response remembers the last state communicated to it
+	 *    (bookingNotifiedStatus). Re-closing only notifies people whose effective
+	 *    status changed since — no duplicate notifications.
+	 *
+	 * @return array{booked: int, declined: int} count of notifications actually sent
+	 */
+	public function notifyOnClose(Appointment $appointment): array {
+		$sent = ['booked' => 0, 'declined' => 0];
+		if (!$this->isEnabled()) {
+			return $sent;
+		}
+
+		$responses = $this->responseMapper->findByAppointment($appointment->getId());
+
+		// Effective status per yes-responder: booked → 'booked', otherwise 'declined'.
+		$targets = [];
+		$bookedCount = 0;
+		foreach ($responses as $response) {
+			if ($response->getResponse() !== 'yes') {
+				continue;
+			}
+			$status = $response->getBookingStatus() === self::STATUS_BOOKED
+				? self::STATUS_BOOKED
+				: self::STATUS_DECLINED;
+			$targets[] = [$response, $status];
+			if ($status === self::STATUS_BOOKED) {
+				$bookedCount++;
+			}
+		}
+
+		// Wave only when at least one person is booked.
+		if ($bookedCount === 0) {
+			return $sent;
+		}
+
+		$now = gmdate('Y-m-d H:i:s');
+		foreach ($targets as [$response, $status]) {
+			// Diff against the last communicated state — skip if unchanged.
+			if ($response->getBookingNotifiedStatus() === $status) {
+				continue;
+			}
+			$this->notificationService->sendBookingNotification(
+				$appointment,
+				$response->getUserId(),
+				$status,
+			);
+			$response->setBookingNotifiedStatus($status);
+			$response->setBookingNotifiedAt($now);
+			$this->responseMapper->update($response);
+
+			if ($status === self::STATUS_BOOKED) {
+				$sent['booked']++;
+			} else {
+				$sent['declined']++;
+			}
+		}
+
+		return $sent;
 	}
 }

--- a/lib/Service/NotificationService.php
+++ b/lib/Service/NotificationService.php
@@ -226,6 +226,49 @@ class NotificationService {
 	}
 
 	/**
+	 * Notify a single attendee about their booking outcome when an appointment
+	 * is closed: booked ("you are planned in") or not ("someone else this time").
+	 *
+	 * @param Appointment $appointment The closed appointment
+	 * @param string $userId The attendee to notify
+	 * @param string $status 'booked' or 'declined'
+	 */
+	public function sendBookingNotification(Appointment $appointment, string $userId, string $status): void {
+		if (!$this->isNotificationsAppEnabled()) {
+			return;
+		}
+
+		$subject = $status === 'booked' ? 'booking_confirmed' : 'booking_declined';
+		$appointmentUrl = $this->urlGenerator->linkToRouteAbsolute(
+			'attendance.page.appointment',
+			['id' => $appointment->getId()]
+		);
+
+		try {
+			$notification = $this->notificationManager->createNotification();
+			$notification->setApp('attendance')
+				->setUser($userId)
+				->setDateTime(new \DateTime())
+				->setObject('appointment', (string)$appointment->getId())
+				->setSubject($subject, [
+					'appointmentId' => $appointment->getId(),
+					'name' => $appointment->getName(),
+					'startDatetime' => $appointment->getStartDatetime(),
+				])
+				->setLink($appointmentUrl);
+
+			$this->notificationManager->notify($notification);
+		} catch (\Exception $e) {
+			$this->logger->error('Failed to send booking notification', [
+				'userId' => $userId,
+				'appointmentId' => $appointment->getId(),
+				'status' => $status,
+				'error' => $e->getMessage(),
+			]);
+		}
+	}
+
+	/**
 	 * Send an appointment reminder notification to a single user.
 	 * Uses the same notification format as ReminderJob but does NOT write to ReminderLogMapper.
 	 *

--- a/src/components/appointment/AppointmentCard.vue
+++ b/src/components/appointment/AppointmentCard.vue
@@ -420,6 +420,54 @@
 				</NcButton>
 			</div>
 		</NcDialog>
+
+		<!-- Close confirmation with planned-in / not-planned-in groups -->
+		<NcDialog
+			v-if="showCloseBookingDialog"
+			:name="t('attendance', 'Close and notify?')"
+			data-test="close-booking-dialog"
+			@closing="showCloseBookingDialog = false">
+			<div class="booking-confirm">
+				<p class="booking-confirm__hint">
+					{{ t('attendance', 'Closing notifies these people about their scheduling status.') }}
+				</p>
+				<div
+					v-for="group in bookingDialogGroups"
+					:key="group.key"
+					class="booking-confirm__group">
+					<h4>{{ group.label }}</h4>
+					<p v-if="group.names.length === 0" class="booking-confirm__empty">
+						{{ t('attendance', 'Nobody') }}
+					</p>
+					<p v-else class="booking-confirm__names">
+						{{ visibleBookingNames(group).join(', ') }}
+						<NcButton
+							v-if="group.names.length > BOOKING_PREVIEW_LIMIT"
+							variant="tertiary"
+							@click="toggleBookingGroup(group.key)">
+							{{ expandedBookingGroups[group.key]
+								? t('attendance', 'Show less')
+								: t('attendance', '+{count} more', { count: group.names.length - BOOKING_PREVIEW_LIMIT }) }}
+						</NcButton>
+					</p>
+				</div>
+			</div>
+			<template #actions>
+				<NcButton
+					variant="tertiary"
+					data-test="close-booking-cancel"
+					@click="showCloseBookingDialog = false">
+					{{ t('attendance', 'Cancel') }}
+				</NcButton>
+				<NcButton
+					variant="primary"
+					:disabled="togglingClosed"
+					data-test="close-booking-confirm"
+					@click="confirmCloseWithBookings">
+					{{ t('attendance', 'Close inquiry') }}
+				</NcButton>
+			</template>
+		</NcDialog>
 	</div>
 </template>
 
@@ -673,11 +721,74 @@ const handleResponse = (response) => {
 }
 
 const togglingClosed = ref(false)
+const showCloseBookingDialog = ref(false)
+
+// Yes-responders split into planned-in / not-planned-in, deduped by user. Drives
+// the close-confirmation dialog and mirrors the server's close-time wave.
+const bookingGroups = computed(() => {
+	const summary = props.appointment.responseSummary
+	const booked = new Map()
+	const declined = new Map()
+	if (!summary) return { booked: [], declined: [] }
+	const sections = []
+	if (summary.by_group) sections.push(...Object.values(summary.by_group))
+	if (summary.by_team) sections.push(...Object.values(summary.by_team))
+	if (summary.others) sections.push(summary.others)
+	for (const section of sections) {
+		for (const r of section.responses || []) {
+			if (r.response !== 'yes') continue
+			const target = r.bookingStatus === 'booked' ? booked : declined
+			target.set(r.userId, r.userName || r.userId)
+		}
+	}
+	for (const uid of booked.keys()) declined.delete(uid)
+	return { booked: [...booked.values()], declined: [...declined.values()] }
+})
 
 const handleToggleClosed = async () => {
 	if (togglingClosed.value) return
-	togglingClosed.value = true
 	const wantsClose = !isClosed.value
+	// Closing with planned-in people triggers a notification wave — confirm the
+	// two named groups first. Without booking / without anyone booked, close is
+	// a direct click as before.
+	if (wantsClose && capabilities.bookingEnabled && bookingGroups.value.booked.length >= 1) {
+		showCloseBookingDialog.value = true
+		return
+	}
+	await performToggleClosed(wantsClose)
+}
+
+const confirmCloseWithBookings = async () => {
+	showCloseBookingDialog.value = false
+	await performToggleClosed(true)
+}
+
+const BOOKING_PREVIEW_LIMIT = 10
+const expandedBookingGroups = ref({})
+const bookingDialogGroups = computed(() => [
+	{
+		key: 'booked',
+		label: t('attendance', 'Scheduled ({count})', { count: bookingGroups.value.booked.length }),
+		names: bookingGroups.value.booked,
+	},
+	{
+		key: 'declined',
+		label: t('attendance', 'Not scheduled ({count})', { count: bookingGroups.value.declined.length }),
+		names: bookingGroups.value.declined,
+	},
+])
+const toggleBookingGroup = (key) => {
+	expandedBookingGroups.value[key] = !expandedBookingGroups.value[key]
+}
+const visibleBookingNames = (group) => (
+	expandedBookingGroups.value[group.key]
+		? group.names
+		: group.names.slice(0, BOOKING_PREVIEW_LIMIT)
+)
+
+const performToggleClosed = async (wantsClose) => {
+	if (togglingClosed.value) return
+	togglingClosed.value = true
 	const url = generateUrl(
 		`/apps/attendance/api/appointments/${props.appointment.id}/${wantsClose ? 'close' : 'reopen'}`,
 	)
@@ -755,6 +866,29 @@ const handleCommentInputEvent = () => {
 
 <style scoped lang="scss">
 @use "../../styles/shared.scss";
+
+.booking-confirm {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+
+    &__hint {
+        color: var(--color-text-maxcontrast);
+    }
+
+    &__group h4 {
+        margin: 0 0 4px;
+    }
+
+    &__names {
+        line-height: 1.5;
+    }
+
+    &__empty {
+        color: var(--color-text-maxcontrast);
+        font-style: italic;
+    }
+}
 
 .remind-target-choices {
     display: flex;

--- a/src/components/appointment/ResponseSummary.vue
+++ b/src/components/appointment/ResponseSummary.vue
@@ -130,7 +130,8 @@
 									v-if="canManageBooking && response.response === 'yes'"
 									class="booking-toggle"
 									:variant="response.bookingStatus === 'booked' ? 'success' : 'tertiary'"
-									:disabled="togglingBooking.has(response.userId)"
+									:disabled="togglingBooking.has(response.userId) || isClosed"
+									:title="isClosed ? t('attendance', 'Reopen the inquiry to change scheduling') : null"
 									:data-test="`booking-toggle-${response.userId}`"
 									@click="toggleBooking(response)">
 									<template #icon>
@@ -286,7 +287,8 @@
 									v-if="canManageBooking && response.response === 'yes'"
 									class="booking-toggle"
 									:variant="response.bookingStatus === 'booked' ? 'success' : 'tertiary'"
-									:disabled="togglingBooking.has(response.userId)"
+									:disabled="togglingBooking.has(response.userId) || isClosed"
+									:title="isClosed ? t('attendance', 'Reopen the inquiry to change scheduling') : null"
 									:data-test="`booking-toggle-${response.userId}`"
 									@click="toggleBooking(response)">
 									<template #icon>
@@ -431,7 +433,8 @@
 									v-if="canManageBooking && response.response === 'yes'"
 									class="booking-toggle"
 									:variant="response.bookingStatus === 'booked' ? 'success' : 'tertiary'"
-									:disabled="togglingBooking.has(response.userId)"
+									:disabled="togglingBooking.has(response.userId) || isClosed"
+									:title="isClosed ? t('attendance', 'Reopen the inquiry to change scheduling') : null"
 									:data-test="`booking-toggle-${response.userId}`"
 									@click="toggleBooking(response)">
 									<template #icon>

--- a/tests/unit/Service/AppointmentServiceTest.php
+++ b/tests/unit/Service/AppointmentServiceTest.php
@@ -11,6 +11,7 @@ use OCA\Attendance\Db\AttendanceResponse;
 use OCA\Attendance\Db\AttendanceResponseMapper;
 use OCA\Attendance\Service\AppointmentService;
 use OCA\Attendance\Service\AttachmentService;
+use OCA\Attendance\Service\BookingService;
 use OCA\Attendance\Service\AuditEventService;
 use OCA\Attendance\Service\ConfigService;
 use OCA\Attendance\Service\GuestService;
@@ -65,6 +66,9 @@ class AppointmentServiceTest extends TestCase {
 	/** @var AuditEventService|MockObject */
 	private $auditEventService;
 
+	/** @var BookingService|MockObject */
+	private $bookingService;
+
 	private AppointmentService $service;
 
 	protected function setUp(): void {
@@ -81,6 +85,7 @@ class AppointmentServiceTest extends TestCase {
 		$this->appManager = $this->createMock(IAppManager::class);
 		$this->guestService = $this->createMock(GuestService::class);
 		$this->auditEventService = $this->createMock(AuditEventService::class);
+		$this->bookingService = $this->createMock(BookingService::class);
 
 		$this->service = new AppointmentService(
 			$this->appointmentMapper,
@@ -96,6 +101,7 @@ class AppointmentServiceTest extends TestCase {
 			$this->appManager,
 			$this->guestService,
 			$this->auditEventService,
+			$this->bookingService,
 		);
 	}
 

--- a/tests/unit/Service/BookingServiceTest.php
+++ b/tests/unit/Service/BookingServiceTest.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 namespace OCA\Attendance\Tests\Unit\Service;
 
+use OCA\Attendance\Db\Appointment;
 use OCA\Attendance\Db\AppointmentMapper;
 use OCA\Attendance\Db\AttendanceResponse;
 use OCA\Attendance\Db\AttendanceResponseMapper;
 use OCA\Attendance\Service\BookingService;
 use OCA\Attendance\Service\ConfigService;
+use OCA\Attendance\Service\NotificationService;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -19,17 +21,33 @@ class BookingServiceTest extends TestCase {
 	private $appointmentMapper;
 	/** @var ConfigService|MockObject */
 	private $configService;
+	/** @var NotificationService|MockObject */
+	private $notificationService;
 	private BookingService $service;
 
 	protected function setUp(): void {
 		$this->responseMapper = $this->createMock(AttendanceResponseMapper::class);
 		$this->appointmentMapper = $this->createMock(AppointmentMapper::class);
 		$this->configService = $this->createMock(ConfigService::class);
+		$this->notificationService = $this->createMock(NotificationService::class);
 		$this->service = new BookingService(
 			$this->responseMapper,
 			$this->appointmentMapper,
 			$this->configService,
+			$this->notificationService,
 		);
+		// Default: an open appointment, so the happy-path booking tests aren't
+		// tripped by the closed-inquiry guard.
+		$this->appointmentMapper->method('find')->willReturn(new Appointment());
+	}
+
+	private function response(string $userId, string $answer, ?string $booking = null, ?string $notified = null): AttendanceResponse {
+		$r = new AttendanceResponse();
+		$r->setUserId($userId);
+		$r->setResponse($answer);
+		$r->setBookingStatus($booking);
+		$r->setBookingNotifiedStatus($notified);
+		return $r;
 	}
 
 	private function yesResponse(): AttendanceResponse {
@@ -78,6 +96,26 @@ class BookingServiceTest extends TestCase {
 		$this->service->setBookingStatus(5, 'alice', 'planned');
 	}
 
+	public function testBookRejectedOnClosedInquiry(): void {
+		// A separate mapper so the closed appointment isn't shadowed by setUp's
+		// default open one.
+		$closedAppointment = new Appointment();
+		$closedAppointment->setClosedAt('2026-01-01 10:00:00');
+		$appointmentMapper = $this->createMock(AppointmentMapper::class);
+		$appointmentMapper->method('find')->with(5)->willReturn($closedAppointment);
+		$service = new BookingService(
+			$this->responseMapper,
+			$appointmentMapper,
+			$this->configService,
+			$this->notificationService,
+		);
+		// Reject before touching the response, and never persist.
+		$this->responseMapper->expects($this->never())->method('update');
+
+		$this->expectException(\InvalidArgumentException::class);
+		$service->book(5, 'alice');
+	}
+
 	public function testBookIsIdempotent(): void {
 		$response = $this->yesResponse();
 		$response->setBookingStatus(BookingService::STATUS_BOOKED);
@@ -91,5 +129,72 @@ class BookingServiceTest extends TestCase {
 	public function testIsEnabledReflectsConfig(): void {
 		$this->configService->method('isBookingEnabled')->willReturn(true);
 		$this->assertTrue($this->service->isEnabled());
+	}
+
+	public function testNotifyOnCloseSkippedWhenFeatureDisabled(): void {
+		$this->configService->method('isBookingEnabled')->willReturn(false);
+		$this->responseMapper->expects($this->never())->method('findByAppointment');
+		$this->notificationService->expects($this->never())->method('sendBookingNotification');
+
+		$sent = $this->service->notifyOnClose($this->appointment());
+		$this->assertSame(['booked' => 0, 'declined' => 0], $sent);
+	}
+
+	public function testNotifyOnCloseSkippedWhenNobodyBooked(): void {
+		$this->configService->method('isBookingEnabled')->willReturn(true);
+		// Two yes-responders, none booked → no wave, closing stays silent.
+		$this->responseMapper->method('findByAppointment')->willReturn([
+			$this->response('alice', 'yes'),
+			$this->response('bob', 'yes'),
+		]);
+		$this->notificationService->expects($this->never())->method('sendBookingNotification');
+		$this->responseMapper->expects($this->never())->method('update');
+
+		$sent = $this->service->notifyOnClose($this->appointment());
+		$this->assertSame(['booked' => 0, 'declined' => 0], $sent);
+	}
+
+	public function testNotifyOnCloseNotifiesBookedAndDeclined(): void {
+		$this->configService->method('isBookingEnabled')->willReturn(true);
+		$this->responseMapper->method('findByAppointment')->willReturn([
+			$this->response('alice', 'yes', BookingService::STATUS_BOOKED),
+			$this->response('bob', 'yes'), // yes but not booked → declined
+			$this->response('carol', 'no'), // ignored (not yes)
+		]);
+
+		$calls = [];
+		$this->notificationService->method('sendBookingNotification')
+			->willReturnCallback(function ($appt, $userId, $status) use (&$calls): void {
+				$calls[$userId] = $status;
+			});
+		$this->responseMapper->expects($this->exactly(2))->method('update')->willReturnArgument(0);
+
+		$sent = $this->service->notifyOnClose($this->appointment());
+		$this->assertSame(['booked' => 1, 'declined' => 1], $sent);
+		$this->assertSame(BookingService::STATUS_BOOKED, $calls['alice']);
+		$this->assertSame(BookingService::STATUS_DECLINED, $calls['bob']);
+		$this->assertArrayNotHasKey('carol', $calls);
+	}
+
+	public function testNotifyOnCloseIsReopenSafeNoDuplicate(): void {
+		$this->configService->method('isBookingEnabled')->willReturn(true);
+		// Everyone already got their last-communicated status → re-close is silent.
+		$this->responseMapper->method('findByAppointment')->willReturn([
+			$this->response('alice', 'yes', BookingService::STATUS_BOOKED, BookingService::STATUS_BOOKED),
+			$this->response('bob', 'yes', null, BookingService::STATUS_DECLINED),
+		]);
+		$this->notificationService->expects($this->never())->method('sendBookingNotification');
+		$this->responseMapper->expects($this->never())->method('update');
+
+		$sent = $this->service->notifyOnClose($this->appointment());
+		$this->assertSame(['booked' => 0, 'declined' => 0], $sent);
+	}
+
+	private function appointment(): Appointment {
+		$a = new Appointment();
+		$a->setId(5);
+		$a->setName('Team sync');
+		$a->setStartDatetime('2026-07-20 10:00:00');
+		return $a;
 	}
 }


### PR DESCRIPTION
Closing with >=1 planned-in person notifies planned-in and not-planned-in yes-responders. Fires only when >=1 booked (else close is unchanged) and is reopen-safe (diffs against the last communicated state — no duplicates). Web: close-confirmation dialog with two named groups, collapsible above 10. +4 tests.

Closes #79
Stacked on #78.