### PR TITLE
fix(booking): show a passed-over user that they are not scheduled

### DIFF
--- a/lib/Service/AppointmentService.php
+++ b/lib/Service/AppointmentService.php
@@ -672,7 +672,7 @@ class AppointmentService {
 		// A row with response=NULL exists when an admin checked the user in
 		// before they ever responded; treat that as "no response" (matches list endpoint).
 		$userResponse = $this->getUserResponse($appointment->getId(), $userId);
-		$appointmentData['userResponse'] = ($userResponse && $userResponse->getResponse() !== null) ? $userResponse : null;
+		$appointmentData['userResponse'] = $this->serializeUserResponse($appointment, $userResponse, $userId);
 		if ($myPermissions['canSeeResponses']) {
 			$appointmentData['responseSummary'] = $this->responseSummaryService->getResponseSummary($appointment->getId(), $myPermissions['canSeeComments']);
 		}
@@ -694,6 +694,29 @@ class AppointmentService {
 	 *
 	 * @return array{isOrganizer: bool, canEdit: bool, canSeeResponses: bool, canSeeComments: bool, canSeeAuditLog: bool}
 	 */
+	/**
+	 * The user's own response as the clients receive it, with the booking
+	 * status resolved to the verdict the user is actually under.
+	 *
+	 * @return array<string, mixed>|null
+	 */
+	private function serializeUserResponse(
+		Appointment $appointment,
+		?AttendanceResponse $userResponse,
+		string $userId,
+	): ?array {
+		if ($userResponse === null || $userResponse->getResponse() === null) {
+			return null;
+		}
+		$data = $userResponse->jsonSerialize();
+		$data['bookingStatus'] = $this->bookingService->effectiveBookingStatus(
+			$appointment,
+			$userResponse,
+			$userId,
+		);
+		return $data;
+	}
+
 	private function buildMyPermissions(
 		Appointment $appointment,
 		string $userId,
@@ -1008,7 +1031,7 @@ class AppointmentService {
 			$appointmentData = $appointment->jsonSerialize();
 			$appointmentData = $this->enrichVisibilityData($appointmentData);
 			$appointmentData = $this->enrichSeriesCount($appointmentData, $appointment);
-			$appointmentData['userResponse'] = $hasResponse ? $userResponse : null;
+			$appointmentData['userResponse'] = $hasResponse ? $this->serializeUserResponse($appointment, $userResponse, $userId) : null;
 			if ($myPermissions['canSeeResponses']) {
 				$appointmentData['responseSummary'] = $this->responseSummaryService->getResponseSummary($appointment->getId(), $myPermissions['canSeeComments']);
 			}
@@ -1048,7 +1071,7 @@ class AppointmentService {
 			$appointmentData = $appointment->jsonSerialize();
 			$appointmentData = $this->enrichVisibilityData($appointmentData);
 			$userResponse = $this->getUserResponse($appointment->getId(), $userId);
-			$appointmentData['userResponse'] = ($userResponse && $userResponse->getResponse() !== null) ? $userResponse : null;
+			$appointmentData['userResponse'] = $this->serializeUserResponse($appointment, $userResponse, $userId);
 			$appointmentData['attachments'] = $this->attachmentService->getAttachments($appointment->getId());
 			$result[] = $appointmentData;
 			$count++;

--- a/lib/Service/AppointmentService.php
+++ b/lib/Service/AppointmentService.php
@@ -672,7 +672,7 @@ class AppointmentService {
 		// A row with response=NULL exists when an admin checked the user in
 		// before they ever responded; treat that as "no response" (matches list endpoint).
 		$userResponse = $this->getUserResponse($appointment->getId(), $userId);
-		$appointmentData['userResponse'] = $this->serializeUserResponse($appointment, $userResponse, $userId);
+		$appointmentData['userResponse'] = $this->serializeUserResponse($userResponse);
 		if ($myPermissions['canSeeResponses']) {
 			$appointmentData['responseSummary'] = $this->responseSummaryService->getResponseSummary($appointment->getId(), $myPermissions['canSeeComments']);
 		}
@@ -694,29 +694,6 @@ class AppointmentService {
 	 *
 	 * @return array{isOrganizer: bool, canEdit: bool, canSeeResponses: bool, canSeeComments: bool, canSeeAuditLog: bool}
 	 */
-	/**
-	 * The user's own response as the clients receive it, with the booking
-	 * status resolved to the verdict the user is actually under.
-	 *
-	 * @return array<string, mixed>|null
-	 */
-	private function serializeUserResponse(
-		Appointment $appointment,
-		?AttendanceResponse $userResponse,
-		string $userId,
-	): ?array {
-		if ($userResponse === null || $userResponse->getResponse() === null) {
-			return null;
-		}
-		$data = $userResponse->jsonSerialize();
-		$data['bookingStatus'] = $this->bookingService->effectiveBookingStatus(
-			$appointment,
-			$userResponse,
-			$userId,
-		);
-		return $data;
-	}
-
 	private function buildMyPermissions(
 		Appointment $appointment,
 		string $userId,
@@ -742,6 +719,21 @@ class AppointmentService {
 			'canSeeComments' => $globalSeeComments || $isOrganizer,
 			'canSeeAuditLog' => $canSeeAuditLog,
 		];
+	}
+
+	/**
+	 * The user's own response as the clients receive it, carrying the booking
+	 * verdict they were actually told rather than the raw column.
+	 *
+	 * @return array<string, mixed>|null
+	 */
+	private function serializeUserResponse(?AttendanceResponse $userResponse): ?array {
+		if ($userResponse === null || $userResponse->getResponse() === null) {
+			return null;
+		}
+		$data = $userResponse->jsonSerialize();
+		$data['bookingStatus'] = $this->bookingService->effectiveBookingStatus($userResponse);
+		return $data;
 	}
 
 	/**
@@ -1031,7 +1023,7 @@ class AppointmentService {
 			$appointmentData = $appointment->jsonSerialize();
 			$appointmentData = $this->enrichVisibilityData($appointmentData);
 			$appointmentData = $this->enrichSeriesCount($appointmentData, $appointment);
-			$appointmentData['userResponse'] = $hasResponse ? $this->serializeUserResponse($appointment, $userResponse, $userId) : null;
+			$appointmentData['userResponse'] = $this->serializeUserResponse($userResponse);
 			if ($myPermissions['canSeeResponses']) {
 				$appointmentData['responseSummary'] = $this->responseSummaryService->getResponseSummary($appointment->getId(), $myPermissions['canSeeComments']);
 			}
@@ -1071,7 +1063,7 @@ class AppointmentService {
 			$appointmentData = $appointment->jsonSerialize();
 			$appointmentData = $this->enrichVisibilityData($appointmentData);
 			$userResponse = $this->getUserResponse($appointment->getId(), $userId);
-			$appointmentData['userResponse'] = $this->serializeUserResponse($appointment, $userResponse, $userId);
+			$appointmentData['userResponse'] = $this->serializeUserResponse($userResponse);
 			$appointmentData['attachments'] = $this->attachmentService->getAttachments($appointment->getId());
 			$result[] = $appointmentData;
 			$count++;

--- a/lib/Service/BookingService.php
+++ b/lib/Service/BookingService.php
@@ -130,27 +130,21 @@ class BookingService {
 	}
 
 	/**
-	 * The booking status as the user should be told it, which is not always the
-	 * one on the row.
+	 * The booking status as the user was actually told it.
 	 *
-	 * The close-time wave stamps every yes-responder 'booked' or 'declined', so
-	 * normally the stored value is the whole truth. It can fall behind, though:
-	 * a wave that found nobody booked stamps no one, and a later booking (after
-	 * a reopen and re-close) leaves the people it passed over still sitting on
-	 * null. To them the appointment reads "you answered yes" when in fact a
-	 * place went to someone else — so fall back to the same verdict the filter
-	 * already draws in [isScheduledOut].
+	 * 'declined' never reaches the booking_status column: only book()/unbook()
+	 * write there, so it holds 'booked' or nothing. The verdict for everyone
+	 * else is recorded by the close-time wave in bookingNotifiedStatus, which
+	 * is what those people received a notification about — and therefore what
+	 * their appointment should keep saying. Reading it costs nothing: it is a
+	 * column on the row the caller already holds.
+	 *
+	 * The wave's own guards come along for free — it skips anyone who did not
+	 * answer yes, and it does not run at all unless somebody got a place, so an
+	 * appointment where planning was never used stays unmarked.
 	 */
-	public function effectiveBookingStatus(
-		Appointment $appointment,
-		AttendanceResponse $response,
-		string $userId,
-	): ?string {
-		$stored = $response->getBookingStatus();
-		if ($stored !== null) {
-			return $stored;
-		}
-		return $this->isScheduledOut($appointment, $userId) ? self::STATUS_DECLINED : null;
+	public function effectiveBookingStatus(AttendanceResponse $response): ?string {
+		return $response->getBookingStatus() ?? $response->getBookingNotifiedStatus();
 	}
 
 	/**

--- a/lib/Service/BookingService.php
+++ b/lib/Service/BookingService.php
@@ -130,6 +130,30 @@ class BookingService {
 	}
 
 	/**
+	 * The booking status as the user should be told it, which is not always the
+	 * one on the row.
+	 *
+	 * The close-time wave stamps every yes-responder 'booked' or 'declined', so
+	 * normally the stored value is the whole truth. It can fall behind, though:
+	 * a wave that found nobody booked stamps no one, and a later booking (after
+	 * a reopen and re-close) leaves the people it passed over still sitting on
+	 * null. To them the appointment reads "you answered yes" when in fact a
+	 * place went to someone else — so fall back to the same verdict the filter
+	 * already draws in [isScheduledOut].
+	 */
+	public function effectiveBookingStatus(
+		Appointment $appointment,
+		AttendanceResponse $response,
+		string $userId,
+	): ?string {
+		$stored = $response->getBookingStatus();
+		if ($stored !== null) {
+			return $stored;
+		}
+		return $this->isScheduledOut($appointment, $userId) ? self::STATUS_DECLINED : null;
+	}
+
+	/**
 	 * Notification wave triggered when an appointment is closed: tell booked
 	 * yes-responders they are planned in and the remaining yes-responders they
 	 * are not. Rules:

--- a/tests/unit/Service/BookingServiceTest.php
+++ b/tests/unit/Service/BookingServiceTest.php
@@ -252,4 +252,67 @@ class BookingServiceTest extends TestCase {
 
 		$this->assertTrue($this->service->isScheduledOut($this->closedAppointment(), 'alice'));
 	}
+
+	// --- effectiveBookingStatus: what the user is actually told ---
+
+	public function testEffectiveBookingStatusKeepsTheStoredVerdict(): void {
+		// The close-time wave already spoke; nothing to second-guess.
+		$this->configService->expects($this->never())->method('isBookingEnabled');
+
+		$booked = $this->response('alice', 'yes', BookingService::STATUS_BOOKED);
+		$this->assertSame(
+			BookingService::STATUS_BOOKED,
+			$this->service->effectiveBookingStatus($this->closedAppointment(), $booked, 'alice'),
+		);
+	}
+
+	public function testEffectiveBookingStatusDeclinesWhenSomebodyElseGotThePlace(): void {
+		// Never stamped — a wave that ran before this booking passed them over.
+		// Without this the card would read "you answered yes" to someone who is
+		// not coming.
+		$this->configService->method('isBookingEnabled')->willReturn(true);
+		$this->responseMapper->method('findByAppointment')->willReturn([
+			$this->response('bob', 'yes', BookingService::STATUS_BOOKED),
+			$this->response('alice', 'yes'),
+		]);
+
+		$this->assertSame(
+			BookingService::STATUS_DECLINED,
+			$this->service->effectiveBookingStatus(
+				$this->closedAppointment(),
+				$this->response('alice', 'yes'),
+				'alice',
+			),
+		);
+	}
+
+	public function testEffectiveBookingStatusStaysOpenWhenNobodyWasScheduled(): void {
+		// The manager does not use planning — a red "not scheduled" on every
+		// yes-responder would be pure noise.
+		$this->configService->method('isBookingEnabled')->willReturn(true);
+		$this->responseMapper->method('findByAppointment')->willReturn([
+			$this->response('alice', 'yes'),
+			$this->response('bob', 'yes'),
+		]);
+
+		$this->assertNull(
+			$this->service->effectiveBookingStatus(
+				$this->closedAppointment(),
+				$this->response('alice', 'yes'),
+				'alice',
+			),
+		);
+	}
+
+	public function testEffectiveBookingStatusStaysOpenWhileTheInquiryRuns(): void {
+		$this->configService->method('isBookingEnabled')->willReturn(true);
+
+		$this->assertNull(
+			$this->service->effectiveBookingStatus(
+				$this->appointment(),
+				$this->response('alice', 'yes'),
+				'alice',
+			),
+		);
+	}
 }

--- a/tests/unit/Service/BookingServiceTest.php
+++ b/tests/unit/Service/BookingServiceTest.php
@@ -255,64 +255,40 @@ class BookingServiceTest extends TestCase {
 
 	// --- effectiveBookingStatus: what the user is actually told ---
 
-	public function testEffectiveBookingStatusKeepsTheStoredVerdict(): void {
-		// The close-time wave already spoke; nothing to second-guess.
-		$this->configService->expects($this->never())->method('isBookingEnabled');
-
-		$booked = $this->response('alice', 'yes', BookingService::STATUS_BOOKED);
+	public function testEffectiveBookingStatusKeepsAStoredBooking(): void {
 		$this->assertSame(
 			BookingService::STATUS_BOOKED,
-			$this->service->effectiveBookingStatus($this->closedAppointment(), $booked, 'alice'),
+			$this->service->effectiveBookingStatus(
+				$this->response('alice', 'yes', BookingService::STATUS_BOOKED),
+			),
 		);
 	}
 
-	public function testEffectiveBookingStatusDeclinesWhenSomebodyElseGotThePlace(): void {
-		// Never stamped — a wave that ran before this booking passed them over.
-		// Without this the card would read "you answered yes" to someone who is
-		// not coming.
-		$this->configService->method('isBookingEnabled')->willReturn(true);
-		$this->responseMapper->method('findByAppointment')->willReturn([
-			$this->response('bob', 'yes', BookingService::STATUS_BOOKED),
-			$this->response('alice', 'yes'),
-		]);
-
+	public function testEffectiveBookingStatusReportsWhatTheCloseWaveTold(): void {
+		// 'declined' never reaches booking_status — only book()/unbook() write
+		// there. Without reading the wave's own column the card would tell a
+		// passed-over user "you answered yes" and nothing more.
 		$this->assertSame(
 			BookingService::STATUS_DECLINED,
 			$this->service->effectiveBookingStatus(
-				$this->closedAppointment(),
-				$this->response('alice', 'yes'),
-				'alice',
+				$this->response('alice', 'yes', null, BookingService::STATUS_DECLINED),
 			),
 		);
 	}
 
-	public function testEffectiveBookingStatusStaysOpenWhenNobodyWasScheduled(): void {
-		// The manager does not use planning — a red "not scheduled" on every
-		// yes-responder would be pure noise.
-		$this->configService->method('isBookingEnabled')->willReturn(true);
-		$this->responseMapper->method('findByAppointment')->willReturn([
-			$this->response('alice', 'yes'),
-			$this->response('bob', 'yes'),
-		]);
-
+	public function testEffectiveBookingStatusIsOpenWhenNoWaveHasRun(): void {
+		// Planning never used, or the inquiry still running: nothing to say.
 		$this->assertNull(
-			$this->service->effectiveBookingStatus(
-				$this->closedAppointment(),
-				$this->response('alice', 'yes'),
-				'alice',
-			),
+			$this->service->effectiveBookingStatus($this->response('alice', 'yes')),
 		);
 	}
 
-	public function testEffectiveBookingStatusStaysOpenWhileTheInquiryRuns(): void {
-		$this->configService->method('isBookingEnabled')->willReturn(true);
+	public function testEffectiveBookingStatusCostsNoQuery(): void {
+		// It reads two columns of a row the caller already holds; a list
+		// endpoint calls this once per appointment.
+		$this->responseMapper->expects($this->never())->method('findByAppointment');
+		$this->configService->expects($this->never())->method('isBookingEnabled');
 
-		$this->assertNull(
-			$this->service->effectiveBookingStatus(
-				$this->appointment(),
-				$this->response('alice', 'yes'),
-				'alice',
-			),
-		);
+		$this->service->effectiveBookingStatus($this->response('alice', 'no'));
 	}
 }


### PR DESCRIPTION
## Das Problem

Niemand hat je das Badge **„Nicht eingeplant"** gesehen — weder im Web noch in der App.

Der Grund liegt tiefer als die Anzeige: `'declined'` landet **nie** in der Spalte `booking_status`. Dort schreiben nur `book()` und `unbook()`, und `unbook()` schreibt `null`. Das Verdikt, das beim Schließen für jeden Ja-Antwortenden berechnet wird (`booked ? 'booked' : 'declined'`), speichert die Schließ-Welle unter `bookingNotifiedStatus` — also unter „was wir dieser Person mitgeteilt haben".

Beide Clients lasen die falsche Spalte und zeigten deshalb weiterhin nur die Antwort („Ja") von jemandem, dessen Platz längst an eine andere Person gegangen war.

## Die Änderung

`BookingService::effectiveBookingStatus()` liefert den Status, den die Person tatsächlich erfahren hat: den gespeicherten, sonst den der Welle. Die drei Termin-Payloads geben ihn als `bookingStatus` aus, sodass **beide Clients ohne eigene Änderung** korrekt werden.

Die Wachen der Welle kommen dabei kostenlos mit:

- Wer nicht „Ja" geantwortet hat, wird übersprungen — ein Nein-Sager bekommt kein „Nicht eingeplant"
- Ohne mindestens eine Buchung läuft keine Welle — bei Terminen, wo Einplanung nie genutzt wurde, bleibt alles unmarkiert

Der Lesezugriff kostet nichts: zwei Spalten der Zeile, die der Aufrufer ohnehin geladen hat.

## Was ein Review verhindert hat

Der erste Entwurf leitete das Verdikt über `isScheduledOut()` ab. Das lädt **alle** Antworten eines Termins, um ein einziges Bool zu bestimmen — bei hundert vergangenen Terminen also hundert Abfragen mit tausenden hydrierten Zeilen, an einer Stelle sogar doppelt, weil der `notScheduledOut`-Filter dieselbe Frage schon gestellt hatte. Und weil `isScheduledOut()` die eigene Antwort nicht prüft, hätte ein Nein-Sager „Nicht eingeplant" gesehen.

## Verifikation

`composer test:unit` — 187 Tests, 402 Assertions. Vier neue decken ab: gespeicherte Buchung gewinnt, Wellen-Verdikt wird gemeldet, ohne Welle bleibt es offen, und der Pfad löst keine Abfrage aus.

`composer openapi` erzeugt keine Änderung — die Feldstruktur bleibt, nur der Wert wird aufgelöst.