### PR TITLE
feat: QR/NFC self-checkin (app-only) with landing page and admin QR tools

### DIFF
--- a/lib/Audit/Verb.php
+++ b/lib/Audit/Verb.php
@@ -63,6 +63,7 @@ final class Verb {
 	public const SOURCE_APP = 'app';
 	public const SOURCE_QUICK_LINK = 'quick_link';
 	public const SOURCE_ADMIN_CHECKIN = 'admin_checkin';
+	public const SOURCE_SELF_CHECKIN = 'self_checkin';
 	public const SOURCE_LEGACY_BACKFILL = 'legacy_backfill';
 	public const SOURCE_AUTO_CLOSE = 'auto_close';
 

--- a/lib/Controller/AdminController.php
+++ b/lib/Controller/AdminController.php
@@ -146,6 +146,7 @@ class AdminController extends Controller {
 					'pushEnabled' => $this->configService->isPushEnabled(),
 					'mobileAppBannerEnabled' => $this->configService->isMobileAppBannerEnabled(),
 					'bookingEnabled' => $this->configService->isBookingEnabled(),
+					'selfCheckinWindowMinutes' => $this->configService->getSelfCheckinWindowMinutes(),
 					'guestsApp' => [
 						'enabled' => $this->guestService->isGuestsAppEnabled(),
 						'whitelistEnabled' => $this->guestService->isGuestsWhitelistEnabled(),
@@ -177,6 +178,7 @@ class AdminController extends Controller {
 	 * @param ?bool $pushEnabled Whether push notifications are enabled
 	 * @param ?bool $mobileAppBannerEnabled Whether the mobile app promotion banner is enabled
 	 * @param ?bool $bookingEnabled Whether the booking / planning feature is enabled
+	 * @param ?int $selfCheckinWindowMinutes Minutes before appointment start that self-check-in opens
 	 * @return DataResponse<Http::STATUS_OK, array<string, mixed>, array{}>|DataResponse<Http::STATUS_UNAUTHORIZED, array{error: string}, array{}>|DataResponse<Http::STATUS_FORBIDDEN, array{error: string}, array{}>|DataResponse<Http::STATUS_INTERNAL_SERVER_ERROR, array{error: string}, array{}>
 	 */
 	#[NoCSRFRequired]
@@ -192,6 +194,7 @@ class AdminController extends Controller {
 		?bool $pushEnabled = null,
 		?bool $mobileAppBannerEnabled = null,
 		?bool $bookingEnabled = null,
+		?int $selfCheckinWindowMinutes = null,
 	): DataResponse {
 		// Get current user
 		$user = $this->userSession->getUser();
@@ -258,6 +261,10 @@ class AdminController extends Controller {
 
 			if ($bookingEnabled !== null) {
 				$this->configService->setBookingEnabled($bookingEnabled);
+			}
+
+			if ($selfCheckinWindowMinutes !== null) {
+				$this->configService->setSelfCheckinWindowMinutes($selfCheckinWindowMinutes);
 			}
 
 			return new DataResponse([]);

--- a/lib/Controller/AppointmentController.php
+++ b/lib/Controller/AppointmentController.php
@@ -875,6 +875,9 @@ class AppointmentController extends Controller {
 			// True when the audit log + response-change notifications feature
 			// is enabled. Clients hide the timeline tab when this is false.
 			'auditLog' => $this->configService->isAuditLogEnabled(),
+			// Server supports QR/NFC self-check-in (method param + overview
+			// endpoint). Mobile clients hide the scan UI when this is false.
+			'selfCheckin' => true,
 		]);
 	}
 

--- a/lib/Controller/SelfCheckinController.php
+++ b/lib/Controller/SelfCheckinController.php
@@ -13,6 +13,7 @@ use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\Attribute\OpenAPI;
+use OCP\AppFramework\Http\Attribute\PublicPage;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\IRequest;
@@ -48,11 +49,12 @@ class SelfCheckinController extends Controller {
 	}
 
 	/**
-	 * Get active appointments for self-check-in
+	 * Get the self-check-in overview
 	 *
-	 * Returns active appointments the current user can self-check into right now.
+	 * Returns active appointments the current user can self-check into right now,
+	 * plus the next upcoming appointment whose check-in window has not opened yet.
 	 *
-	 * @return DataResponse<Http::STATUS_OK, list<AttendanceSelfCheckinAppointment>, array{}>|DataResponse<Http::STATUS_UNAUTHORIZED, array{error: string}, array{}>|DataResponse<Http::STATUS_FORBIDDEN, array{error: string}, array{}>|DataResponse<Http::STATUS_INTERNAL_SERVER_ERROR, array{error: string}, array{}>
+	 * @return DataResponse<Http::STATUS_OK, AttendanceSelfCheckinOverview, array{}>|DataResponse<Http::STATUS_UNAUTHORIZED, array{error: string}, array{}>|DataResponse<Http::STATUS_FORBIDDEN, array{error: string}, array{}>|DataResponse<Http::STATUS_INTERNAL_SERVER_ERROR, array{error: string}, array{}>
 	 */
 	#[NoAdminRequired]
 	#[NoCSRFRequired]
@@ -69,8 +71,8 @@ class SelfCheckinController extends Controller {
 		}
 
 		try {
-			$appointments = $this->selfCheckinService->getActiveAppointments($user->getUID());
-			return new DataResponse($appointments);
+			$overview = $this->selfCheckinService->getOverview($user->getUID());
+			return new DataResponse($overview);
 		} catch (\Exception $e) {
 			$this->logger->error('Self-checkin: failed to get active appointments: ' . $e->getMessage());
 			return new DataResponse(
@@ -84,12 +86,13 @@ class SelfCheckinController extends Controller {
 	 * Self-check-in to a specific appointment
 	 *
 	 * @param int $appointmentId ID of the appointment to check into
+	 * @param string $method How the check-in was triggered: qr or nfc
 	 * @return DataResponse<Http::STATUS_OK, AttendanceSelfCheckinResult, array{}>|DataResponse<Http::STATUS_BAD_REQUEST, array{error: string}, array{}>|DataResponse<Http::STATUS_UNAUTHORIZED, array{error: string}, array{}>|DataResponse<Http::STATUS_FORBIDDEN, array{error: string}, array{}>|DataResponse<Http::STATUS_INTERNAL_SERVER_ERROR, array{error: string}, array{}>
 	 */
 	#[NoAdminRequired]
 	#[NoCSRFRequired]
 	#[OpenAPI(OpenAPI::SCOPE_DEFAULT)]
-	public function checkin(int $appointmentId): DataResponse {
+	public function checkin(int $appointmentId, string $method = 'qr'): DataResponse {
 		$user = $this->requireUser();
 		if ($user instanceof DataResponse) {
 			return $user;
@@ -101,7 +104,7 @@ class SelfCheckinController extends Controller {
 		}
 
 		try {
-			$result = $this->selfCheckinService->selfCheckin($appointmentId, $user->getUID());
+			$result = $this->selfCheckinService->selfCheckin($appointmentId, $user->getUID(), $method);
 			return new DataResponse($result);
 		} catch (\InvalidArgumentException $e) {
 			return new DataResponse(
@@ -119,13 +122,12 @@ class SelfCheckinController extends Controller {
 
 	/**
 	 * GET /self-checkin
-	 * Web fallback page — shows active appointments with check-in buttons.
-	 * For users who scanned the NFC sticker but don't have the app.
-	 *
-	 * @NoAdminRequired
-	 * @NoCSRFRequired
+	 * Landing page for scanned QR codes / NFC tags. Self-check-in itself is
+	 * app-only — this page tells visitors to get the mobile app and offers a
+	 * deep link that opens it directly. Public so a scan without an active
+	 * browser session still lands on the funnel instead of a login wall.
 	 */
-	#[NoAdminRequired]
+	#[PublicPage]
 	#[NoCSRFRequired]
 	#[OpenAPI(OpenAPI::SCOPE_IGNORE)]
 	public function showPage(): TemplateResponse {
@@ -136,7 +138,7 @@ class SelfCheckinController extends Controller {
 			Application::APP_ID,
 			'selfcheckin',
 			[],
-			'user'
+			'guest'
 		);
 	}
 }

--- a/lib/Db/AppointmentMapper.php
+++ b/lib/Db/AppointmentMapper.php
@@ -176,6 +176,7 @@ class AppointmentMapper extends QBMapper {
 			->where(
 				$qb->expr()->andX(
 					$qb->expr()->eq('is_active', $qb->createNamedParameter(1, IQueryBuilder::PARAM_INT)),
+					$qb->expr()->isNull('cancelled_at'),
 					// start_datetime <= NOW + windowMinutes (appointment has started or starts soon)
 					$qb->expr()->lte('start_datetime', $qb->createNamedParameter($now->modify("+{$windowMinutes} minutes")->format('Y-m-d H:i:s'))),
 					// end_datetime >= NOW (appointment hasn't ended yet)
@@ -183,6 +184,34 @@ class AppointmentMapper extends QBMapper {
 				)
 			)
 			->orderBy('start_datetime', 'ASC');
+
+		return $this->findEntities($qb);
+	}
+
+	/**
+	 * Find the next active, non-cancelled appointments whose self-check-in
+	 * window has not opened yet (start_datetime > now + window). Limited,
+	 * because the caller only needs the first one visible to a user.
+	 *
+	 * @return array<Appointment>
+	 */
+	public function findUpcomingOutsideWindow(int $windowMinutes, int $limit = 25): array {
+		$qb = $this->db->getQueryBuilder();
+
+		$windowEdge = (new \DateTime('now', new \DateTimeZone('UTC')))
+			->modify("+{$windowMinutes} minutes");
+
+		$qb->select('*')
+			->from($this->getTableName())
+			->where(
+				$qb->expr()->andX(
+					$qb->expr()->eq('is_active', $qb->createNamedParameter(1, IQueryBuilder::PARAM_INT)),
+					$qb->expr()->isNull('cancelled_at'),
+					$qb->expr()->gt('start_datetime', $qb->createNamedParameter($windowEdge->format('Y-m-d H:i:s')))
+				)
+			)
+			->orderBy('start_datetime', 'ASC')
+			->setMaxResults($limit);
 
 		return $this->findEntities($qb);
 	}

--- a/lib/ResponseDefinitions.php
+++ b/lib/ResponseDefinitions.php
@@ -150,6 +150,7 @@ namespace OCA\Attendance;
  *   responseToggle: bool,
  *   guestInvitation: bool,
  *   auditLog: bool,
+ *   selfCheckin: bool,
  * }
  * @psalm-type AttendanceAuditUserRef = array{
  *   userId: string,
@@ -201,6 +202,7 @@ namespace OCA\Attendance;
  *   pushEnabled: bool,
  *   mobileAppBannerEnabled: bool,
  *   bookingEnabled: bool,
+ *   selfCheckinWindowMinutes: int,
  *   guestsApp: AttendanceGuestsAppStatus,
  * }
  * @psalm-type AttendanceAdminStatus = array{
@@ -232,6 +234,16 @@ namespace OCA\Attendance;
  *   alreadyCheckedIn: bool,
  *   checkinState: ?string,
  *   checkinAt: ?string,
+ * }
+ * @psalm-type AttendanceSelfCheckinNextUpcoming = array{
+ *   id: int,
+ *   name: string,
+ *   startDatetime: string,
+ *   checkinWindowStartsAt: string,
+ * }
+ * @psalm-type AttendanceSelfCheckinOverview = array{
+ *   appointments: list<AttendanceSelfCheckinAppointment>,
+ *   nextUpcoming: ?AttendanceSelfCheckinNextUpcoming,
  * }
  * @psalm-type AttendanceSelfCheckinResult = array{
  *   appointment: AttendanceAppointmentData,

--- a/lib/Service/ConfigService.php
+++ b/lib/Service/ConfigService.php
@@ -278,6 +278,20 @@ class ConfigService {
 	}
 
 	/**
+	 * Minutes before an appointment starts that self-check-in opens.
+	 * The window always closes at the appointment end.
+	 */
+	public function getSelfCheckinWindowMinutes(): int {
+		$value = (int)$this->config->getAppValue(self::APP_ID, 'self_checkin_window_minutes', '30');
+		return max(0, min(1440, $value));
+	}
+
+	public function setSelfCheckinWindowMinutes(int $minutes): void {
+		$minutes = max(0, min(1440, $minutes));
+		$this->config->setAppValue(self::APP_ID, 'self_checkin_window_minutes', (string)$minutes);
+	}
+
+	/**
 	 * Get the push proxy server URL.
 	 * Configurable via occ: occ config:app:set attendance push_proxy_server --value="https://your-proxy.example.com"
 	 *

--- a/lib/Service/ConfigService.php
+++ b/lib/Service/ConfigService.php
@@ -287,7 +287,7 @@ class ConfigService {
 	}
 
 	public function setSelfCheckinWindowMinutes(int $minutes): void {
-		$minutes = max(0, min(1440, $minutes));
+		// No clamp here — the getter clamps, which also covers values set via occ.
 		$this->config->setAppValue(self::APP_ID, 'self_checkin_window_minutes', (string)$minutes);
 	}
 

--- a/lib/Service/SelfCheckinService.php
+++ b/lib/Service/SelfCheckinService.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace OCA\Attendance\Service;
 
+use OCA\Attendance\Audit\Verb;
+use OCA\Attendance\Db\Appointment;
 use OCA\Attendance\Db\AppointmentMapper;
 use OCA\Attendance\Db\AttendanceResponse;
 use OCA\Attendance\Db\AttendanceResponseMapper;
@@ -18,43 +20,57 @@ class SelfCheckinService {
 	private AppointmentMapper $appointmentMapper;
 	private AttendanceResponseMapper $responseMapper;
 	private VisibilityService $visibilityService;
+	private ConfigService $configService;
+	private AuditEventService $auditEventService;
 	private LoggerInterface $logger;
 
-	/** Default time window in minutes before appointment start to allow check-in */
-	private const DEFAULT_WINDOW_MINUTES = 30;
+	/** Valid trigger methods for a self-check-in, mirrored in checkin_source as "self_<method>" */
+	public const VALID_METHODS = ['qr', 'nfc'];
 
 	public function __construct(
 		AppointmentMapper $appointmentMapper,
 		AttendanceResponseMapper $responseMapper,
 		VisibilityService $visibilityService,
+		ConfigService $configService,
+		AuditEventService $auditEventService,
 		LoggerInterface $logger,
 	) {
 		$this->appointmentMapper = $appointmentMapper;
 		$this->responseMapper = $responseMapper;
 		$this->visibilityService = $visibilityService;
+		$this->configService = $configService;
+		$this->auditEventService = $auditEventService;
 		$this->logger = $logger;
 	}
 
 	/**
-	 * Get active appointments that a user can self-check into right now.
+	 * Get the self-check-in overview for a user: appointments that can be
+	 * checked into right now, plus the next upcoming appointment whose
+	 * check-in window has not opened yet (for the "nothing right now" screen).
 	 *
-	 * Returns appointments where:
-	 * - is_active = 1
-	 * - start_datetime - 30min <= NOW <= end_datetime
-	 * - User is a target attendee (via visibility settings)
+	 * An appointment is checkin-able when:
+	 * - is_active = 1 and not cancelled
+	 * - start_datetime - window <= NOW <= end_datetime
+	 * - the user is a target attendee (via visibility settings)
 	 *
 	 * @param string $userId The user ID
-	 * @return array List of appointment data with check-in status
+	 * @return array{appointments: list<array<string, mixed>>, nextUpcoming: ?array{id: int, name: string, startDatetime: string, checkinWindowStartsAt: string}}
 	 */
-	public function getActiveAppointments(string $userId): array {
-		$appointments = $this->appointmentMapper->findActiveInWindow(self::DEFAULT_WINDOW_MINUTES);
+	public function getOverview(string $userId): array {
+		$windowMinutes = $this->configService->getSelfCheckinWindowMinutes();
+		$appointments = $this->appointmentMapper->findActiveInWindow($windowMinutes);
 
 		$result = [];
+		$inWindowIds = [];
 		foreach ($appointments as $appointment) {
+			if ($appointment->isCancelled()) {
+				continue;
+			}
 			// Only include appointments where the user is a target attendee
 			if (!$this->visibilityService->isUserTargetAttendee($appointment, $userId)) {
 				continue;
 			}
+			$inWindowIds[] = $appointment->getId();
 
 			$appointmentData = $appointment->jsonSerialize();
 
@@ -74,7 +90,45 @@ class SelfCheckinService {
 			$result[] = $appointmentData;
 		}
 
-		return $result;
+		return [
+			'appointments' => $result,
+			'nextUpcoming' => $this->findNextUpcoming($userId, $windowMinutes, $inWindowIds),
+		];
+	}
+
+	/**
+	 * Find the next visible appointment whose check-in window has not opened
+	 * yet, so clients can show "check-in opens at …" when nothing matches now.
+	 *
+	 * @param list<int> $excludeIds appointments already offered for check-in
+	 * @return ?array{id: int, name: string, startDatetime: string, checkinWindowStartsAt: string}
+	 */
+	private function findNextUpcoming(string $userId, int $windowMinutes, array $excludeIds): ?array {
+		$now = new \DateTime('now', new \DateTimeZone('UTC'));
+		foreach ($this->appointmentMapper->findUpcoming() as $appointment) {
+			if ($appointment->isCancelled() || in_array($appointment->getId(), $excludeIds, true)) {
+				continue;
+			}
+			$windowStart = $this->getWindowStart($appointment, $windowMinutes);
+			if ($windowStart <= $now) {
+				continue;
+			}
+			if (!$this->visibilityService->isUserTargetAttendee($appointment, $userId)) {
+				continue;
+			}
+			return [
+				'id' => $appointment->getId(),
+				'name' => $appointment->getName(),
+				'startDatetime' => $appointment->getStartDatetime(),
+				'checkinWindowStartsAt' => $windowStart->format('Y-m-d H:i:s'),
+			];
+		}
+		return null;
+	}
+
+	private function getWindowStart(Appointment $appointment, int $windowMinutes): \DateTime {
+		$start = new \DateTime($appointment->getStartDatetime(), new \DateTimeZone('UTC'));
+		return $start->modify('-' . $windowMinutes . ' minutes');
 	}
 
 	/**
@@ -82,10 +136,15 @@ class SelfCheckinService {
 	 *
 	 * @param int $appointmentId The appointment ID
 	 * @param string $userId The user checking themselves in
+	 * @param string $method How the check-in was triggered ('qr' or 'nfc')
 	 * @return array Result with appointment details and check-in status
 	 * @throws \InvalidArgumentException If validation fails
 	 */
-	public function selfCheckin(int $appointmentId, string $userId): array {
+	public function selfCheckin(int $appointmentId, string $userId, string $method): array {
+		if (!in_array($method, self::VALID_METHODS, true)) {
+			throw new \InvalidArgumentException('Invalid check-in method.');
+		}
+
 		// Verify appointment exists and is active
 		try {
 			$appointment = $this->appointmentMapper->find($appointmentId);
@@ -93,15 +152,14 @@ class SelfCheckinService {
 			throw new \InvalidArgumentException('Appointment not found.');
 		}
 
-		if (!$appointment->getIsActive()) {
+		if (!$appointment->getIsActive() || $appointment->isCancelled()) {
 			throw new \InvalidArgumentException('Appointment is not active.');
 		}
 
 		// Verify appointment is within the check-in time window
 		$now = new \DateTime('now', new \DateTimeZone('UTC'));
-		$start = new \DateTime($appointment->getStartDatetime(), new \DateTimeZone('UTC'));
 		$end = new \DateTime($appointment->getEndDatetime(), new \DateTimeZone('UTC'));
-		$windowStart = (clone $start)->modify('-' . self::DEFAULT_WINDOW_MINUTES . ' minutes');
+		$windowStart = $this->getWindowStart($appointment, $this->configService->getSelfCheckinWindowMinutes());
 
 		if ($now < $windowStart || $now > $end) {
 			throw new \InvalidArgumentException('Appointment is not within the check-in time window.');
@@ -138,7 +196,7 @@ class SelfCheckinService {
 		$response->setCheckinState('yes');
 		$response->setCheckinBy($userId); // Self-check-in: checkinBy == userId
 		$response->setCheckinAt(gmdate('Y-m-d H:i:s'));
-		$response->setCheckinSource('nfc');
+		$response->setCheckinSource('self_' . $method);
 
 		if ($response->getId()) {
 			$this->responseMapper->update($response);
@@ -146,7 +204,16 @@ class SelfCheckinService {
 			$this->responseMapper->insert($response);
 		}
 
-		$this->logger->info("User {$userId} self-checked in to appointment {$appointmentId}");
+		$this->auditEventService->record(
+			Verb::CHECKIN_RECORDED,
+			$appointmentId,
+			$userId,
+			$userId,
+			['checkinState' => 'yes', 'method' => $method],
+			Verb::SOURCE_SELF_CHECKIN,
+		);
+
+		$this->logger->info("User {$userId} self-checked in to appointment {$appointmentId} via {$method}");
 
 		$responseData = $response->jsonSerialize();
 		return [

--- a/lib/Service/SelfCheckinService.php
+++ b/lib/Service/SelfCheckinService.php
@@ -25,7 +25,7 @@ class SelfCheckinService {
 	private LoggerInterface $logger;
 
 	/** Valid trigger methods for a self-check-in, mirrored in checkin_source as "self_<method>" */
-	public const VALID_METHODS = ['qr', 'nfc'];
+	private const VALID_METHODS = ['qr', 'nfc'];
 
 	public function __construct(
 		AppointmentMapper $appointmentMapper,
@@ -61,16 +61,11 @@ class SelfCheckinService {
 		$appointments = $this->appointmentMapper->findActiveInWindow($windowMinutes);
 
 		$result = [];
-		$inWindowIds = [];
 		foreach ($appointments as $appointment) {
-			if ($appointment->isCancelled()) {
-				continue;
-			}
 			// Only include appointments where the user is a target attendee
 			if (!$this->visibilityService->isUserTargetAttendee($appointment, $userId)) {
 				continue;
 			}
-			$inWindowIds[] = $appointment->getId();
 
 			$appointmentData = $appointment->jsonSerialize();
 
@@ -92,7 +87,11 @@ class SelfCheckinService {
 
 		return [
 			'appointments' => $result,
-			'nextUpcoming' => $this->findNextUpcoming($userId, $windowMinutes, $inWindowIds),
+			// Only needed for the "nothing right now" screen — skip the extra
+			// query when there is something to check into.
+			'nextUpcoming' => $result === []
+				? $this->findNextUpcoming($userId, $windowMinutes)
+				: null,
 		];
 	}
 
@@ -100,19 +99,10 @@ class SelfCheckinService {
 	 * Find the next visible appointment whose check-in window has not opened
 	 * yet, so clients can show "check-in opens at …" when nothing matches now.
 	 *
-	 * @param list<int> $excludeIds appointments already offered for check-in
 	 * @return ?array{id: int, name: string, startDatetime: string, checkinWindowStartsAt: string}
 	 */
-	private function findNextUpcoming(string $userId, int $windowMinutes, array $excludeIds): ?array {
-		$now = new \DateTime('now', new \DateTimeZone('UTC'));
-		foreach ($this->appointmentMapper->findUpcoming() as $appointment) {
-			if ($appointment->isCancelled() || in_array($appointment->getId(), $excludeIds, true)) {
-				continue;
-			}
-			$windowStart = $this->getWindowStart($appointment, $windowMinutes);
-			if ($windowStart <= $now) {
-				continue;
-			}
+	private function findNextUpcoming(string $userId, int $windowMinutes): ?array {
+		foreach ($this->appointmentMapper->findUpcomingOutsideWindow($windowMinutes) as $appointment) {
 			if (!$this->visibilityService->isUserTargetAttendee($appointment, $userId)) {
 				continue;
 			}
@@ -120,7 +110,7 @@ class SelfCheckinService {
 				'id' => $appointment->getId(),
 				'name' => $appointment->getName(),
 				'startDatetime' => $appointment->getStartDatetime(),
-				'checkinWindowStartsAt' => $windowStart->format('Y-m-d H:i:s'),
+				'checkinWindowStartsAt' => $this->getWindowStart($appointment, $windowMinutes)->format('Y-m-d H:i:s'),
 			];
 		}
 		return null;

--- a/openapi-administration.json
+++ b/openapi-administration.json
@@ -59,6 +59,7 @@
                     "pushEnabled",
                     "mobileAppBannerEnabled",
                     "bookingEnabled",
+                    "selfCheckinWindowMinutes",
                     "guestsApp"
                 ],
                 "properties": {
@@ -97,6 +98,10 @@
                     },
                     "bookingEnabled": {
                         "type": "boolean"
+                    },
+                    "selfCheckinWindowMinutes": {
+                        "type": "integer",
+                        "format": "int64"
                     },
                     "guestsApp": {
                         "$ref": "#/components/schemas/GuestsAppStatus"
@@ -176,7 +181,8 @@
                     "remindMaybe",
                     "responseToggle",
                     "guestInvitation",
-                    "auditLog"
+                    "auditLog",
+                    "selfCheckin"
                 ],
                 "properties": {
                     "calendarAvailable": {
@@ -213,6 +219,9 @@
                         "type": "boolean"
                     },
                     "auditLog": {
+                        "type": "boolean"
+                    },
+                    "selfCheckin": {
                         "type": "boolean"
                     }
                 }
@@ -542,6 +551,13 @@
                                         "nullable": true,
                                         "default": null,
                                         "description": "Whether the booking / planning feature is enabled"
+                                    },
+                                    "selfCheckinWindowMinutes": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "nullable": true,
+                                        "default": null,
+                                        "description": "Minutes before appointment start that self-check-in opens"
                                     }
                                 }
                             }

--- a/openapi-full.json
+++ b/openapi-full.json
@@ -59,6 +59,7 @@
                     "pushEnabled",
                     "mobileAppBannerEnabled",
                     "bookingEnabled",
+                    "selfCheckinWindowMinutes",
                     "guestsApp"
                 ],
                 "properties": {
@@ -97,6 +98,10 @@
                     },
                     "bookingEnabled": {
                         "type": "boolean"
+                    },
+                    "selfCheckinWindowMinutes": {
+                        "type": "integer",
+                        "format": "int64"
                     },
                     "guestsApp": {
                         "$ref": "#/components/schemas/GuestsAppStatus"
@@ -567,7 +572,8 @@
                     "remindMaybe",
                     "responseToggle",
                     "guestInvitation",
-                    "auditLog"
+                    "auditLog",
+                    "selfCheckin"
                 ],
                 "properties": {
                     "calendarAvailable": {
@@ -604,6 +610,9 @@
                         "type": "boolean"
                     },
                     "auditLog": {
+                        "type": "boolean"
+                    },
+                    "selfCheckin": {
                         "type": "boolean"
                     }
                 }
@@ -1090,6 +1099,53 @@
                     "checkinAt": {
                         "type": "string",
                         "nullable": true
+                    }
+                }
+            },
+            "SelfCheckinNextUpcoming": {
+                "type": "object",
+                "required": [
+                    "id",
+                    "name",
+                    "startDatetime",
+                    "checkinWindowStartsAt"
+                ],
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "startDatetime": {
+                        "type": "string"
+                    },
+                    "checkinWindowStartsAt": {
+                        "type": "string"
+                    }
+                }
+            },
+            "SelfCheckinOverview": {
+                "type": "object",
+                "required": [
+                    "appointments",
+                    "nextUpcoming"
+                ],
+                "properties": {
+                    "appointments": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/SelfCheckinAppointment"
+                        }
+                    },
+                    "nextUpcoming": {
+                        "nullable": true,
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/SelfCheckinNextUpcoming"
+                            }
+                        ]
                     }
                 }
             },
@@ -5295,8 +5351,8 @@
         "/index.php/apps/attendance/api/self-checkin/appointments": {
             "get": {
                 "operationId": "self_checkin-get-active-appointments",
-                "summary": "Get active appointments for self-check-in",
-                "description": "Returns active appointments the current user can self-check into right now.",
+                "summary": "Get the self-check-in overview",
+                "description": "Returns active appointments the current user can self-check into right now, plus the next upcoming appointment whose check-in window has not opened yet.",
                 "tags": [
                     "self_checkin"
                 ],
@@ -5314,10 +5370,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/SelfCheckinAppointment"
-                                    }
+                                    "$ref": "#/components/schemas/SelfCheckinOverview"
                                 }
                             }
                         }
@@ -5423,6 +5476,11 @@
                                         "type": "integer",
                                         "format": "int64",
                                         "description": "ID of the appointment to check into"
+                                    },
+                                    "method": {
+                                        "type": "string",
+                                        "default": "qr",
+                                        "description": "How the check-in was triggered: qr or nfc"
                                     }
                                 }
                             }
@@ -5778,6 +5836,13 @@
                                         "nullable": true,
                                         "default": null,
                                         "description": "Whether the booking / planning feature is enabled"
+                                    },
+                                    "selfCheckinWindowMinutes": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "nullable": true,
+                                        "default": null,
+                                        "description": "Minutes before appointment start that self-check-in opens"
                                     }
                                 }
                             }

--- a/openapi.json
+++ b/openapi.json
@@ -425,7 +425,8 @@
                     "remindMaybe",
                     "responseToggle",
                     "guestInvitation",
-                    "auditLog"
+                    "auditLog",
+                    "selfCheckin"
                 ],
                 "properties": {
                     "calendarAvailable": {
@@ -462,6 +463,9 @@
                         "type": "boolean"
                     },
                     "auditLog": {
+                        "type": "boolean"
+                    },
+                    "selfCheckin": {
                         "type": "boolean"
                     }
                 }
@@ -905,6 +909,53 @@
                     "checkinAt": {
                         "type": "string",
                         "nullable": true
+                    }
+                }
+            },
+            "SelfCheckinNextUpcoming": {
+                "type": "object",
+                "required": [
+                    "id",
+                    "name",
+                    "startDatetime",
+                    "checkinWindowStartsAt"
+                ],
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "startDatetime": {
+                        "type": "string"
+                    },
+                    "checkinWindowStartsAt": {
+                        "type": "string"
+                    }
+                }
+            },
+            "SelfCheckinOverview": {
+                "type": "object",
+                "required": [
+                    "appointments",
+                    "nextUpcoming"
+                ],
+                "properties": {
+                    "appointments": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/SelfCheckinAppointment"
+                        }
+                    },
+                    "nextUpcoming": {
+                        "nullable": true,
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/SelfCheckinNextUpcoming"
+                            }
+                        ]
                     }
                 }
             },
@@ -5079,8 +5130,8 @@
         "/index.php/apps/attendance/api/self-checkin/appointments": {
             "get": {
                 "operationId": "self_checkin-get-active-appointments",
-                "summary": "Get active appointments for self-check-in",
-                "description": "Returns active appointments the current user can self-check into right now.",
+                "summary": "Get the self-check-in overview",
+                "description": "Returns active appointments the current user can self-check into right now, plus the next upcoming appointment whose check-in window has not opened yet.",
                 "tags": [
                     "self_checkin"
                 ],
@@ -5098,10 +5149,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/SelfCheckinAppointment"
-                                    }
+                                    "$ref": "#/components/schemas/SelfCheckinOverview"
                                 }
                             }
                         }
