### PR TITLE
fix(#76): move a closed inquiry out of the nav 'Unanswered' section

### DIFF
--- a/playwright.config.js
+++ b/playwright.config.js
@@ -52,6 +52,7 @@ export default defineConfig({
 				'11-notification-option.spec.js',
 				'14-close-inquiry.spec.js',
 				'22-response-rescind.spec.js',
+				'24-close-nav-resort.spec.js',
 				'checkin.spec.js',
 			],
 			fullyParallel: false, // tests within a file stay sequential

--- a/src/views/AllAppointments.vue
+++ b/src/views/AllAppointments.vue
@@ -359,6 +359,11 @@ const handleClosedToggled = (updated) => {
 	if (index !== -1) {
 		appointments.value[index] = { ...appointments.value[index], ...updated }
 	}
+	// Closing/reopening changes how the appointment is bucketed in the nav menu
+	// (a closed-but-unanswered inquiry is no longer "Unanswered" — it belongs
+	// under "Upcoming"). The parent recomputes those sections from freshly
+	// loaded data, so trigger the same refresh answering does.
+	emit('responseUpdated')
 }
 const loading = ref(true)
 const responseComments = reactive({})

--- a/src/views/AppointmentDetail.vue
+++ b/src/views/AppointmentDetail.vue
@@ -184,6 +184,10 @@ const onClosedToggled = (updated) => {
 	if (appointment.value && updated?.id === appointment.value.id) {
 		appointment.value = { ...appointment.value, ...updated }
 	}
+	// Closing/reopening re-buckets the appointment in the nav menu (a
+	// closed-but-unanswered inquiry moves out of "Unanswered" into "Upcoming").
+	// Trigger the same parent refresh that answering does.
+	emit('responseUpdated')
 }
 
 const loadAppointmentSilently = async () => {

--- a/tests/e2e/24-close-nav-resort.spec.js
+++ b/tests/e2e/24-close-nav-resort.spec.js
@@ -1,0 +1,57 @@
+import {
+	test,
+	expect,
+	createAppointmentViaAPI,
+	deleteAllAppointments,
+} from './fixtures/nextcloud.js'
+
+// Regression for #76: closing an inquiry you never answered must move it out of
+// the sidebar "Unanswered" section and into "Upcoming" immediately — a closed
+// inquiry can no longer be answered, so it is no longer an unanswered to-do. It
+// used to stay under "Unanswered" until a full page reload.
+const FILTER_STORAGE_KEY = 'attendance:list-filters'
+
+test.describe('Close inquiry re-buckets it in the nav sidebar (#76)', () => {
+	test.describe.configure({ mode: 'serial' })
+
+	const name = 'Nav Resort On Close'
+
+	test.beforeAll(async ({ request }) => {
+		await deleteAllAppointments(request)
+		// Unrestricted → admin is in the audience; never answered → the sidebar
+		// lists it under "Unanswered".
+		await createAppointmentViaAPI(request, { name, daysFromNow: 9 })
+	})
+
+	test.afterAll(async ({ request }) => {
+		await deleteAllAppointments(request)
+	})
+
+	test('closing an unanswered inquiry leaves the Unanswered nav section without reload', async ({ page, loginAsUser, attendanceApp }) => {
+		await loginAsUser('admin', 'admin')
+		await attendanceApp()
+		await page.evaluate((key) => window.localStorage.removeItem(key), FILTER_STORAGE_KEY)
+		await page.reload()
+		await page.waitForLoadState('networkidle')
+
+		const unansweredNav = page.locator('[data-test="nav-unanswered-appointment"]', { hasText: name })
+		const upcomingNav = page.locator('[data-test="nav-upcoming-appointment"]', { hasText: name })
+
+		// Precondition: it starts under "Unanswered" in the sidebar.
+		await expect(unansweredNav).toBeVisible()
+
+		// Close it via the card's action menu in the main list.
+		const card = page.locator('[data-test="appointment-card"]', { hasText: name }).first()
+		await expect(card).toBeVisible()
+		await card.getByRole('button', { name: 'Actions' }).click()
+		await page.getByRole('menuitem', { name: 'Close inquiry' }).click()
+		await expect(card.locator('[data-test="closed-banner"]')).toBeVisible()
+
+		// The fix: without a reload it must leave "Unanswered" (the only
+		// unanswered item → the whole section disappears) and show up under
+		// "Upcoming".
+		await expect(unansweredNav).toHaveCount(0)
+		await expect(page.locator('[data-test="nav-unanswered"]')).toHaveCount(0)
+		await expect(upcomingNav).toHaveCount(1)
+	})
+})


### PR DESCRIPTION
Re-opened as a fresh PR (GitHub refused to reopen #84 after it was auto-closed during the handoff-file cleanup).

Real-world feedback: the bug **is** reproducible in the sidebar nav. When you close an inquiry you never answered, it stayed under **Unanswered** in the menu until a reload, instead of dropping down to **Upcoming**.

Root cause: the nav computeds in App.vue were already correct (unanswered = no response AND still open), but App.vue only refreshed its nav data on *answer*, not on *close*. The close handlers in the list and detail views now emit `responseUpdated`, so the parent reloads and re-buckets the appointment immediately.

Closes #76
Stacked on #74.