### PR TITLE
Push notifications: admin UI polish + test reminder delivery fix

### DIFF
--- a/lib/Controller/AdminController.php
+++ b/lib/Controller/AdminController.php
@@ -298,7 +298,7 @@ class AdminController extends Controller {
 		}
 
 		try {
-			$this->notificationService->sendReminderToUser($appointment, $user->getUID());
+			$this->notificationService->sendReminderToUser($appointment, $user->getUID(), true);
 			return new DataResponse([
 				'sent' => 1,
 				'appointmentName' => $appointment->getName(),

--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -52,8 +52,10 @@ class Notifier implements INotifier {
 
 		$l = $this->l10nFactory->get('attendance', $languageCode);
 
-		// For single-appointment notifications, check if the user already responded
-		if (in_array($notification->getSubject(), ['appointment_reminder', 'appointment_created'])) {
+		// For single-appointment notifications, check if the user already responded.
+		// Test reminders skip this so the delivery chain can be verified end-to-end.
+		if (in_array($notification->getSubject(), ['appointment_reminder', 'appointment_created'])
+			&& !($notification->getSubjectParameters()['test'] ?? false)) {
 			$parameters = $notification->getSubjectParameters();
 			$appointmentId = $parameters['appointmentId'] ?? 0;
 			if ($appointmentId > 0) {

--- a/lib/Service/NotificationService.php
+++ b/lib/Service/NotificationService.php
@@ -275,7 +275,7 @@ class NotificationService {
 	 * @param \OCA\Attendance\Db\Appointment $appointment The appointment to remind about
 	 * @param string $userId The user to send the reminder to
 	 */
-	public function sendReminderToUser(Appointment $appointment, string $userId): void {
+	public function sendReminderToUser(Appointment $appointment, string $userId, bool $isTest = false): void {
 		if (!$this->isNotificationsAppEnabled()) {
 			$this->logger->warning('Cannot send reminder - notifications app is not enabled');
 			return;
@@ -289,7 +289,7 @@ class NotificationService {
 			return;
 		}
 
-		$this->sendReminderNotification($appointment, $userId);
+		$this->sendReminderNotification($appointment, $userId, $isTest);
 	}
 
 	/**
@@ -350,22 +350,29 @@ class NotificationService {
 	 * Internal: create and send a single reminder notification.
 	 * Does not check isNotificationsAppEnabled — callers must check first.
 	 */
-	private function sendReminderNotification(Appointment $appointment, string $userId): void {
+	private function sendReminderNotification(Appointment $appointment, string $userId, bool $isTest = false): void {
 		$appointmentUrl = $this->urlGenerator->linkToRouteAbsolute(
 			'attendance.page.appointment',
 			['id' => $appointment->getId()]
 		);
+
+		$subjectParameters = [
+			'appointmentId' => $appointment->getId(),
+			'name' => $appointment->getName(),
+			'startDatetime' => $appointment->getStartDatetime(),
+		];
+		// Test reminders bypass the already-responded dismissal in the Notifier,
+		// so admins can verify the delivery chain regardless of their own response.
+		if ($isTest) {
+			$subjectParameters['test'] = true;
+		}
 
 		$notification = $this->notificationManager->createNotification();
 		$notification->setApp('attendance')
 			->setUser($userId)
 			->setDateTime(new \DateTime())
 			->setObject('appointment', (string)$appointment->getId())
-			->setSubject('appointment_reminder', [
-				'appointmentId' => $appointment->getId(),
-				'name' => $appointment->getName(),
-				'startDatetime' => $appointment->getStartDatetime(),
-			])
+			->setSubject('appointment_reminder', $subjectParameters)
 			->setLink($appointmentUrl);
 
 		$this->notificationManager->notify($notification);

--- a/src/views/AdminSettings.vue
+++ b/src/views/AdminSettings.vue
@@ -461,7 +461,7 @@
 										{{ n('attendance', '{count} device registered for push notifications', '{count} devices registered for push notifications', pushDeviceCount, { count: pushDeviceCount }) }}
 									</p>
 									<NcButton
-										variant="tertiary"
+										variant="secondary"
 										:disabled="sendingTestReminder"
 										class="test-reminder-button"
 										data-test="button-test-push"
@@ -1166,8 +1166,6 @@ onMounted(async () => {
 	display: flex;
 	align-items: center;
 	gap: 8px;
-	color: var(--color-success);
-	font-weight: 500;
 }
 
 .mobile-app-links {

--- a/tests/unit/Notification/NotifierTest.php
+++ b/tests/unit/Notification/NotifierTest.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\Attendance\Tests\Unit\Notification;
+
+use OCA\Attendance\Db\AttendanceResponse;
+use OCA\Attendance\Db\AttendanceResponseMapper;
+use OCA\Attendance\Notification\Notifier;
+use OCA\Attendance\Service\QuickResponseTokenService;
+use OCP\IConfig;
+use OCP\IL10N;
+use OCP\IURLGenerator;
+use OCP\L10N\IFactory;
+use OCP\Notification\AlreadyProcessedException;
+use OCP\Notification\IAction;
+use OCP\Notification\INotification;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class NotifierTest extends TestCase {
+	/** @var IFactory|MockObject */
+	private $l10nFactory;
+	/** @var IURLGenerator|MockObject */
+	private $urlGenerator;
+	/** @var QuickResponseTokenService|MockObject */
+	private $tokenService;
+	/** @var IConfig|MockObject */
+	private $config;
+	/** @var AttendanceResponseMapper|MockObject */
+	private $responseMapper;
+
+	private Notifier $notifier;
+
+	protected function setUp(): void {
+		$this->l10nFactory = $this->createMock(IFactory::class);
+		$this->urlGenerator = $this->createMock(IURLGenerator::class);
+		$this->tokenService = $this->createMock(QuickResponseTokenService::class);
+		$this->config = $this->createMock(IConfig::class);
+		$this->responseMapper = $this->createMock(AttendanceResponseMapper::class);
+
+		$this->config->method('getUserValue')->willReturn('');
+
+		$l = $this->createMock(IL10N::class);
+		$l->method('t')->willReturnCallback(
+			static fn (string $text, array $params = []): string => vsprintf($text, $params),
+		);
+		$this->l10nFactory->method('get')->willReturn($l);
+
+		$this->notifier = new Notifier(
+			$this->l10nFactory,
+			$this->urlGenerator,
+			$this->tokenService,
+			$this->config,
+			$this->responseMapper,
+		);
+	}
+
+	private function mockReminderNotification(array $subjectParameters): INotification|MockObject {
+		$notification = $this->createMock(INotification::class);
+		$notification->method('getApp')->willReturn('attendance');
+		$notification->method('getSubject')->willReturn('appointment_reminder');
+		$notification->method('getSubjectParameters')->willReturn($subjectParameters);
+		$notification->method('getUser')->willReturn('alice');
+		$notification->method('setParsedSubject')->willReturnSelf();
+		$notification->method('setParsedMessage')->willReturnSelf();
+		$notification->method('setIcon')->willReturnSelf();
+		$notification->method('createAction')->willReturnCallback(function () {
+			$action = $this->createMock(IAction::class);
+			$action->method('setLabel')->willReturnSelf();
+			$action->method('setParsedLabel')->willReturnSelf();
+			$action->method('setLink')->willReturnSelf();
+			$action->method('setPrimary')->willReturnSelf();
+			return $action;
+		});
+		return $notification;
+	}
+
+	public function testReminderIsDismissedWhenUserAlreadyResponded(): void {
+		$response = new AttendanceResponse();
+		$response->setResponse('yes');
+		$this->responseMapper->method('findByAppointmentAndUser')
+			->with(42, 'alice')
+			->willReturn($response);
+
+		$notification = $this->mockReminderNotification([
+			'appointmentId' => 42,
+			'name' => 'Rehearsal',
+			'startDatetime' => '2026-08-01 18:00:00',
+		]);
+
+		$this->expectException(AlreadyProcessedException::class);
+		$this->notifier->prepare($notification, 'de');
+	}
+
+	public function testTestReminderBypassesAlreadyRespondedCheck(): void {
+		$this->responseMapper->expects($this->never())
+			->method('findByAppointmentAndUser');
+
+		$notification = $this->mockReminderNotification([
+			'appointmentId' => 42,
+			'name' => 'Rehearsal',
+			'startDatetime' => '2026-08-01 18:00:00',
+			'test' => true,
+		]);
+
+		$result = $this->notifier->prepare($notification, 'de');
+		$this->assertSame($notification, $result);
+	}
+
+	public function testReminderIsKeptForMaybeResponders(): void {
+		$response = new AttendanceResponse();
+		$response->setResponse('maybe');
+		$this->responseMapper->method('findByAppointmentAndUser')
+			->with(42, 'alice')
+			->willReturn($response);
+
+		$notification = $this->mockReminderNotification([
+			'appointmentId' => 42,
+			'name' => 'Rehearsal',
+			'startDatetime' => '2026-08-01 18:00:00',
+		]);
+
+		$result = $this->notifier->prepare($notification, 'de');
+		$this->assertSame($notification, $result);
+	}
+}


### PR DESCRIPTION
## Summary

### UI (admin settings, push notifications section)
- The **registered devices** line is plain text now instead of the success-green highlight
- **Send test notification** is a secondary button (was tertiary, barely visible)

### Fix: test notification never arrived for admins who already responded
The `Notifier` dismisses `appointment_reminder` notifications via `AlreadyProcessedException` once the user has answered the appointment with yes or no. Since the test button sends a regular reminder for the next open appointment, the test notification was silently swallowed whenever the admin had already responded: the button reported success, but nothing showed up in the bell and no push reached the devices (verified against the push relay delivery log — only `type: background` delete-pushes went out).

Test reminders now carry a `test` subject parameter that skips the already-responded dismissal, so the button actually verifies the delivery chain end-to-end.

**Mobile compatibility:** the subject stays `appointment_reminder`; only an additional subject parameter is added. Older mobile clients are unaffected, no capability flag needed.

## Test plan
- [x] `composer test:unit` — 155 tests green, incl. new `NotifierTest` covering dismissal, maybe-responder passthrough, and the test-reminder bypass
- [ ] Manual: press *Send test notification* as an admin who already answered the next appointment → notification appears in bell + on device

🤖 Generated with [Claude Code](https://claude.com/claude-code)