@@ -5207,6 +5255,11 @@
                                         "type": "integer",
                                         "format": "int64",
                                         "description": "ID of the appointment to check into"
+                                    },
+                                    "method": {
+                                        "type": "string",
+                                        "default": "qr",
+                                        "description": "How the check-in was triggered: qr or nfc"
                                     }
                                 }
                             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "attendance",
-  "version": "1.36.0",
+  "version": "1.39.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "attendance",
-      "version": "1.36.0",
+      "version": "1.39.1",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@nextcloud/axios": "^2.5.1",
@@ -21,6 +21,7 @@
         "dompurify": "^3.3.1",
         "easymde": "^2.20.0",
         "marked": "^18.0.0",
+        "qrcode": "^1.5.4",
         "rrule": "^2.8.1",
         "vue": "^3.5.25",
         "vue-material-design-icons": "^5.3.1"
@@ -4417,7 +4418,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4427,7 +4427,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -5272,6 +5271,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/cancelable-promise": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/cancelable-promise/-/cancelable-promise-4.3.1.tgz",
@@ -5483,7 +5491,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -5496,7 +5503,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/colord": {
@@ -5944,6 +5950,15 @@
         }
       }
     },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/decode-named-character-reference": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
@@ -6081,6 +6096,12 @@
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
       "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dijkstrajs": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
