### PR TITLE
fix(deps): bump brace-expansion to 5.0.8 (CVE-2026-14257)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "attendance",
-  "version": "1.40.0",
+  "version": "1.41.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "attendance",
-      "version": "1.40.0",
+      "version": "1.41.2",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@nextcloud/axios": "^2.6.0",
@@ -4276,16 +4276,16 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {


### PR DESCRIPTION
Replaces #116, which addressed the same advisory but in a way that would have made things worse.

## What

`npm audit` flags `brace-expansion <= 5.0.7` as a high-severity DoS (unbounded expansion → OOM crash), [GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg) / CVE-2026-14257.

The hoisted `5.0.7` instance was only pinned by the lockfile. The declaring ranges already permit `5.0.8`, so `npm update brace-expansion` is the whole fix — **no `package.json` change and no `overrides` entry needed**, and the entry stays `dev: true`.

The lockfile's `version` field also drifted (`1.40.0` vs. `1.41.2` in `package.json`); this syncs it.

## Coverage

Every `brace-expansion` in the tree comes in via `minimatch`:

| Path | Version | |
|---|---|---|
| `eslint@10.7.0` → `minimatch@10.2.5` | 5.0.8 | fixed here |
| `@nextcloud/vite-config` → `vite-plugin-dts` → `@microsoft/api-extractor` → `minimatch@10.2.3` | 5.0.8 | fixed here (deduped) |
| `@nextcloud/dialogs` → `webdav` → `minimatch@9.0.9` | 2.1.2 | remains — only non-dev path |
| `@nextcloud/vite-config` → `vite-plugin-dts` → `@vue/language-core` → `minimatch@9.0.9` | 2.1.2 | remains, dev-only |

`npm audit` reports **"No fix available"** for the two `2.1.2` paths: `2.1.2` is the latest `maintenance-v2` release and upstream shipped no 2.x backport.

Overriding them to 5.x is not viable. `minimatch@9` does `__importDefault(require("brace-expansion"))` and calls the default export; v2 is a function, whereas v5 is ESM-first and exports a `{ expand, … }` object — the call would throw at runtime.

Impact of the remainder is low regardless: `brace-expansion` is not imported anywhere in `src/`, never reaches the Vite bundle, and the input to `minimatch` here is glob patterns from build tooling, not user data. Left for upstream.

## Verification

- [x] `npm run build` passes
- [x] `npm audit` no longer lists `node_modules/brace-expansion` (3 flagged paths → 2)
- [x] Lockfile integrity hash matches `registry.npmjs.org` for `brace-expansion@5.0.8`
- [x] Diff is `package-lock.json` only, 6 lines