### PR TITLE
fix: UTC-marked datetimes in self-checkin nextUpcoming + iOS Smart App Banner

### DIFF
--- a/lib/Controller/SelfCheckinController.php
+++ b/lib/Controller/SelfCheckinController.php
@@ -145,7 +145,7 @@ class SelfCheckinController extends Controller {
 		// launches the installed app without the custom-scheme confirmation
 		// dialog (and offers the App Store when it is missing). The
 		// app-argument mirrors the deep link the page fires itself.
-		$server = rtrim($this->urlGenerator->getAbsoluteURL('/'), '/');
+		$server = $this->urlGenerator->getBaseUrl();
 		Util::addHeader('meta', [
 			'name' => 'apple-itunes-app',
 			'content' => 'app-id=' . self::APPLE_APP_ID

--- a/lib/Controller/SelfCheckinController.php
+++ b/lib/Controller/SelfCheckinController.php
@@ -17,6 +17,7 @@ use OCP\AppFramework\Http\Attribute\PublicPage;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\IRequest;
+use OCP\IURLGenerator;
 use OCP\IUserSession;
 use OCP\Util;
 use Psr\Log\LoggerInterface;
@@ -28,9 +29,13 @@ use Psr\Log\LoggerInterface;
 class SelfCheckinController extends Controller {
 	use RequiresAuthTrait;
 
+	/** App Store ID of the companion app, same app as src/utils/mobileApp.js. */
+	private const APPLE_APP_ID = '6759988681';
+
 	private SelfCheckinService $selfCheckinService;
 	private PermissionService $permissionService;
 	private IUserSession $userSession;
+	private IURLGenerator $urlGenerator;
 	private LoggerInterface $logger;
 
 	public function __construct(
@@ -39,12 +44,14 @@ class SelfCheckinController extends Controller {
 		SelfCheckinService $selfCheckinService,
 		PermissionService $permissionService,
 		IUserSession $userSession,
+		IURLGenerator $urlGenerator,
 		LoggerInterface $logger,
 	) {
 		parent::__construct($appName, $request);
 		$this->selfCheckinService = $selfCheckinService;
 		$this->permissionService = $permissionService;
 		$this->userSession = $userSession;
+		$this->urlGenerator = $urlGenerator;
 		$this->logger = $logger;
 	}
 
@@ -133,6 +140,17 @@ class SelfCheckinController extends Controller {
 	public function showPage(): TemplateResponse {
 		Util::addScript(Application::APP_ID, Application::APP_ID . '-selfcheckin');
 		Util::addStyle(Application::APP_ID, Application::APP_ID . '-selfcheckin');
+
+		// iOS Smart App Banner: Safari shows a native "Open" banner that
+		// launches the installed app without the custom-scheme confirmation
+		// dialog (and offers the App Store when it is missing). The
+		// app-argument mirrors the deep link the page fires itself.
+		$server = rtrim($this->urlGenerator->getAbsoluteURL('/'), '/');
+		Util::addHeader('meta', [
+			'name' => 'apple-itunes-app',
+			'content' => 'app-id=' . self::APPLE_APP_ID
+				. ', app-argument=nc-attendance://self-checkin?server=' . rawurlencode($server),
+		]);
 
 		return new TemplateResponse(
 			Application::APP_ID,

--- a/lib/Db/DatetimeFormatTrait.php
+++ b/lib/Db/DatetimeFormatTrait.php
@@ -22,9 +22,17 @@ trait DatetimeFormatTrait {
 		try {
 			$utcTimezone = new \DateTimeZone('UTC');
 			$date = new \DateTime($datetime, $utcTimezone);
-			return $date->format('Y-m-d\TH:i:s\Z');
+			return $this->formatUtcDatetime($date);
 		} catch (\Exception $e) {
 			return $datetime;
 		}
+	}
+
+	/**
+	 * Format a DateTime (already representing a UTC instant) to the API wire
+	 * format ('Y-m-d\TH:i:s\Z').
+	 */
+	protected function formatUtcDatetime(\DateTimeInterface $date): string {
+		return $date->format('Y-m-d\TH:i:s\Z');
 	}
 }

--- a/lib/Service/SelfCheckinService.php
+++ b/lib/Service/SelfCheckinService.php
@@ -9,6 +9,7 @@ use OCA\Attendance\Db\Appointment;
 use OCA\Attendance\Db\AppointmentMapper;
 use OCA\Attendance\Db\AttendanceResponse;
 use OCA\Attendance\Db\AttendanceResponseMapper;
+use OCA\Attendance\Db\DatetimeFormatTrait;
 use OCP\AppFramework\Db\DoesNotExistException;
 use Psr\Log\LoggerInterface;
 
@@ -17,6 +18,8 @@ use Psr\Log\LoggerInterface;
  * Handles finding active appointments and performing self-check-in for users.
  */
 class SelfCheckinService {
+	use DatetimeFormatTrait;
+
 	private AppointmentMapper $appointmentMapper;
 	private AttendanceResponseMapper $responseMapper;
 	private VisibilityService $visibilityService;
@@ -106,11 +109,13 @@ class SelfCheckinService {
 			if (!$this->visibilityService->isUserTargetAttendee($appointment, $userId)) {
 				continue;
 			}
+			// UTC-marked ISO strings like every other datetime in the API —
+			// naive strings would be interpreted as local time by clients.
 			return [
 				'id' => $appointment->getId(),
 				'name' => $appointment->getName(),
-				'startDatetime' => $appointment->getStartDatetime(),
-				'checkinWindowStartsAt' => $this->getWindowStart($appointment, $windowMinutes)->format('Y-m-d H:i:s'),
+				'startDatetime' => $this->formatDatetimeToUtc($appointment->getStartDatetime()) ?? '',
+				'checkinWindowStartsAt' => $this->getWindowStart($appointment, $windowMinutes)->format('Y-m-d\TH:i:s\Z'),
 			];
 		}
 		return null;

--- a/lib/Service/SelfCheckinService.php
+++ b/lib/Service/SelfCheckinService.php
@@ -115,7 +115,7 @@ class SelfCheckinService {
 				'id' => $appointment->getId(),
 				'name' => $appointment->getName(),
 				'startDatetime' => $this->formatDatetimeToUtc($appointment->getStartDatetime()) ?? '',
-				'checkinWindowStartsAt' => $this->getWindowStart($appointment, $windowMinutes)->format('Y-m-d\TH:i:s\Z'),
+				'checkinWindowStartsAt' => $this->formatUtcDatetime($this->getWindowStart($appointment, $windowMinutes)),
 			];
 		}
 		return null;

--- a/tests/unit/Service/SelfCheckinServiceTest.php
+++ b/tests/unit/Service/SelfCheckinServiceTest.php
@@ -248,12 +248,12 @@ class SelfCheckinServiceTest extends TestCase {
 		$this->assertSame(2, $overview['nextUpcoming']['id']);
 		// Datetimes must carry the UTC marker like the rest of the API —
 		// naive strings get misread as local time by the mobile client.
-		$expectedStart = (new \DateTime($next->getStartDatetime(), new \DateTimeZone('UTC')))
-			->format('Y-m-d\TH:i:s\Z');
-		$this->assertSame($expectedStart, $overview['nextUpcoming']['startDatetime']);
-		$expectedWindowStart = (new \DateTime($next->getStartDatetime(), new \DateTimeZone('UTC')))
-			->modify('-30 minutes')->format('Y-m-d\TH:i:s\Z');
-		$this->assertSame($expectedWindowStart, $overview['nextUpcoming']['checkinWindowStartsAt']);
+		$start = new \DateTime($next->getStartDatetime(), new \DateTimeZone('UTC'));
+		$this->assertSame($start->format('Y-m-d\TH:i:s\Z'), $overview['nextUpcoming']['startDatetime']);
+		$this->assertSame(
+			$start->modify('-30 minutes')->format('Y-m-d\TH:i:s\Z'),
+			$overview['nextUpcoming']['checkinWindowStartsAt'],
+		);
 	}
 
 	public function testGetOverviewSkipsInvisibleAppointments(): void {

--- a/tests/unit/Service/SelfCheckinServiceTest.php
+++ b/tests/unit/Service/SelfCheckinServiceTest.php
@@ -246,8 +246,13 @@ class SelfCheckinServiceTest extends TestCase {
 		$this->assertSame([], $overview['appointments']);
 		$this->assertNotNull($overview['nextUpcoming']);
 		$this->assertSame(2, $overview['nextUpcoming']['id']);
+		// Datetimes must carry the UTC marker like the rest of the API —
+		// naive strings get misread as local time by the mobile client.
+		$expectedStart = (new \DateTime($next->getStartDatetime(), new \DateTimeZone('UTC')))
+			->format('Y-m-d\TH:i:s\Z');
+		$this->assertSame($expectedStart, $overview['nextUpcoming']['startDatetime']);
 		$expectedWindowStart = (new \DateTime($next->getStartDatetime(), new \DateTimeZone('UTC')))
-			->modify('-30 minutes')->format('Y-m-d H:i:s');
+			->modify('-30 minutes')->format('Y-m-d\TH:i:s\Z');
 		$this->assertSame($expectedWindowStart, $overview['nextUpcoming']['checkinWindowStartsAt']);
 	}
 


### PR DESCRIPTION
## Timezone fix (root cause of UTC times in the app)

The self-checkin overview's `nextUpcoming` payload sent `startDatetime` as the raw database string and `checkinWindowStartsAt` as `Y-m-d H:i:s` — both without a timezone marker. Clients parse those as local time, so the mobile app displayed UTC wall-clock values.

Both fields are now serialized like every other datetime in the API (`Y-m-d\TH:i:s\Z`, via `DatetimeFormatTrait`). Existing app builds already call `toLocal()` on the parsed value, so this fixes older clients too — no capability flag needed. The unit test now pins the format for both fields.

## iOS Smart App Banner (carried over, previously unmerged)

The self-checkin landing page now emits an `apple-itunes-app` meta header. Safari renders a native banner whose "Open" action launches the installed app directly — without the custom-scheme confirmation dialog — and offers the App Store when the app is missing. The `app-argument` carries the same `nc-attendance://self-checkin?server=…` deep link the page fires itself.

## Tests

- `composer test:unit`: 152 tests, 352 assertions, green

Paired with luflow/attendance-flutter (defensive parsing of timezone-less datetimes from older servers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016iEePfyBvmf2yKhdUKN1Mq

---
_Generated by [Claude Code](https://claude.ai/code/session_016iEePfyBvmf2yKhdUKN1Mq)_