### PR TITLE
ci: update first-party GitHub Actions to Node 24 majors

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
         with:
           path: ${{ env.APP_NAME }}
       - name: Run build

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Read package.json node and npm engines version
         uses: skjnldsv/read-package-engines-version-actions@06d6baf7d8f41934ab630e97d9e6c0bc9c9ac5e4 # v3
@@ -20,7 +20,7 @@ jobs:
           fallbackNpm: '^10'
 
       - name: Set up node ${{ steps.versions.outputs.nodeVersion }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ steps.versions.outputs.nodeVersion }}
 
@@ -53,7 +53,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: playwright-report
           path: playwright-report/
@@ -63,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up PHP
         uses: shivammathur/setup-php@v2


### PR DESCRIPTION
Fixes the deprecation warning `Node.js 20 is deprecated … forced to run on Node.js 24` in workflow logs.

- `actions/checkout` v2/v4 → v5 (release.yml still used the ancient v2)
- `actions/setup-node` v4 → v5
- `actions/upload-artifact` v4 → v5

Checked all release notes: the only breaking change is the Node 24 runtime plus minimum runner v2.327.1 (GitHub-hosted runners already exceed it). setup-node v5's new auto-caching only activates when `package.json` has a `packageManager` field — ours does not, so it is a no-op. Deliberately staying on checkout v5 (not v6, which changes credential persistence). Third-party actions (`shivammathur/setup-php`, `svenstaro/upload-release-action`, `R0Wi/nextcloud-appstore-push-action`, SHA-pinned `read-package-engines-version-actions`) are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)