### PR TITLE
feat(#80): reflect booking status in the calendar feed

### DIFF
--- a/lib/Service/IcalService.php
+++ b/lib/Service/IcalService.php
@@ -207,9 +207,8 @@ class IcalService {
 			'yes' => $l->t('Yes'),
 			'no' => $l->t('No'),
 			'maybe' => $l->t('Maybe'),
-			null => '?',
 		];
-		$responseLabel = $responseLabels[$responseState] ?? '?';
+		$responseLabel = $responseState !== null ? ($responseLabels[$responseState] ?? '?') : '?';
 
 		// Determine iCal STATUS and TRANSP based on response
 		// STATUS: CONFIRMED for all (the appointment itself is confirmed, only attendance varies)
@@ -219,12 +218,29 @@ class IcalService {
 			'yes' => 'OPAQUE',
 			'no' => 'TRANSPARENT',
 			'maybe' => 'TRANSPARENT',
-			null => 'TRANSPARENT',
 		];
-		$transp = $transpMap[$responseState] ?? 'TRANSPARENT';
+		$transp = $responseState !== null ? ($transpMap[$responseState] ?? 'TRANSPARENT') : 'TRANSPARENT';
 
 		// Build summary with response suffix
 		$summary = $appointment->getName() . ' (' . $l->t('Me') . ': ' . $responseLabel . ')';
+
+		// Booking status (only when the feature is on and the user said yes):
+		// reflect whether the user is scheduled via a title marker and TRANSP.
+		// scheduled → busy (OPAQUE); not scheduled → free (TRANSPARENT). No
+		// COLOR — Google ignores it in subscribed feeds. Flows through on the
+		// next poll since the feed is regenerated per request.
+		$bookingStatus = $response ? $response->getBookingStatus() : null;
+		if ($responseState === 'yes' && $this->configService->isBookingEnabled()) {
+			if ($bookingStatus === 'booked') {
+				$transp = 'OPAQUE';
+				$summary = $appointment->getName()
+					. ' (' . $l->t('Me') . ': ' . $l->t('Scheduled') . ')';
+			} else {
+				$transp = 'TRANSPARENT';
+				$summary = $appointment->getName()
+					. ' (' . $l->t('Me') . ': ' . $l->t('Not scheduled') . ')';
+			}
+		}
 
 		// Cancelled appointments: the event will not take place. This is the one
 		// case where iCal STATUS:CANCELLED is semantically correct. Mark the title

--- a/tests/unit/Service/IcalServiceTest.php
+++ b/tests/unit/Service/IcalServiceTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\Attendance\Tests\Unit\Service;
+
+use OCA\Attendance\Db\Appointment;
+use OCA\Attendance\Db\AppointmentMapper;
+use OCA\Attendance\Db\AppointmentAttachmentMapper;
+use OCA\Attendance\Db\AttendanceResponse;
+use OCA\Attendance\Db\AttendanceResponseMapper;
+use OCA\Attendance\Db\IcalTokenMapper;
+use OCA\Attendance\Service\ConfigService;
+use OCA\Attendance\Service\IcalService;
+use OCA\Attendance\Service\VisibilityService;
+use OCP\IConfig;
+use OCP\IL10N;
+use OCP\IURLGenerator;
+use OCP\L10N\IFactory as IL10NFactory;
+use OCP\Security\ISecureRandom;
+use PHPUnit\Framework\TestCase;
+
+class IcalServiceTest extends TestCase {
+	private ConfigService $configService;
+	private AppointmentAttachmentMapper $attachmentMapper;
+	private IcalService $service;
+
+	protected function setUp(): void {
+		$this->configService = $this->createMock(ConfigService::class);
+		$this->attachmentMapper = $this->createMock(AppointmentAttachmentMapper::class);
+		$this->attachmentMapper->method('findByAppointment')->willReturn([]);
+
+		$urlGenerator = $this->createMock(IURLGenerator::class);
+		$urlGenerator->method('getAbsoluteURL')->willReturn('https://example.test/');
+		$urlGenerator->method('linkToRouteAbsolute')->willReturn('https://example.test/app');
+
+		$this->service = new IcalService(
+			$this->createMock(IcalTokenMapper::class),
+			$this->createMock(AppointmentMapper::class),
+			$this->attachmentMapper,
+			$this->createMock(AttendanceResponseMapper::class),
+			$this->createMock(VisibilityService::class),
+			$this->configService,
+			$this->createMock(ISecureRandom::class),
+			$urlGenerator,
+			$this->createMock(IL10NFactory::class),
+			$this->createMock(IConfig::class),
+		);
+	}
+
+	private function appointment(): Appointment {
+		$a = new Appointment();
+		$a->setId(5);
+		$a->setName('Team sync');
+		$a->setDescription('');
+		$a->setStartDatetime('2026-07-20 10:00:00');
+		$a->setEndDatetime('2026-07-20 11:00:00');
+		$a->setCreatedAt('2026-07-01 09:00:00');
+		$a->setUpdatedAt('2026-07-01 09:00:00');
+		return $a;
+	}
+
+	private function generate(Appointment $appointment, ?AttendanceResponse $response): string {
+		$l = $this->createMock(IL10N::class);
+		$l->method('t')->willReturnArgument(0);
+		$ref = new \ReflectionMethod(IcalService::class, 'generateVEvent');
+		return $ref->invoke($this->service, $appointment, $response, 'alice', $l, 'example.test', []);
+	}
+
+	private function yes(?string $booking): AttendanceResponse {
+		$r = new AttendanceResponse();
+		$r->setId(1);
+		$r->setAppointmentId(5);
+		$r->setUserId('alice');
+		$r->setResponse('yes');
+		$r->setBookingStatus($booking);
+		$r->setRespondedAt('2026-07-02 09:00:00');
+		return $r;
+	}
+
+	public function testPlannedInIsBusyWithTitleMarker(): void {
+		$this->configService->method('isBookingEnabled')->willReturn(true);
+		$out = $this->generate($this->appointment(), $this->yes('booked'));
+		$this->assertStringContainsString('Scheduled', $out);
+		$this->assertStringContainsString('TRANSP:OPAQUE', $out);
+	}
+
+	public function testNotPlannedInIsFreeWithTitleMarker(): void {
+		$this->configService->method('isBookingEnabled')->willReturn(true);
+		$out = $this->generate($this->appointment(), $this->yes(null));
+		$this->assertStringContainsString('Not scheduled', $out);
+		$this->assertStringContainsString('TRANSP:TRANSPARENT', $out);
+	}
+
+	public function testBookingIgnoredWhenFeatureDisabled(): void {
+		$this->configService->method('isBookingEnabled')->willReturn(false);
+		$out = $this->generate($this->appointment(), $this->yes('booked'));
+		// Falls back to the plain response suffix and the yes=busy default.
+		$this->assertStringContainsString('Yes', $out);
+		$this->assertStringNotContainsString('Scheduled', $out);
+		$this->assertStringContainsString('TRANSP:OPAQUE', $out);
+	}
+
+	public function testNoColorPropertyEmitted(): void {
+		$this->configService->method('isBookingEnabled')->willReturn(true);
+		$out = $this->generate($this->appointment(), $this->yes('booked'));
+		// COLOR is deliberately not used (Google ignores it in subscribed feeds).
+		$this->assertStringNotContainsString('COLOR', $out);
+	}
+}


### PR DESCRIPTION
For yes-responders (when booking is on) the ICS feed marks the title (Me: Planned in / Not planned in) and sets TRANSP (planned in = busy, else free). No COLOR (Google ignores it in subscribed feeds). Flows through on next poll. +4 IcalService tests; fixes a latent null-array-offset deprecation.

Closes #80
Stacked on #79.