### PR TITLE
chore: Add l10n-drift and l10n-pull agent skills

### DIFF
--- a/.claude/skills/l10n-drift/SKILL.md
+++ b/.claude/skills/l10n-drift/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: l10n-drift
+description: Check and fix translation-string drift between the attendance-flutter mobile app and this repo — every string the Flutter app uses must be registered here so Transifex extracts it. Use whenever new strings were added to or removed from the Flutter app, before/after Flutter feature PRs, or when the user says "string abgleich", "sync flutter strings", "translation drift", or asks to copy Flutter strings to the web app.
+---
+
+# Flutter ↔ web translation-string drift
+
+Transifex only extracts strings from THIS repo (`t()`/`n()` in `src/`,
+`$l->t()` in `lib/`). The Flutter app (`attendance-flutter`, usually checked
+out next to this repo) uses the same English strings as easy_localization
+keys and receives the translations by copying `l10n/*.json` (see the
+`l10n-pull` skill). Mobile-only strings are therefore registered in a
+module-scope block in `src/App.vue` (column-0 `t('attendance', …)` lines,
+kept alphabetical inside the "Strings that only appear in the Flutter mobile
+app" section).
+
+## Step 1 — Run the checker
+
+```bash
+python3 .claude/skills/l10n-drift/scripts/check_drift.py
+```
+
+Make sure the Flutter checkout is on the branch you want to compare against
+(usually `main` or the feature branch being reviewed). The script reports:
+
+- **MISSING** — keys the Flutter app uses that no `t()`/`n()`/`$l->t()` call
+  here registers. These would ship untranslated.
+- **STALE** — keys in the App.vue registration block that neither the
+  Flutter app nor the web app uses anymore. Dead weight for translators.
+- **UNRESOLVED** — `.tr()` calls on plain identifiers the script cannot
+  resolve statically. Compare them against `data-keys.json` (next to the
+  script): if the underlying data (labels, templates, option maps) gained or
+  lost entries, update that file and re-run. Dynamic values (e.g. Nextcloud
+  group names) are untranslatable — ignore those sites.
+
+## Step 2 — Homogenize before adding (IMPORTANT)
+
+For every MISSING string, first check whether an already-registered string
+with the same meaning exists — reusing it means zero new translation work:
+
+```bash
+python3 -c "import json; d=json.load(open('l10n/de.json'))['translations']; \
+  print([k for k in d if 'SEARCHWORD' in k.lower()])"
+```
+
+- If a well-matching translated string exists (e.g. a generic error like
+  `Error loading data` / `Something went wrong`, or an audit-log wording),
+  **change the Flutter code to use that exact string** instead of adding a
+  new one. Meaning must be identical — don't force it: a verb button
+  ("Check in") is not the noun ("Check-in"), and platform conventions
+  ("Done") may be worth their own string.
+- Otherwise register the string in the App.vue block (alphabetical order).
+
+## Step 3 — Fix the drift
+
+- **Add MISSING** to the App.vue block. Mind the repo translation rules
+  (CLAUDE.md): sentence-case, no "successfully", ellipsis as ` …`
+  (NBSP before `…` — the Flutter side writes `'… …'` in Dart, the key
+  must match byte-for-byte), numbered placeholders stay as `{name}`.
+- **Remove STALE** lines — but grep the Flutter repo for a literal fragment
+  first; the string might be reached through data (then it belongs in
+  `data-keys.json`, not deleted).
+- Known trap: Dart implicit string concatenation (`"a " "b".tr()`) — the
+  key is the FULL concatenated string, never a fragment.
+- Strings used by web code but only reached indirectly (e.g. the audit-log
+  templates in `src/utils/auditFormat.js`) are registered near their
+  definition in that file, not in App.vue.
+
+## Step 4 — Verify and finish
+
+1. Re-run the script — it must exit 0 (no MISSING, no STALE).
+2. `npm run build` (never commit `js/`/`css/` build output).
+3. If Flutter code changed too, run `flutter analyze` on the touched files.
+4. Commit per repo (no Claude co-author), typically as `fix(l10n): …`.
+   Server-visible changes may also need the push-proxy repo
+   (`attendance-push`) — e.g. new trial-feedback reason codes must be
+   whitelisted in `handlers/feedback.go` there.

--- a/.claude/skills/l10n-drift/data-keys.json
+++ b/.claude/skills/l10n-drift/data-keys.json
@@ -1,0 +1,47 @@
+{
+  "note": "Translation keys that reach .tr() in attendance-flutter through data structures (lists/maps/params) instead of an adjacent string literal. check_drift.py cannot see these statically — it merges this list into the Flutter key set. When check_drift.py reports an UNRESOLVED call site, check whether the data it reads gained/lost keys and update the matching group here. Dynamic values (e.g. Nextcloud group names in checkin_screen.dart) are untranslatable and intentionally NOT listed.",
+  "keys": {
+    "lib/widgets/audit_format.dart — _buildSegments/_formatCheckin templates": [
+      "{actor} answered {response}",
+      "{actor} changed response from {from} to {to}",
+      "{actor} recorded check-in for {subject}: {state}",
+      "{actor} checked themselves in: {state}",
+      "Check-in recorded: {state}",
+      "{actor} updated check-in for {subject}: {state}",
+      "{actor} updated their own check-in: {state}",
+      "Check-in updated: {state}"
+    ],
+    "lib/widgets/audit_format.dart — _fieldLabels values": [
+      "name",
+      "description",
+      "time",
+      "visibility",
+      "response deadline"
+    ],
+    "lib/widgets/trial_feedback_sheet.dart — _reasons labels and prompts": [
+      "Too expensive",
+      "I'd buy it just for myself, not for my organization",
+      "I need an invoice",
+      "I'm missing a feature",
+      "I'm still evaluating",
+      "It's not my decision alone",
+      "Another reason",
+      "What would you be willing to pay?",
+      "Your fair price"
+    ],
+    "lib/screens/appointments_screen.dart — filter option values": [
+      "Yes",
+      "Maybe",
+      "No",
+      "No response",
+      "Opened",
+      "Closed"
+    ],
+    "lib/screens/create_appointment_screen.dart — duration units": [
+      "minutes",
+      "hours",
+      "days",
+      "weeks"
+    ]
+  }
+}

--- a/.claude/skills/l10n-drift/scripts/check_drift.py
+++ b/.claude/skills/l10n-drift/scripts/check_drift.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""Check translation-string drift between the Flutter app and this repo.
+
+The Flutter app (attendance-flutter) uses easy_localization with the English
+source strings as keys; Transifex only extracts strings registered in THIS
+repo (t()/n() in src/, $l->t() in lib/). Every key the Flutter app uses must
+therefore also appear here — mobile-only strings are registered in the
+module-scope block in src/App.vue.
+
+Extraction covers, on the Flutter side:
+  - string literals directly before .tr(/.plural( — incl. multi-line literals
+    and Dart implicit concatenation ("a " "b".tr() → key is the FULL string)
+  - parenthesised expressions before .tr( — ternaries and ?? defaults; every
+    literal inside the parens is treated as a candidate key
+  - data-driven keys (labels/templates stored in lists/maps and translated
+    later, e.g. r.label.tr()) via data-keys.json next to this script
+  - remaining .tr( call sites on plain identifiers are reported as
+    UNRESOLVED so a human can check whether data-keys.json needs updating
+
+Exit code 0 when clean, 1 when drift (or unresolved sites) was found.
+"""
+import argparse
+import json
+import os
+import re
+import sys
+
+LIT = r"(?:'((?:[^'\\]|\\.)*)'|\"((?:[^\"\\]|\\.)*)\")"
+LIT_RE = re.compile(LIT)
+CONCAT_TR_RE = re.compile(rf"((?:{LIT}\s+)*{LIT})\s*\.\s*(?:tr|plural)\s*\(")
+TR_CALL_RE = re.compile(r"\.\s*(?:tr|plural)\s*\(")
+# ncPlural(context, '%n singular', '%n plural', n) — the app's gettext-aware
+# plural helper (lib/services/nextcloud_asset_loader.dart); both forms are keys.
+NCPLURAL_RE = re.compile(rf"\bncPlural\s*\(\s*[^,()]*,\s*{LIT}\s*,\s*{LIT}")
+WEB_T_RE = re.compile(r"""\b[tn]\s*\(\s*['"]attendance['"]\s*,\s*""" + LIT)
+WEB_N2_RE = re.compile(
+    r"""\bn\s*\(\s*['"]attendance['"]\s*,\s*(?:'(?:[^'\\]|\\.)*'|"(?:[^"\\]|\\.)*")\s*,\s*"""
+    + LIT)
+PHP_T_RE = re.compile(r"->[tn]\s*\(\s*" + LIT)
+BLOCK_LINE_RE = re.compile(r"^t\(\s*'attendance',\s*" + LIT, re.M)
+
+
+def unesc(s):
+    s = re.sub(r'\\u([0-9a-fA-F]{4})', lambda m: chr(int(m.group(1), 16)), s)
+    return (s.replace("\\'", "'").replace('\\"', '"')
+            .replace('\\n', '\n').replace('\\t', '\t').replace('\\\\', '\\'))
+
+
+def lit_value(match, base=0):
+    """Value of a LIT match: exactly one of the two groups participated."""
+    a, b = match.group(base + 1), match.group(base + 2)
+    return unesc(a if a is not None else b)
+
+
+def walk(root, exts, skip=('.claude', 'build', 'node_modules', '.git')):
+    for dirpath, dirs, files in os.walk(root):
+        dirs[:] = [d for d in dirs if d not in skip]
+        for f in files:
+            if f.endswith(exts):
+                yield os.path.join(dirpath, f)
+
+
+def extract_web(app_root):
+    """All keys Transifex extracts from this repo (Vue/JS + PHP)."""
+    keys = set()
+    for p in walk(os.path.join(app_root, 'src'), ('.vue', '.js', '.ts')):
+        src = open(p, encoding='utf-8').read()
+        for m in WEB_T_RE.finditer(src):
+            keys.add(lit_value(m))
+        for m in WEB_N2_RE.finditer(src):
+            keys.add(lit_value(m))
+    for p in walk(os.path.join(app_root, 'lib'), ('.php',)):
+        src = open(p, encoding='utf-8').read()
+        for m in PHP_T_RE.finditer(src):
+            keys.add(lit_value(m))
+    return keys
+
+
+def matching_paren_start(src, close_idx):
+    """Index of the '(' matching src[close_idx] == ')' (skips string literals)."""
+    depth = 0
+    k = close_idx
+    while k >= 0:
+        ch = src[k]
+        if ch in "'\"":
+            q = ch
+            k -= 1
+            while k >= 0 and not (src[k] == q and (k == 0 or src[k - 1] != '\\')):
+                k -= 1
+        elif ch == ')':
+            depth += 1
+        elif ch == '(':
+            depth -= 1
+            if depth == 0:
+                return k
+        k -= 1
+    return 0
+
+
+def extract_flutter(flutter_root):
+    """Keys used by the Flutter app + unresolved (identifier-based) call sites."""
+    keys = set()
+    unresolved = []
+    for p in walk(os.path.join(flutter_root, 'lib'), ('.dart',)):
+        src = open(p, encoding='utf-8').read()
+        for m in CONCAT_TR_RE.finditer(src):
+            parts = [lit_value(mm) for mm in LIT_RE.finditer(m.group(1))]
+            keys.add(''.join(parts))
+        for m in NCPLURAL_RE.finditer(src):
+            keys.add(lit_value(m))
+            keys.add(lit_value(m, base=2))
+        for m in TR_CALL_RE.finditer(src):
+            j = m.start() - 1
+            while j >= 0 and src[j].isspace():
+                j -= 1
+            if j < 0 or src[j] in "'\"":
+                continue  # literal-adjacent: handled above
+            if src[j] == ')':
+                start = matching_paren_start(src, j)
+                for mm in LIT_RE.finditer(src[start:j + 1]):
+                    keys.add(lit_value(mm))
+            else:
+                line_no = src.count('\n', 0, m.start()) + 1
+                line = src.splitlines()[line_no - 1].strip()
+                if line.startswith('//'):
+                    continue  # doc/line comment, not code
+                rel = os.path.relpath(p, flutter_root)
+                site = f'{rel}:{line_no}: {line[:100]}'
+                if site not in unresolved:
+                    unresolved.append(site)
+    keys.discard('')
+    return keys, unresolved
+
+
+def load_data_keys(script_dir):
+    path = os.path.join(script_dir, '..', 'data-keys.json')
+    data = json.load(open(path, encoding='utf-8'))
+    keys = set()
+    for group in data['keys'].values():
+        keys.update(group)
+    return keys
+
+
+def app_vue_block(app_root):
+    """Keys in the module-scope registration block (column-0 t() lines)."""
+    src = open(os.path.join(app_root, 'src/App.vue'), encoding='utf-8').read()
+    return {lit_value(m) for m in BLOCK_LINE_RE.finditer(src)}
+
+
+def web_without_block(app_root):
+    """Web keys with App.vue's column-0 registration lines removed."""
+    keys = set()
+    for p in walk(os.path.join(app_root, 'src'), ('.vue', '.js', '.ts')):
+        src = open(p, encoding='utf-8').read()
+        if os.path.basename(p) == 'App.vue' and 'src/App.vue' in p.replace(os.sep, '/'):
+            src = BLOCK_LINE_RE.sub('', src)
+        for m in WEB_T_RE.finditer(src):
+            keys.add(lit_value(m))
+        for m in WEB_N2_RE.finditer(src):
+            keys.add(lit_value(m))
+    for p in walk(os.path.join(app_root, 'lib'), ('.php',)):
+        src = open(p, encoding='utf-8').read()
+        for m in PHP_T_RE.finditer(src):
+            keys.add(lit_value(m))
+    return keys
+
+
+def find_flutter_repo(app_root, override):
+    if override:
+        return os.path.abspath(override)
+    candidates = [
+        os.path.join(app_root, '..', 'attendance-flutter'),
+        os.path.join(app_root, '..', '..', 'attendance-flutter'),
+    ]
+    for c in candidates:
+        if os.path.isdir(os.path.join(c, 'lib')):
+            return os.path.abspath(c)
+    sys.exit('attendance-flutter repo not found — pass --flutter PATH')
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument('--flutter', help='path to the attendance-flutter repo')
+    ap.add_argument('--json', action='store_true', help='machine-readable output')
+    args = ap.parse_args()
+
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    app_root = os.path.abspath(os.path.join(script_dir, '..', '..', '..', '..'))
+    flutter_root = find_flutter_repo(app_root, args.flutter)
+
+    web = extract_web(app_root)
+    flutter, unresolved = extract_flutter(flutter_root)
+    flutter |= load_data_keys(script_dir)
+
+    missing = sorted(flutter - web)
+    stale = sorted(app_vue_block(app_root) - flutter - web_without_block(app_root))
+
+    if args.json:
+        print(json.dumps({'missing': missing, 'stale': stale,
+                          'unresolved': unresolved}, indent=1, ensure_ascii=False))
+    else:
+        print(f'Flutter repo: {flutter_root}')
+        print(f'MISSING in web app ({len(missing)}):')
+        for s in missing:
+            print('  ', json.dumps(s, ensure_ascii=False))
+        print(f'STALE in App.vue block ({len(stale)}):')
+        for s in stale:
+            print('  ', json.dumps(s, ensure_ascii=False))
+        print(f'UNRESOLVED .tr() call sites ({len(unresolved)}) — verify these are '
+              'covered by data-keys.json or dynamic (untranslatable) values:')
+        for s in unresolved:
+            print('  ', s)
+
+    sys.exit(1 if missing or stale else 0)
+
+
+if __name__ == '__main__':
+    main()

--- a/.claude/skills/l10n-pull/SKILL.md
+++ b/.claude/skills/l10n-pull/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: l10n-pull
+description: Pull the latest Transifex translations from this repo's main branch into the attendance-flutter app (copies l10n/*.json into assets/l10n/ and checks the supportedLocales list). Use when the user wants to update/sync/refresh the mobile app's translations, mentions "Übersetzungen ziehen", "neueste Übersetzungen", or after new strings were translated on Transifex.
+---
+
+# Pull translations into the Flutter app
+
+Transifex syncs translations nightly onto this repo's `main` branch
+(`l10n/*.json`, commits like "fix(l10n): Update translations from
+Transifex"). The Flutter app bundles verbatim copies under `assets/l10n/`
+and lists its locales in `lib/services/nextcloud_asset_loader.dart`
+(`supportedLocales`).
+
+## Step 1 — Dry run
+
+```bash
+python3 .claude/skills/l10n-pull/scripts/pull_translations.py --dry-run
+```
+
+Reads `origin/main` via `git show` (fetches first), so the local branch and
+working tree of this repo stay untouched. Review the report:
+
+- **changed / new** — locale files that will be updated or added.
+- **orphaned** — files in `assets/l10n/` with no upstream counterpart.
+  Do NOT delete blindly: check whether the language was really dropped
+  upstream or just renamed; removing a locale is user-visible.
+- **ADD to supportedLocales** — ready-to-paste `Locale(...)` lines for new
+  languages (special cases like `sr@latin` → `Locale.fromSubtags(languageCode:
+  'sr', scriptCode: 'Latn')` are handled by the loader; the script knows the
+  mapping).
+
+## Step 2 — Apply
+
+```bash
+python3 .claude/skills/l10n-pull/scripts/pull_translations.py
+```
+
+Then, if the report asked for it, add the new `Locale(...)` entries to
+`supportedLocales` in `lib/services/nextcloud_asset_loader.dart` (keep the
+list sorted like the surrounding entries).
+
+## Step 3 — Verify and finish
+
+In the Flutter repo:
+
+1. `flutter analyze lib/services/nextcloud_asset_loader.dart` if the loader
+   changed.
+2. Spot-check one updated file renders as valid JSON with the expected
+   structure: `{"translations": {...}, "pluralForm": "..."}`.
+3. Commit on a branch (e.g. `chore/l10n-update`) as
+   `fix(l10n): Update translations from attendance` — no Claude co-author —
+   and offer to open a PR.
+
+Note: run this AFTER new mobile strings have been translated on Transifex
+and synced to main; running it earlier is harmless but won't bring the new
+strings yet. The counterpart direction (registering new Flutter strings for
+extraction) is the `l10n-drift` skill.

--- a/.claude/skills/l10n-pull/scripts/pull_translations.py
+++ b/.claude/skills/l10n-pull/scripts/pull_translations.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Pull the latest Transifex translations from this repo into attendance-flutter.
+
+Translations land nightly on this repo's main branch (l10n/*.json). The
+Flutter app bundles verbatim copies under assets/l10n/. This script:
+
+  1. fetches origin/main (unless --no-fetch)
+  2. copies every l10n/*.json from origin/main into the Flutter repo's
+     assets/l10n/ (reads via `git show`, so the local working tree and
+     current branch of this repo stay untouched)
+  3. reports which locales are new/changed/removed and whether
+     lib/services/nextcloud_asset_loader.dart's supportedLocales list is
+     out of sync (printed as ready-to-paste Locale(...) lines)
+
+Use --dry-run to see what would change without writing anything.
+"""
+import argparse
+import os
+import re
+import subprocess
+import sys
+
+
+def run(args, cwd, **kw):
+    return subprocess.run(args, cwd=cwd, check=True, capture_output=True, **kw)
+
+
+def find_flutter_repo(app_root, override):
+    if override:
+        return os.path.abspath(override)
+    for c in (os.path.join(app_root, '..', 'attendance-flutter'),
+              os.path.join(app_root, '..', '..', 'attendance-flutter')):
+        if os.path.isdir(os.path.join(c, 'assets', 'l10n')):
+            return os.path.abspath(c)
+    sys.exit('attendance-flutter repo not found — pass --flutter PATH')
+
+
+def loader_locales(loader_src):
+    """Locales declared in the supportedLocales const, as file-stem strings."""
+    stems = set()
+    for m in re.finditer(r"Locale\('([A-Za-z0-9]+)'(?:,\s*'([A-Za-z0-9]+)')?\)",
+                         loader_src):
+        stems.add(m.group(1) + ('_' + m.group(2) if m.group(2) else ''))
+    # Nextcloud's sr@latin.json is declared via Locale.fromSubtags(sr, Latn).
+    for m in re.finditer(
+            r"Locale\.fromSubtags\(languageCode:\s*'([A-Za-z]+)',\s*"
+            r"scriptCode:\s*'Latn'\)", loader_src):
+        stems.add(m.group(1) + '@latin')
+    return stems
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument('--flutter', help='path to the attendance-flutter repo')
+    ap.add_argument('--no-fetch', action='store_true',
+                    help='skip `git fetch origin main`')
+    ap.add_argument('--dry-run', action='store_true',
+                    help='report only, write nothing')
+    args = ap.parse_args()
+
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    app_root = os.path.abspath(os.path.join(script_dir, '..', '..', '..', '..'))
+    flutter_root = find_flutter_repo(app_root, args.flutter)
+    dest_dir = os.path.join(flutter_root, 'assets', 'l10n')
+
+    if not args.no_fetch:
+        run(['git', 'fetch', 'origin', 'main'], cwd=app_root)
+
+    names = run(['git', 'ls-tree', '--name-only', 'origin/main', 'l10n/'],
+                cwd=app_root, text=True).stdout.split()
+    json_paths = sorted(p for p in names if p.endswith('.json'))
+    if not json_paths:
+        sys.exit('no l10n/*.json found in origin/main — wrong repo?')
+
+    added, changed, unchanged = [], [], []
+    upstream_stems = set()
+    for path in json_paths:
+        stem = os.path.splitext(os.path.basename(path))[0]
+        upstream_stems.add(stem)
+        content = run(['git', 'show', f'origin/main:{path}'], cwd=app_root).stdout
+        dest = os.path.join(dest_dir, os.path.basename(path))
+        if not os.path.exists(dest):
+            added.append(stem)
+        elif open(dest, 'rb').read() != content:
+            changed.append(stem)
+        else:
+            unchanged.append(stem)
+            continue
+        if not args.dry_run:
+            with open(dest, 'wb') as f:
+                f.write(content)
+
+    local_stems = {os.path.splitext(f)[0] for f in os.listdir(dest_dir)
+                   if f.endswith('.json')}
+    orphaned = sorted(local_stems - upstream_stems)
+
+    loader_path = os.path.join(flutter_root, 'lib', 'services',
+                               'nextcloud_asset_loader.dart')
+    declared = loader_locales(open(loader_path, encoding='utf-8').read())
+    missing_in_loader = sorted(upstream_stems - declared)
+    declared_without_file = sorted(declared - upstream_stems - {'en'})
+
+    mode = 'DRY RUN — nothing written' if args.dry_run else f'written to {dest_dir}'
+    print(f'{mode}')
+    print(f'changed: {len(changed)}  new: {len(added)}  unchanged: {len(unchanged)}')
+    if added:
+        print('new locales:', ', '.join(added))
+    if orphaned:
+        print('orphaned in assets/l10n (not in origin/main — check before '
+              'deleting):', ', '.join(orphaned))
+    if missing_in_loader:
+        print('\nADD to supportedLocales in lib/services/nextcloud_asset_loader.dart:')
+        for stem in missing_in_loader:
+            parts = stem.split('_', 1)
+            arg = f"'{parts[0]}', '{parts[1]}'" if len(parts) == 2 else f"'{parts[0]}'"
+            print(f'  Locale({arg}),')
+    if declared_without_file:
+        print('declared in supportedLocales but no upstream file (check/remove):',
+              ', '.join(declared_without_file))
+    if not missing_in_loader and not declared_without_file:
+        print('supportedLocales is in sync.')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary

Two agent skills for the recurring Flutter ↔ web translation workflows:

**l10n-drift** — checks and fixes string drift between `attendance-flutter` and this repo. `scripts/check_drift.py` extracts keys from both codebases (incl. multi-line literals, Dart implicit concatenation, ternary/`??` expressions, `ncPlural` pairs, and data-driven keys via `data-keys.json`), reports MISSING/STALE/UNRESOLVED, and the skill walks through homogenizing onto already-translated strings before registering new ones.

**l10n-pull** — copies the nightly Transifex translations from `origin/main` (`l10n/*.json`) into the Flutter app's `assets/l10n/` via `git show` (working tree stays untouched) and diffs the `supportedLocales` list in `nextcloud_asset_loader.dart`, printing ready-to-paste `Locale(...)` lines (incl. the `sr@latin`/`es_419` special cases).

Both scripts tested against the current repos: drift check correctly reports exactly the 5 strings pending in luflow/attendance-flutter#28, dry-run pull correctly reports 90 outdated locale files and 6 orphaned locales (km, kn, ms_MY, ta, tk, ur_PK — removed upstream at some point).

🤖 Generated with [Claude Code](https://claude.com/claude-code)