+      "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
       "license": "MIT"
     },
     "node_modules/dir-glob": {
@@ -6317,7 +6338,6 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/end-of-stream": {
@@ -7823,7 +7843,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
@@ -8837,7 +8856,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -10879,6 +10897,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/package-name-regex": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/package-name-regex/-/package-name-regex-2.0.6.tgz",
@@ -10986,7 +11013,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -11155,6 +11181,15 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/pngjs": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/possible-typed-array-names": {
@@ -11442,6 +11477,155 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/qrcode": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
+      "integrity": "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "dijkstrajs": "^1.0.1",
+        "pngjs": "^5.0.0",
+        "yargs": "^15.3.1"
+      },
+      "bin": {
+        "qrcode": "bin/qrcode"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/qrcode/node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
+    "node_modules/qrcode/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/qrcode/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "license": "ISC"
+    },
+    "node_modules/qrcode/node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/qs": {
       "version": "6.15.1",
@@ -11736,7 +11920,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -11751,6 +11934,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "license": "ISC"
     },
     "node_modules/requireindex": {
       "version": "1.2.0",
@@ -12601,6 +12790,12 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "license": "ISC"
+    },
     "node_modules/set-function-length": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
@@ -13193,7 +13388,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -15579,6 +15773,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/which-module": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+      "license": "ISC"
     },
     "node_modules/which-typed-array": {
       "version": "1.1.20",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "dompurify": "^3.3.1",
     "easymde": "^2.20.0",
     "marked": "^18.0.0",
+    "qrcode": "^1.5.4",
     "rrule": "^2.8.1",
     "vue": "^3.5.25",
     "vue-material-design-icons": "^5.3.1"

--- a/src/views/AdminSettings.vue
+++ b/src/views/AdminSettings.vue
@@ -176,6 +176,11 @@
 						<p class="hint-text">
 							{{ t('attendance', 'NFC tag shopping advice: use NXP NTAG213 tags (or newer) of at least 25 mm, and on-metal tags for metal surfaces. Avoid MIFARE Classic tags — they do not work with iPhones.') }}
 						</p>
+						<p class="hint-text">
+							<a class="self-checkin-qr__app-link" href="#mobile-apps">
+								{{ t('attendance', 'You can also write NFC tags directly with the Attendance mobile app.') }}
+							</a>
+						</p>
 					</div>
 				</div>
 			</NcSettingsSection>
@@ -369,8 +374,9 @@
 				</NcCheckboxRadioSwitch>
 			</NcSettingsSection>
 
-			<NcSettingsSection :name="t('attendance', 'Mobile apps')"
-				:description="t('attendance', 'Share these links with your colleagues to install the Attendance mobile app.')">
+			<div id="mobile-apps">
+				<NcSettingsSection :name="t('attendance', 'Mobile apps')"
+					:description="t('attendance', 'Share these links with your colleagues to install the Attendance mobile app.')">
 				<div class="mobile-app-links">
 					<div v-for="store in mobileAppStores" :key="store.id" class="mobile-app-link">
 						<label class="mobile-app-link__label">
@@ -455,6 +461,7 @@
 					</template>
 				</div>
 			</NcSettingsSection>
+			</div>
 
 			<NcSettingsSection :name="t('attendance', 'Display options')"
 				:description="t('attendance', 'Choose how appointments are displayed across the app.')">
@@ -1049,6 +1056,11 @@ onMounted(async () => {
 		gap: 8px;
 		flex-wrap: wrap;
 		margin: 8px 0;
+	}
+
+	.self-checkin-qr__app-link {
+		color: var(--color-primary-element);
+		text-decoration: underline;
 	}
 }
 

--- a/src/views/AdminSettings.vue
+++ b/src/views/AdminSettings.vue
@@ -881,10 +881,7 @@ const downloadQrCode = () => {
 	link.click()
 }
 
-const copySelfCheckinUrl = () => copyToClipboard(selfCheckinUrl, {
-	successMessage: window.t('attendance', 'Link copied'),
-	errorMessage: window.t('attendance', 'Failed to copy link'),
-})
+const copySelfCheckinUrl = () => copyStoreUrl(selfCheckinUrl)
 
 const copyStoreUrl = (url) => copyToClipboard(url, {
 	successMessage: window.t('attendance', 'Link copied'),

--- a/src/views/AdminSettings.vue
+++ b/src/views/AdminSettings.vue
@@ -140,14 +140,17 @@
 						{{ n('attendance', '%n group selected', '%n groups selected', selectedSelfCheckinRoles.length, { n: selectedSelfCheckinRoles.length }) }}
 					</p>
 
-					<NcInputField
-						v-model.number="selfCheckinWindowMinutes"
-						type="number"
-						class="self-checkin-window-field"
-						:label="t('attendance', 'Check-in window (minutes before start)')"
-						:helper-text="t('attendance', 'How many minutes before an appointment starts attendees can check in. The window always closes when the appointment ends.')"
-						data-test="input-self-checkin-window"
-						:input-props="{ min: 0, max: 1440 }" />
+					<!-- Wrapper div: scoped attrs don't reach the NcInputField root,
+					     so the spacing lives on an own template element. -->
+					<div class="self-checkin-window-field">
+						<NcInputField
+							v-model.number="selfCheckinWindowMinutes"
+							type="number"
+							:label="t('attendance', 'Check-in window (minutes before start)')"
+							:helper-text="t('attendance', 'How many minutes before an appointment starts attendees can check in. The window always closes when the appointment ends.')"
+							data-test="input-self-checkin-window"
+							:input-props="{ min: 0, max: 1440 }" />
+					</div>
 
 					<div class="self-checkin-qr">
 						<h5>{{ t('attendance', 'Check-in code') }}</h5>

--- a/src/views/AdminSettings.vue
+++ b/src/views/AdminSettings.vue
@@ -1022,7 +1022,9 @@ onMounted(async () => {
 
 .self-checkin-window-field {
 	max-width: 400px;
-	margin-top: 12px;
+	/* The floating label sits above the input border, so it needs extra
+	   room to not collide with the group hint text above. */
+	margin-top: 24px;
 }
 
 .self-checkin-qr {

--- a/src/views/AdminSettings.vue
+++ b/src/views/AdminSettings.vue
@@ -139,6 +139,44 @@
 					<p class="hint-text">
 						{{ n('attendance', '%n group selected', '%n groups selected', selectedSelfCheckinRoles.length, { n: selectedSelfCheckinRoles.length }) }}
 					</p>
+
+					<NcInputField
+						v-model.number="selfCheckinWindowMinutes"
+						type="number"
+						class="self-checkin-window-field"
+						:label="t('attendance', 'Check-in window (minutes before start)')"
+						:helper-text="t('attendance', 'How many minutes before an appointment starts attendees can check in. The window always closes when the appointment ends.')"
+						data-test="input-self-checkin-window"
+						:input-props="{ min: 0, max: 1440 }" />
+
+					<div class="self-checkin-qr">
+						<h5>{{ t('attendance', 'Check-in code') }}</h5>
+						<p class="subsection-hint">
+							{{ t('attendance', 'Print this QR code and put it up at the entrance, or write the URL to NFC tags. One code works for all appointments — the app matches by time.') }}
+						</p>
+						<img v-if="qrDataUrl"
+							:src="qrDataUrl"
+							:alt="t('attendance', 'Self-check-in QR code')"
+							class="self-checkin-qr__image"
+							data-test="self-checkin-qr">
+						<div class="self-checkin-qr__actions">
+							<NcButton variant="secondary" @click="downloadQrCode">
+								<template #icon>
+									<Download :size="20" />
+								</template>
+								{{ t('attendance', 'Download QR code') }}
+							</NcButton>
+							<NcButton variant="secondary" @click="copySelfCheckinUrl">
+								<template #icon>
+									<ContentCopy :size="20" />
+								</template>
+								{{ t('attendance', 'Copy URL for NFC tags') }}
+							</NcButton>
+						</div>
+						<p class="hint-text">
+							{{ t('attendance', 'NFC tag shopping advice: use NXP NTAG213 tags (or newer) of at least 25 mm, and on-metal tags for metal surfaces. Avoid MIFARE Classic tags — they do not work with iPhones.') }}
+						</p>
+					</div>
 				</div>
 			</NcSettingsSection>
 
@@ -546,7 +584,9 @@ import CellphoneCheck from 'vue-material-design-icons/CellphoneCheck.vue'
 import AppleIcon from 'vue-material-design-icons/Apple.vue'
 import GoogleIcon from 'vue-material-design-icons/Google.vue'
 import ContentCopy from 'vue-material-design-icons/ContentCopy.vue'
+import Download from 'vue-material-design-icons/Download.vue'
 import OpenInNew from 'vue-material-design-icons/OpenInNew.vue'
+import QRCode from 'qrcode'
 import GroupSelect from '../components/common/GroupSelect.vue'
 import { formatDate, formatDateTimeMedium } from '../utils/datetime.js'
 import { APPLE_STORE_URL, GOOGLE_STORE_URL } from '../utils/mobileApp.js'
@@ -569,6 +609,9 @@ const selectedCheckinRoles = ref([])
 const selectedSeeResponseOverviewRoles = ref([])
 const selectedSeeCommentsRoles = ref([])
 const selectedSelfCheckinRoles = ref([])
+const selfCheckinWindowMinutes = ref(30)
+const qrDataUrl = ref(null)
+const selfCheckinUrl = window.location.origin + generateUrl('/apps/attendance/self-checkin')
 const remindersEnabled = ref(false)
 const reminderDays = ref(7)
 const reminderFrequency = ref(0)
@@ -701,6 +744,8 @@ const loadSettings = async () => {
 				.filter(group => group !== undefined)
 		}
 
+		selfCheckinWindowMinutes.value = config.selfCheckinWindowMinutes ?? 30
+
 		// Load reminder settings
 		remindersEnabled.value = config.reminders.enabled || false
 		reminderDays.value = config.reminders.reminderDays || 7
@@ -807,6 +852,7 @@ const saveSettings = async () => {
 				pushEnabled: pushEnabled.value,
 				mobileAppBannerEnabled: mobileAppBannerEnabled.value,
 				bookingEnabled: bookingEnabled.value,
+				selfCheckinWindowMinutes: selfCheckinWindowMinutes.value,
 			},
 		)
 
@@ -818,6 +864,27 @@ const saveSettings = async () => {
 		loading.value = false
 	}
 }
+
+const generateQrCode = async () => {
+	try {
+		qrDataUrl.value = await QRCode.toDataURL(selfCheckinUrl, { width: 512, margin: 2 })
+	} catch (error) {
+		console.error('Error generating QR code:', error)
+	}
+}
+
+const downloadQrCode = () => {
+	if (!qrDataUrl.value) return
+	const link = document.createElement('a')
+	link.href = qrDataUrl.value
+	link.download = 'attendance-self-checkin-qr.png'
+	link.click()
+}
+
+const copySelfCheckinUrl = () => copyToClipboard(selfCheckinUrl, {
+	successMessage: window.t('attendance', 'Link copied'),
+	errorMessage: window.t('attendance', 'Failed to copy link'),
+})
 
 const copyStoreUrl = (url) => copyToClipboard(url, {
 	successMessage: window.t('attendance', 'Link copied'),
@@ -854,6 +921,7 @@ const sendTestReminder = async () => {
 
 // Lifecycle
 onMounted(async () => {
+	generateQrCode()
 	await loadSettings()
 
 	// Handle hash navigation after content is loaded
@@ -953,6 +1021,36 @@ onMounted(async () => {
 	margin: 0 0 4px 0;
 	font-size: 15px;
 	font-weight: 600;
+}
+
+.self-checkin-window-field {
+	max-width: 400px;
+	margin-top: 12px;
+}
+
+.self-checkin-qr {
+	margin-top: 20px;
+
+	h5 {
+		font-weight: 600;
+		margin-bottom: 4px;
+	}
+
+	.self-checkin-qr__image {
+		width: 180px;
+		height: 180px;
+		border-radius: var(--border-radius-large);
+		background: #fff;
+		padding: 8px;
+		box-sizing: content-box;
+	}
+
+	.self-checkin-qr__actions {
+		display: flex;
+		gap: 8px;
+		flex-wrap: wrap;
+		margin: 8px 0;
+	}
 }
 
 .subsection-hint {

--- a/src/views/SelfCheckin.vue
+++ b/src/views/SelfCheckin.vue
@@ -39,6 +39,7 @@
 </template>
 
 <script setup>
+import { onMounted } from 'vue'
 import { NcButton } from '@nextcloud/vue'
 import { getRootUrl } from '@nextcloud/router'
 import AppleIcon from 'vue-material-design-icons/Apple.vue'
@@ -47,8 +48,33 @@ import CellphoneIcon from 'vue-material-design-icons/Cellphone.vue'
 import OpenInAppIcon from 'vue-material-design-icons/OpenInApp.vue'
 import { APPLE_STORE_URL, GOOGLE_STORE_URL } from '../utils/mobileApp.js'
 
+const ANDROID_PACKAGE = 'de.krautnerds.attendance'
+
+const isAndroid = /android/i.test(navigator.userAgent)
+const isIos = /iphone|ipad|ipod/i.test(navigator.userAgent)
+
 const server = window.location.origin + getRootUrl()
-const deepLink = 'nc-attendance://self-checkin?server=' + encodeURIComponent(server)
+const encodedServer = encodeURIComponent(server)
+const schemeLink = 'nc-attendance://self-checkin?server=' + encodedServer
+
+// On Android an intent:// URL opens the app when installed and falls back
+// to the Play Store otherwise — better than the bare scheme, which errors
+// silently without the app.
+const deepLink = isAndroid
+	? 'intent://self-checkin?server=' + encodedServer
+		+ '#Intent;scheme=nc-attendance;package=' + ANDROID_PACKAGE
+		+ ';S.browser_fallback_url=' + encodeURIComponent(GOOGLE_STORE_URL) + ';end'
+	: schemeLink
+
+onMounted(() => {
+	// Best-effort auto-open on phones so the scan goes straight into the
+	// app without tapping the button. Universal links are not an option
+	// here (every Nextcloud instance has its own domain), so this may be
+	// blocked without a user gesture — the button stays as fallback.
+	if (isAndroid || isIos) {
+		window.location.href = deepLink
+	}
+})
 </script>
 
 <style scoped>

--- a/src/views/SelfCheckin.vue
+++ b/src/views/SelfCheckin.vue
@@ -39,7 +39,6 @@
 </template>
 
 <script setup>
-import { computed } from 'vue'
 import { NcButton } from '@nextcloud/vue'
 import { getRootUrl } from '@nextcloud/router'
 import AppleIcon from 'vue-material-design-icons/Apple.vue'
@@ -48,10 +47,8 @@ import CellphoneIcon from 'vue-material-design-icons/Cellphone.vue'
 import OpenInAppIcon from 'vue-material-design-icons/OpenInApp.vue'
 import { APPLE_STORE_URL, GOOGLE_STORE_URL } from '../utils/mobileApp.js'
 
-const deepLink = computed(() => {
-	const server = window.location.origin + getRootUrl()
-	return 'krautnerds://attendance/self-checkin?server=' + encodeURIComponent(server)
-})
+const server = window.location.origin + getRootUrl()
+const deepLink = 'krautnerds://attendance/self-checkin?server=' + encodeURIComponent(server)
 </script>
 
 <style scoped>

--- a/src/views/SelfCheckin.vue
+++ b/src/views/SelfCheckin.vue
@@ -48,19 +48,22 @@ import OpenInAppIcon from 'vue-material-design-icons/OpenInApp.vue'
 import { APPLE_STORE_URL, GOOGLE_STORE_URL } from '../utils/mobileApp.js'
 
 const server = window.location.origin + getRootUrl()
-const deepLink = 'krautnerds://attendance/self-checkin?server=' + encodeURIComponent(server)
+const deepLink = 'nc-attendance://self-checkin?server=' + encodeURIComponent(server)
 </script>
 
 <style scoped>
 .self-checkin-landing {
 	max-width: 420px;
 	margin: 40px auto;
-	padding: 20px;
+	padding: 32px 24px;
 	display: flex;
 	flex-direction: column;
 	align-items: center;
 	gap: 12px;
 	text-align: center;
+	background-color: var(--color-main-background);
+	border-radius: var(--border-radius-large);
+	box-shadow: 0 0 10px var(--color-box-shadow);
 }
 
 .self-checkin-landing__icon {

--- a/src/views/SelfCheckin.vue
+++ b/src/views/SelfCheckin.vue
@@ -1,296 +1,88 @@
 <template>
-	<div class="self-checkin-container">
-		<!-- Loading State -->
-		<template v-if="loading">
-			<div class="loading-state">
-				<NcLoadingIcon :size="44" />
-				<p>{{ t('attendance', 'Finding active appointments…') }}</p>
-			</div>
-		</template>
+	<div class="self-checkin-landing">
+		<CellphoneIcon class="self-checkin-landing__icon" :size="56" />
+		<h2>{{ t('attendance', 'Check in with the Attendance app') }}</h2>
+		<p class="self-checkin-landing__text">
+			{{ t('attendance', 'Self-check-in works in the Attendance mobile app. Open the app and scan this code again, or get the app below.') }}
+		</p>
 
-		<!-- Error State -->
-		<template v-else-if="error">
-			<NcNoteCard type="error">
-				<p>{{ errorMessage }}</p>
-			</NcNoteCard>
-			<div class="button-row">
-				<NcButton variant="primary" @click="loadAppointments">
-					{{ t('attendance', 'Try again') }}
-				</NcButton>
-			</div>
-		</template>
+		<div class="self-checkin-landing__open">
+			<NcButton variant="primary" :href="deepLink">
+				<template #icon>
+					<OpenInAppIcon :size="20" />
+				</template>
+				{{ t('attendance', 'Open in the app') }}
+			</NcButton>
+		</div>
 
-		<!-- Success State -->
-		<template v-else-if="checkedIn">
-			<div class="success-state">
-				<NcNoteCard type="success">
-					<h2>{{ checkedInAlready ? t('attendance', 'Already checked in') : t('attendance', 'Checked in!') }}</h2>
-				</NcNoteCard>
-
-				<div class="appointment-details">
-					<h3>{{ checkedInAppointment.name }}</h3>
-					<p class="date-time">
-						<CalendarIcon :size="18" />
-						{{ formatDateRange(checkedInAppointment.startDatetime, checkedInAppointment.endDatetime) }}
-					</p>
-					<p v-if="checkedInAt" class="checkin-time">
-						{{ t('attendance', 'Checked in at {time}', { time: formatTime(checkedInAt) }) }}
-					</p>
-				</div>
-			</div>
-		</template>
-
-		<!-- No Appointments -->
-		<template v-else-if="appointments.length === 0">
-			<NcNoteCard type="info">
-				<h2>{{ t('attendance', 'No active appointments') }}</h2>
-				<p>{{ t('attendance', 'There are no appointments happening right now.') }}</p>
-			</NcNoteCard>
-			<div class="button-row">
-				<NcButton variant="primary" :href="appUrl">
-					{{ t('attendance', 'Open Attendance app') }}
-				</NcButton>
-			</div>
-		</template>
-
-		<!-- Single Appointment: Auto check-in -->
-		<template v-else-if="appointments.length === 1">
-			<h2>{{ t('attendance', 'Check in') }}</h2>
-			<div class="appointment-details">
-				<h3>{{ appointments[0].name }}</h3>
-				<p class="date-time">
-					<CalendarIcon :size="18" />
-					{{ formatDateRange(appointments[0].startDatetime, appointments[0].endDatetime) }}
-				</p>
-			</div>
-			<div class="button-row">
-				<NcButton
-					variant="primary"
-					:disabled="submitting"
-					@click="doCheckin(appointments[0].id)">
-					<template #icon>
-						<NcLoadingIcon v-if="submitting" :size="20" />
-						<CheckIcon v-else :size="20" />
-					</template>
-					{{ t('attendance', 'Check in now') }}
-				</NcButton>
-			</div>
-		</template>
-
-		<!-- Multiple Appointments: Let user choose -->
-		<template v-else>
-			<h2>{{ t('attendance', 'Which appointment?') }}</h2>
-			<p class="subtitle">
-				{{ t('attendance', 'Select the appointment you want to check into:') }}
-			</p>
-			<div class="appointment-list">
-				<div
-					v-for="appointment in appointments"
-					:key="appointment.id"
-					class="appointment-card"
-					@click="doCheckin(appointment.id)">
-					<div class="appointment-info">
-						<h3>{{ appointment.name }}</h3>
-						<p class="date-time">
-							<CalendarIcon :size="16" />
-							{{ formatDateRange(appointment.startDatetime, appointment.endDatetime) }}
-						</p>
-					</div>
-					<NcLoadingIcon v-if="submitting && submittingId === appointment.id" :size="20" />
-					<CheckIcon v-else :size="20" />
-				</div>
-			</div>
-		</template>
+		<div class="self-checkin-landing__stores">
+			<NcButton variant="secondary"
+				:href="APPLE_STORE_URL"
+				target="_blank"
+				rel="noopener">
+				<template #icon>
+					<AppleIcon :size="20" />
+				</template>
+				{{ t('attendance', 'App Store') }}
+			</NcButton>
+			<NcButton variant="secondary"
+				:href="GOOGLE_STORE_URL"
+				target="_blank"
+				rel="noopener">
+				<template #icon>
+					<GoogleIcon :size="20" />
+				</template>
+				{{ t('attendance', 'Google Play') }}
+			</NcButton>
+		</div>
 	</div>
 </template>
 
 <script setup>
-import { ref, computed, onMounted } from 'vue'
-import { NcButton, NcNoteCard, NcLoadingIcon } from '@nextcloud/vue'
-import { generateUrl } from '@nextcloud/router'
-import axios from '@nextcloud/axios'
-import CalendarIcon from 'vue-material-design-icons/Calendar.vue'
-import CheckIcon from 'vue-material-design-icons/Check.vue'
-import { formatDateRange } from '../utils/datetime.js'
+import { computed } from 'vue'
+import { NcButton } from '@nextcloud/vue'
+import { getRootUrl } from '@nextcloud/router'
+import AppleIcon from 'vue-material-design-icons/Apple.vue'
+import GoogleIcon from 'vue-material-design-icons/Google.vue'
+import CellphoneIcon from 'vue-material-design-icons/Cellphone.vue'
+import OpenInAppIcon from 'vue-material-design-icons/OpenInApp.vue'
+import { APPLE_STORE_URL, GOOGLE_STORE_URL } from '../utils/mobileApp.js'
 
-// State
-const loading = ref(true)
-const error = ref(false)
-const errorMessage = ref('')
-const appointments = ref([])
-const submitting = ref(false)
-const submittingId = ref(null)
-const checkedIn = ref(false)
-const checkedInAlready = ref(false)
-const checkedInAppointment = ref(null)
-const checkedInAt = ref(null)
-
-// Computed
-const appUrl = computed(() => generateUrl('/apps/attendance/'))
-
-// Format time for display
-const formatTime = (datetime) => {
-	if (!datetime) return ''
-	try {
-		const date = new Date(datetime)
-		return date.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' })
-	} catch {
-		return datetime
-	}
-}
-
-// Load active appointments
-const loadAppointments = async () => {
-	loading.value = true
-	error.value = false
-
-	try {
-		const url = generateUrl('/apps/attendance/api/self-checkin/appointments')
-		const response = await axios.get(url)
-		appointments.value = response.data
-
-		// If there's exactly one appointment and the user is already checked in, show that
-		if (response.data.length === 1 && response.data[0].alreadyCheckedIn) {
-			checkedIn.value = true
-			checkedInAlready.value = true
-			checkedInAppointment.value = response.data[0]
-			checkedInAt.value = response.data[0].checkinAt
-		}
-	} catch (err) {
-		error.value = true
-		errorMessage.value = err.response?.data?.error || t('attendance', 'Failed to load appointments.')
-	} finally {
-		loading.value = false
-	}
-}
-
-// Perform check-in
-const doCheckin = async (appointmentId) => {
-	if (submitting.value) return
-
-	submitting.value = true
-	submittingId.value = appointmentId
-
-	try {
-		const url = generateUrl('/apps/attendance/api/self-checkin')
-		const response = await axios.post(url, { appointmentId })
-
-		checkedIn.value = true
-		checkedInAlready.value = response.data.alreadyCheckedIn || false
-		checkedInAppointment.value = response.data.appointment
-		checkedInAt.value = response.data.checkinAt
-	} catch (err) {
-		error.value = true
-		errorMessage.value = err.response?.data?.error || t('attendance', 'Failed to check in.')
-	} finally {
-		submitting.value = false
-		submittingId.value = null
-	}
-}
-
-onMounted(() => {
-	loadAppointments()
+const deepLink = computed(() => {
+	const server = window.location.origin + getRootUrl()
+	return 'krautnerds://attendance/self-checkin?server=' + encodeURIComponent(server)
 })
 </script>
 
-<style scoped lang="scss">
-.self-checkin-container {
-	max-width: 500px;
+<style scoped>
+.self-checkin-landing {
+	max-width: 420px;
 	margin: 40px auto;
 	padding: 20px;
-
-	h2 {
-		text-align: center;
-		margin-bottom: 8px;
-	}
-
-	.subtitle {
-		text-align: center;
-		color: var(--color-text-maxcontrast);
-		margin-bottom: 20px;
-	}
-}
-
-.loading-state {
 	display: flex;
 	flex-direction: column;
 	align-items: center;
-	gap: 16px;
-	padding: 40px 0;
-
-	p {
-		color: var(--color-text-maxcontrast);
-	}
-}
-
-.success-state {
+	gap: 12px;
 	text-align: center;
 }
 
-.appointment-details {
-	background: var(--color-background-hover);
-	border-radius: var(--border-radius-large);
-	padding: 16px;
-	margin: 20px 0;
-
-	h3 {
-		margin: 0 0 12px 0;
-	}
-
-	.date-time {
-		display: flex;
-		align-items: center;
-		gap: 8px;
-		margin: 8px 0;
-		color: var(--color-text-maxcontrast);
-	}
-
-	.checkin-time {
-		color: var(--color-text-maxcontrast);
-		font-size: 14px;
-		margin-top: 8px;
-	}
+.self-checkin-landing__icon {
+	color: var(--color-primary-element);
 }
 
-.appointment-list {
-	display: flex;
-	flex-direction: column;
-	gap: 8px;
+.self-checkin-landing__text {
+	color: var(--color-text-maxcontrast);
 }
 
-.appointment-card {
-	display: flex;
-	align-items: center;
-	justify-content: space-between;
-	padding: 16px;
-	background: var(--color-background-hover);
-	border-radius: var(--border-radius-large);
-	cursor: pointer;
-	transition: background 0.2s;
-
-	&:hover {
-		background: var(--color-background-dark);
-	}
-
-	.appointment-info {
-		h3 {
-			margin: 0 0 4px 0;
-		}
-
-		.date-time {
-			display: flex;
-			align-items: center;
-			gap: 6px;
-			color: var(--color-text-maxcontrast);
-			font-size: 14px;
-		}
-	}
+.self-checkin-landing__open {
+	margin-top: 8px;
 }
 
-.button-row {
+.self-checkin-landing__stores {
 	display: flex;
 	gap: 12px;
+	flex-wrap: wrap;
 	justify-content: center;
-	margin-top: 20px;
+	margin-top: 4px;
 }
 </style>

--- a/tests/unit/Service/SelfCheckinServiceTest.php
+++ b/tests/unit/Service/SelfCheckinServiceTest.php
@@ -1,0 +1,261 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\Attendance\Tests\Unit\Service;
+
+use OCA\Attendance\Audit\Verb;
+use OCA\Attendance\Db\Appointment;
+use OCA\Attendance\Db\AppointmentMapper;
+use OCA\Attendance\Db\AttendanceResponse;
+use OCA\Attendance\Db\AttendanceResponseMapper;
+use OCA\Attendance\Service\AuditEventService;
+use OCA\Attendance\Service\ConfigService;
+use OCA\Attendance\Service\SelfCheckinService;
+use OCA\Attendance\Service\VisibilityService;
+use OCP\AppFramework\Db\DoesNotExistException;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+class SelfCheckinServiceTest extends TestCase {
+	private AppointmentMapper|MockObject $appointmentMapper;
+	private AttendanceResponseMapper|MockObject $responseMapper;
+	private VisibilityService|MockObject $visibilityService;
+	private ConfigService|MockObject $configService;
+	private AuditEventService|MockObject $auditEventService;
+	private LoggerInterface|MockObject $logger;
+	private SelfCheckinService $service;
+
+	protected function setUp(): void {
+		$this->appointmentMapper = $this->createMock(AppointmentMapper::class);
+		$this->responseMapper = $this->createMock(AttendanceResponseMapper::class);
+		$this->visibilityService = $this->createMock(VisibilityService::class);
+		$this->configService = $this->createMock(ConfigService::class);
+		$this->auditEventService = $this->createMock(AuditEventService::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
+
+		$this->service = new SelfCheckinService(
+			$this->appointmentMapper,
+			$this->responseMapper,
+			$this->visibilityService,
+			$this->configService,
+			$this->auditEventService,
+			$this->logger,
+		);
+
+		$this->configService->method('getSelfCheckinWindowMinutes')->willReturn(30);
+	}
+
+	private function makeAppointment(
+		int $id,
+		string $start,
+		string $end,
+		bool $active = true,
+		?string $cancelledAt = null,
+	): Appointment {
+		$appointment = new Appointment();
+		$appointment->setId($id);
+		$appointment->setName('Training');
+		$appointment->setStartDatetime($start);
+		$appointment->setEndDatetime($end);
+		$appointment->setIsActive($active ? 1 : 0);
+		$appointment->setCancelledAt($cancelledAt);
+		return $appointment;
+	}
+
+	/** An appointment currently inside the default 30-minute window. */
+	private function makeCurrentAppointment(int $id = 1): Appointment {
+		return $this->makeAppointment(
+			$id,
+			gmdate('Y-m-d H:i:s', time() - 600),
+			gmdate('Y-m-d H:i:s', time() + 3600),
+		);
+	}
+
+	public function testSelfCheckinRejectsInvalidMethod(): void {
+		$this->expectException(\InvalidArgumentException::class);
+		$this->expectExceptionMessage('Invalid check-in method.');
+
+		$this->service->selfCheckin(1, 'alice', 'manual');
+	}
+
+	public function testSelfCheckinViaQrSetsSourceAndRecordsAudit(): void {
+		$appointment = $this->makeCurrentAppointment();
+		$this->appointmentMapper->method('find')->willReturn($appointment);
+		$this->visibilityService->method('isUserTargetAttendee')->willReturn(true);
+		$this->responseMapper->method('findByAppointmentAndUser')
+			->willThrowException(new DoesNotExistException('no row'));
+
+		$inserted = null;
+		$this->responseMapper->expects($this->once())
+			->method('insert')
+			->willReturnCallback(function (AttendanceResponse $response) use (&$inserted) {
+				$inserted = $response;
+				return $response;
+			});
+
+		$this->auditEventService->expects($this->once())
+			->method('record')
+			->with(
+				Verb::CHECKIN_RECORDED,
+				1,
+				'alice',
+				'alice',
+				['checkinState' => 'yes', 'method' => 'qr'],
+				Verb::SOURCE_SELF_CHECKIN,
+			);
+
+		$result = $this->service->selfCheckin(1, 'alice', 'qr');
+
+		$this->assertSame('yes', $result['checkinState']);
+		$this->assertFalse($result['alreadyCheckedIn']);
+		$this->assertSame('self_qr', $inserted->getCheckinSource());
+		$this->assertSame('alice', $inserted->getCheckinBy());
+	}
+
+	public function testSelfCheckinViaNfcSetsNfcSource(): void {
+		$appointment = $this->makeCurrentAppointment();
+		$this->appointmentMapper->method('find')->willReturn($appointment);
+		$this->visibilityService->method('isUserTargetAttendee')->willReturn(true);
+		$this->responseMapper->method('findByAppointmentAndUser')
+			->willThrowException(new DoesNotExistException('no row'));
+		$this->responseMapper->method('insert')->willReturnArgument(0);
+
+		$this->auditEventService->expects($this->once())
+			->method('record')
+			->with(
+				Verb::CHECKIN_RECORDED,
+				1,
+				'alice',
+				'alice',
+				['checkinState' => 'yes', 'method' => 'nfc'],
+				Verb::SOURCE_SELF_CHECKIN,
+			);
+
+		$this->service->selfCheckin(1, 'alice', 'nfc');
+	}
+
+	public function testSelfCheckinAlreadyCheckedInReturnsEarlyWithoutAudit(): void {
+		$appointment = $this->makeCurrentAppointment();
+		$this->appointmentMapper->method('find')->willReturn($appointment);
+		$this->visibilityService->method('isUserTargetAttendee')->willReturn(true);
+
+		$response = new AttendanceResponse();
+		$response->setId(5);
+		$response->setAppointmentId(1);
+		$response->setUserId('alice');
+		$response->setCheckinState('yes');
+		$response->setCheckinAt(gmdate('Y-m-d H:i:s'));
+		$this->responseMapper->method('findByAppointmentAndUser')->willReturn($response);
+
+		$this->responseMapper->expects($this->never())->method('update');
+		$this->responseMapper->expects($this->never())->method('insert');
+		$this->auditEventService->expects($this->never())->method('record');
+
+		$result = $this->service->selfCheckin(1, 'alice', 'qr');
+
+		$this->assertTrue($result['alreadyCheckedIn']);
+	}
+
+	public function testSelfCheckinRespectsConfiguredWindow(): void {
+		// Appointment starts in 20 minutes — inside the default 30-minute
+		// window, but outside a reconfigured 10-minute window.
+		$configService = $this->createMock(ConfigService::class);
+		$configService->method('getSelfCheckinWindowMinutes')->willReturn(10);
+		$service = new SelfCheckinService(
+			$this->appointmentMapper,
+			$this->responseMapper,
+			$this->visibilityService,
+			$configService,
+			$this->auditEventService,
+			$this->logger,
+		);
+
+		$appointment = $this->makeAppointment(
+			1,
+			gmdate('Y-m-d H:i:s', time() + 1200),
+			gmdate('Y-m-d H:i:s', time() + 4800),
+		);
+		$this->appointmentMapper->method('find')->willReturn($appointment);
+
+		$this->expectException(\InvalidArgumentException::class);
+		$this->expectExceptionMessage('Appointment is not within the check-in time window.');
+
+		$service->selfCheckin(1, 'alice', 'qr');
+	}
+
+	public function testSelfCheckinRejectsCancelledAppointment(): void {
+		$appointment = $this->makeAppointment(
+			1,
+			gmdate('Y-m-d H:i:s', time() - 600),
+			gmdate('Y-m-d H:i:s', time() + 3600),
+			true,
+			gmdate('Y-m-d H:i:s'),
+		);
+		$this->appointmentMapper->method('find')->willReturn($appointment);
+
+		$this->expectException(\InvalidArgumentException::class);
+		$this->expectExceptionMessage('Appointment is not active.');
+
+		$this->service->selfCheckin(1, 'alice', 'qr');
+	}
+
+	public function testSelfCheckinRejectsNonAttendee(): void {
+		$appointment = $this->makeCurrentAppointment();
+		$this->appointmentMapper->method('find')->willReturn($appointment);
+		$this->visibilityService->method('isUserTargetAttendee')->willReturn(false);
+
+		$this->expectException(\InvalidArgumentException::class);
+		$this->expectExceptionMessage('You are not an attendee of this appointment.');
+
+		$this->service->selfCheckin(1, 'alice', 'qr');
+	}
+
+	public function testGetOverviewListsInWindowAppointmentsAndNextUpcoming(): void {
+		$current = $this->makeCurrentAppointment(1);
+		$next = $this->makeAppointment(
+			2,
+			gmdate('Y-m-d H:i:s', time() + 7200),
+			gmdate('Y-m-d H:i:s', time() + 10800),
+		);
+
+		$this->appointmentMapper->method('findActiveInWindow')->with(30)->willReturn([$current]);
+		$this->appointmentMapper->method('findUpcoming')->willReturn([$current, $next]);
+		$this->visibilityService->method('isUserTargetAttendee')->willReturn(true);
+		$this->responseMapper->method('findByAppointmentAndUser')
+			->willThrowException(new DoesNotExistException('no row'));
+
+		$overview = $this->service->getOverview('alice');
+
+		$this->assertCount(1, $overview['appointments']);
+		$this->assertSame(1, $overview['appointments'][0]['id']);
+		$this->assertFalse($overview['appointments'][0]['alreadyCheckedIn']);
+
+		$this->assertNotNull($overview['nextUpcoming']);
+		$this->assertSame(2, $overview['nextUpcoming']['id']);
+		$expectedWindowStart = (new \DateTime($next->getStartDatetime(), new \DateTimeZone('UTC')))
+			->modify('-30 minutes')->format('Y-m-d H:i:s');
+		$this->assertSame($expectedWindowStart, $overview['nextUpcoming']['checkinWindowStartsAt']);
+	}
+
+	public function testGetOverviewSkipsInvisibleAndCancelledAppointments(): void {
+		$cancelled = $this->makeAppointment(
+			1,
+			gmdate('Y-m-d H:i:s', time() - 600),
+			gmdate('Y-m-d H:i:s', time() + 3600),
+			true,
+			gmdate('Y-m-d H:i:s'),
+		);
+		$invisible = $this->makeCurrentAppointment(2);
+
+		$this->appointmentMapper->method('findActiveInWindow')->willReturn([$cancelled, $invisible]);
+		$this->appointmentMapper->method('findUpcoming')->willReturn([]);
+		$this->visibilityService->method('isUserTargetAttendee')->willReturn(false);
+
+		$overview = $this->service->getOverview('alice');
+
+		$this->assertSame([], $overview['appointments']);
+		$this->assertNull($overview['nextUpcoming']);
+	}
+}

--- a/tests/unit/Service/SelfCheckinServiceTest.php
+++ b/tests/unit/Service/SelfCheckinServiceTest.php
@@ -212,16 +212,12 @@ class SelfCheckinServiceTest extends TestCase {
 		$this->service->selfCheckin(1, 'alice', 'qr');
 	}
 
-	public function testGetOverviewListsInWindowAppointmentsAndNextUpcoming(): void {
+	public function testGetOverviewListsInWindowAppointmentsWithoutNextUpcoming(): void {
 		$current = $this->makeCurrentAppointment(1);
-		$next = $this->makeAppointment(
-			2,
-			gmdate('Y-m-d H:i:s', time() + 7200),
-			gmdate('Y-m-d H:i:s', time() + 10800),
-		);
 
 		$this->appointmentMapper->method('findActiveInWindow')->with(30)->willReturn([$current]);
-		$this->appointmentMapper->method('findUpcoming')->willReturn([$current, $next]);
+		// nextUpcoming is only computed when nothing is in the window.
+		$this->appointmentMapper->expects($this->never())->method('findUpcomingOutsideWindow');
 		$this->visibilityService->method('isUserTargetAttendee')->willReturn(true);
 		$this->responseMapper->method('findByAppointmentAndUser')
 			->willThrowException(new DoesNotExistException('no row'));
@@ -231,7 +227,23 @@ class SelfCheckinServiceTest extends TestCase {
 		$this->assertCount(1, $overview['appointments']);
 		$this->assertSame(1, $overview['appointments'][0]['id']);
 		$this->assertFalse($overview['appointments'][0]['alreadyCheckedIn']);
+		$this->assertNull($overview['nextUpcoming']);
+	}
 
+	public function testGetOverviewReturnsNextUpcomingWhenNothingInWindow(): void {
+		$next = $this->makeAppointment(
+			2,
+			gmdate('Y-m-d H:i:s', time() + 7200),
+			gmdate('Y-m-d H:i:s', time() + 10800),
+		);
+
+		$this->appointmentMapper->method('findActiveInWindow')->willReturn([]);
+		$this->appointmentMapper->method('findUpcomingOutsideWindow')->with(30)->willReturn([$next]);
+		$this->visibilityService->method('isUserTargetAttendee')->willReturn(true);
+
+		$overview = $this->service->getOverview('alice');
+
+		$this->assertSame([], $overview['appointments']);
 		$this->assertNotNull($overview['nextUpcoming']);
 		$this->assertSame(2, $overview['nextUpcoming']['id']);
 		$expectedWindowStart = (new \DateTime($next->getStartDatetime(), new \DateTimeZone('UTC')))
@@ -239,18 +251,11 @@ class SelfCheckinServiceTest extends TestCase {
 		$this->assertSame($expectedWindowStart, $overview['nextUpcoming']['checkinWindowStartsAt']);
 	}
 
-	public function testGetOverviewSkipsInvisibleAndCancelledAppointments(): void {
-		$cancelled = $this->makeAppointment(
-			1,
-			gmdate('Y-m-d H:i:s', time() - 600),
-			gmdate('Y-m-d H:i:s', time() + 3600),
-			true,
-			gmdate('Y-m-d H:i:s'),
-		);
+	public function testGetOverviewSkipsInvisibleAppointments(): void {
 		$invisible = $this->makeCurrentAppointment(2);
 
-		$this->appointmentMapper->method('findActiveInWindow')->willReturn([$cancelled, $invisible]);
-		$this->appointmentMapper->method('findUpcoming')->willReturn([]);
+		$this->appointmentMapper->method('findActiveInWindow')->willReturn([$invisible]);
+		$this->appointmentMapper->method('findUpcomingOutsideWindow')->willReturn([]);
 		$this->visibilityService->method('isUserTargetAttendee')->willReturn(false);
 
 		$overview = $this->service->getOverview('alice');


### PR DESCRIPTION
## Was ist neu

QR-Code/NFC-Self-Checkin: Teilnehmer checken sich selbst ein, indem sie einen instanzweiten QR-Code (Aushang) oder NFC-Tag mit der **Attendance-App** scannen. Self-Checkin ist bewusst App-only — der Scan ohne App landet auf einer „Hol dir die App"-Seite.

### API (S1–S3)

- `POST /api/self-checkin` nimmt `method` (`qr` | `nfc`) entgegen → `checkin_source` = `self_qr`/`self_nfc` (ersetzt das pauschale `nfc`; bisher nutzte kein Client den Endpoint)
- Self-Checkin schreibt jetzt ein **Audit-Event** (`checkin.recorded`, Source `self_checkin`, Methode im `meta`, `actor == subject`)
- Neue Capability **`selfCheckin`** in `getCapabilities()` fürs Client-Gating
- Self-Checkin-**Zeitfenster konfigurierbar** (Admin-Setting, Default 30 Min. vor Start; Ende bleibt Terminende), Werte geklemmt auf 0–1440
- `GET /api/self-checkin/appointments` liefert neu `{appointments, nextUpcoming}` — inkl. nächstem Termin + Fensterbeginn für den „gerade nichts"-Screen; abgesagte Termine werden übersprungen

### Web (S4–S5)

- **Harter Cut:** `GET /self-checkin` ist jetzt eine öffentliche Landeseite (Store-Badges + „In der App öffnen"-Button mit `nc-attendance://self-checkin?server=…`); der Web-Checkin entfällt (war nirgends verlinkt)
- **Admin-Settings:** QR-Code-Anzeige mit PNG-Download, URL-Copy-Feld für NFC-Beschriftung, Fenster-Einstellung und NFC-Sticker-Kaufempfehlung (NTAG213 ≥ 25 mm, On-Metal bei Metall, Warnung vor MIFARE Classic)

## Breaking / Kompatibilität

- Web-Self-Checkin entfernt (Landeseite ersetzt ihn) — bewusste Produktentscheidung, Feature war nie verlinkt
- Response-Shape von `GET /api/self-checkin/appointments` geändert (Liste → Objekt); kein veröffentlichter Client nutzt den Endpoint, das Flutter-Feature gated auf die neue Capability
- Alte App-Versionen: sehen das Feature nicht (Capability fehlt auf alten Servern / neues Flag defaultet zu false)

## Tests

- Neue `SelfCheckinServiceTest` (Methoden-Validierung, Audit, Fenster-Konfiguration, Cancelled-Filter, Overview/NextUpcoming)
- `composer test:unit`: 151 Tests grün
- `composer openapi` regeneriert, `npm run build` erfolgreich

Companion-PR im Flutter-Repo: luflow/attendance-flutter#19 (QR/NFC-Scan-Flow, Deeplink, Organizer-Tools).

🤖 Generated with [Claude Code](https://claude.com/claude-code)