### PR TITLE
feat(response): let managers set answers on behalf of users

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -28,6 +28,7 @@ return [
 
 		// Attendance response routes
 		['name' => 'appointment#respond', 'url' => '/api/appointments/{id}/respond', 'verb' => 'POST'],
+		['name' => 'appointment#respondForUser', 'url' => '/api/appointments/{appointmentId}/respond/{targetUserId}', 'verb' => 'POST'],
 		['name' => 'appointment#getResponses', 'url' => '/api/appointments/{id}/responses', 'verb' => 'GET'],
 
 		// Audit log

--- a/lib/Audit/Verb.php
+++ b/lib/Audit/Verb.php
@@ -63,6 +63,7 @@ final class Verb {
 	public const SOURCE_APP = 'app';
 	public const SOURCE_QUICK_LINK = 'quick_link';
 	public const SOURCE_ADMIN_CHECKIN = 'admin_checkin';
+	public const SOURCE_ADMIN_RESPONSE = 'admin_response';
 	public const SOURCE_SELF_CHECKIN = 'self_checkin';
 	public const SOURCE_LEGACY_BACKFILL = 'legacy_backfill';
 	public const SOURCE_AUTO_CLOSE = 'auto_close';

--- a/lib/Controller/AppointmentController.php
+++ b/lib/Controller/AppointmentController.php
@@ -719,7 +719,7 @@ class AppointmentController extends Controller {
 	}
 
 	/**
-	 * Set or clear a response on behalf of another user (requires manage appointments permission or being an organizer)
+	 * Set or clear a response on behalf of another user (requires the respond-for-others permission)
 	 *
 	 * @param int $appointmentId Appointment ID
 	 * @param string $targetUserId User ID whose response is set
@@ -735,9 +735,16 @@ class AppointmentController extends Controller {
 			return new DataResponse(['error' => 'User not authenticated'], 401);
 		}
 
-		$appointment = $this->findManageableAppointment($appointmentId, $user->getUID(), 'Insufficient permissions to set responses for other users');
-		if ($appointment instanceof DataResponse) {
-			return $appointment;
+		// Own permission, deliberately not implied by manage/organizer rights —
+		// only members of the explicitly configured groups may answer for others.
+		if (!$this->permissionService->canRespondForOthers($user->getUID())) {
+			return new DataResponse(['error' => 'Insufficient permissions to set responses for other users'], 403);
+		}
+
+		try {
+			$appointment = $this->appointmentService->getAppointment($appointmentId);
+		} catch (\Exception $e) {
+			return new DataResponse(['error' => 'Appointment not found'], 404);
 		}
 
 		try {
@@ -875,6 +882,7 @@ class AppointmentController extends Controller {
 			'canSeeResponseOverview' => $this->permissionService->canSeeResponseOverview($user->getUID()),
 			'canSeeComments' => $this->permissionService->canSeeComments($user->getUID()),
 			'canSelfCheckin' => $this->permissionService->canSelfCheckin($user->getUID()),
+			'canRespondForOthers' => $this->permissionService->canRespondForOthers($user->getUID()),
 		]);
 	}
 
@@ -919,9 +927,11 @@ class AppointmentController extends Controller {
 			// myPermissions payload, create_appointments permission). Mobile
 			// clients hide organizer UI when this is false.
 			'organizers' => true,
-			// Server supports POST /respond/{targetUserId} so managers can
-			// set an answer on behalf of a person (issue #47). Mobile clients
-			// hide the on-behalf picker when this is false.
+			// Server supports POST /respond/{targetUserId} for setting an
+			// answer on behalf of a person (issue #47), gated by the
+			// respond_for_others permission. Mobile clients hide the
+			// on-behalf picker when this is false or the user lacks the
+			// permission (getPermissions.canRespondForOthers).
 			'respondOnBehalf' => true,
 		]);
 	}

--- a/lib/Controller/AppointmentController.php
+++ b/lib/Controller/AppointmentController.php
@@ -742,7 +742,7 @@ class AppointmentController extends Controller {
 
 		try {
 			$attendanceResponse = $this->appointmentService->submitResponseForUser(
-				$appointmentId,
+				$appointment,
 				$targetUserId,
 				$response,
 				$user->getUID()

--- a/lib/Controller/AppointmentController.php
+++ b/lib/Controller/AppointmentController.php
@@ -719,6 +719,41 @@ class AppointmentController extends Controller {
 	}
 
 	/**
+	 * Set or clear a response on behalf of another user (requires manage appointments permission or being an organizer)
+	 *
+	 * @param int $appointmentId Appointment ID
+	 * @param string $targetUserId User ID whose response is set
+	 * @param ?string $response Response value: yes, no, maybe — or null to clear the response so the person counts as "not yet responded" again
+	 * @return DataResponse<Http::STATUS_OK, AttendanceResponseData, array{}>|DataResponse<Http::STATUS_BAD_REQUEST, array{error: string}, array{}>|DataResponse<Http::STATUS_UNAUTHORIZED, array{error: string}, array{}>|DataResponse<Http::STATUS_FORBIDDEN, array{error: string}, array{}>|DataResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>
+	 */
+	#[NoAdminRequired]
+	#[NoCSRFRequired]
+	#[OpenAPI]
+	public function respondForUser(int $appointmentId, string $targetUserId, ?string $response = null): DataResponse {
+		$user = $this->userSession->getUser();
+		if (!$user) {
+			return new DataResponse(['error' => 'User not authenticated'], 401);
+		}
+
+		$appointment = $this->findManageableAppointment($appointmentId, $user->getUID(), 'Insufficient permissions to set responses for other users');
+		if ($appointment instanceof DataResponse) {
+			return $appointment;
+		}
+
+		try {
+			$attendanceResponse = $this->appointmentService->submitResponseForUser(
+				$appointmentId,
+				$targetUserId,
+				$response,
+				$user->getUID()
+			);
+			return new DataResponse($attendanceResponse);
+		} catch (\Exception $e) {
+			return new DataResponse(['error' => $e->getMessage()], 400);
+		}
+	}
+
+	/**
 	 * Get upcoming appointments for dashboard widget
 	 *
 	 * @return DataResponse<Http::STATUS_OK, list<AttendanceAppointmentWithResponse>, array{}>|DataResponse<Http::STATUS_BAD_REQUEST, array{error: string}, array{}>|DataResponse<Http::STATUS_UNAUTHORIZED, array{error: string}, array{}>
@@ -884,6 +919,10 @@ class AppointmentController extends Controller {
 			// myPermissions payload, create_appointments permission). Mobile
 			// clients hide organizer UI when this is false.
 			'organizers' => true,
+			// Server supports POST /respond/{targetUserId} so managers can
+			// set an answer on behalf of a person (issue #47). Mobile clients
+			// hide the on-behalf picker when this is false.
+			'respondOnBehalf' => true,
 		]);
 	}
 

--- a/lib/Listener/ResponseChangeNotificationListener.php
+++ b/lib/Listener/ResponseChangeNotificationListener.php
@@ -128,10 +128,15 @@ class ResponseChangeNotificationListener {
 
 	private function subjectParametersFor(AuditEvent $event, string $appointmentName): array {
 		$meta = $event->getMetaArray();
+		$actor = $event->getActorId() ?? '';
+		$subject = $event->getSubjectId() ?? '';
 		return [
 			'appointmentId' => $event->getAppointmentId(),
 			'appointmentName' => $appointmentName,
-			'actor' => $event->getActorId() ?? '',
+			'actor' => $actor,
+			// Only set when someone answered on behalf of another person —
+			// the Notifier then renders the on-behalf wording.
+			'onBehalfOf' => $subject !== '' && $subject !== $actor ? $subject : '',
 			'from' => (string)($meta['from'] ?? ''),
 			'to' => (string)($meta['to'] ?? ($meta['response'] ?? '')),
 		];

--- a/lib/Listener/ResponseChangeNotificationListener.php
+++ b/lib/Listener/ResponseChangeNotificationListener.php
@@ -128,15 +128,13 @@ class ResponseChangeNotificationListener {
 
 	private function subjectParametersFor(AuditEvent $event, string $appointmentName): array {
 		$meta = $event->getMetaArray();
-		$actor = $event->getActorId() ?? '';
-		$subject = $event->getSubjectId() ?? '';
 		return [
 			'appointmentId' => $event->getAppointmentId(),
 			'appointmentName' => $appointmentName,
-			'actor' => $actor,
-			// Only set when someone answered on behalf of another person —
-			// the Notifier then renders the on-behalf wording.
-			'onBehalfOf' => $subject !== '' && $subject !== $actor ? $subject : '',
+			'actor' => $event->getActorId() ?? '',
+			// Shipped verbatim like the audit API does — the Notifier collapses
+			// subject == actor into the self wording, same as the audit renderers.
+			'subject' => $event->getSubjectId() ?? '',
 			'from' => (string)($meta['from'] ?? ''),
 			'to' => (string)($meta['to'] ?? ($meta['response'] ?? '')),
 		];

--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -203,10 +203,14 @@ class Notifier implements INotifier {
 	private function prepareResponseChangeNotification(INotification $notification, \OCP\IL10N $l): INotification {
 		$params = $notification->getSubjectParameters();
 		$actor = (string)($params['actor'] ?? '');
-		$onBehalfOf = (string)($params['onBehalfOf'] ?? '');
+		$subject = (string)($params['subject'] ?? '');
 		$appointmentName = (string)($params['appointmentName'] ?? '');
 		$from = (string)($params['from'] ?? '');
 		$to = (string)($params['to'] ?? '');
+
+		// Same collapse rule as the audit renderers: a subject only shows up
+		// in the wording when someone answered on behalf of another person.
+		$onBehalfOf = ($subject !== '' && $subject !== $actor) ? $subject : '';
 
 		$actorLabel = $actor !== '' ? $actor : $l->t('Someone');
 		$fromLabel = $this->translateResponseValue($from, $l);

--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -203,6 +203,7 @@ class Notifier implements INotifier {
 	private function prepareResponseChangeNotification(INotification $notification, \OCP\IL10N $l): INotification {
 		$params = $notification->getSubjectParameters();
 		$actor = (string)($params['actor'] ?? '');
+		$onBehalfOf = (string)($params['onBehalfOf'] ?? '');
 		$appointmentName = (string)($params['appointmentName'] ?? '');
 		$from = (string)($params['from'] ?? '');
 		$to = (string)($params['to'] ?? '');
@@ -213,26 +214,47 @@ class Notifier implements INotifier {
 
 		switch ($notification->getSubject()) {
 			case 'response_changed':
-				$subject = $l->t('%1$s changed their response from %2$s to %3$s on "%4$s"', [
-					$actorLabel,
-					$fromLabel,
-					$toLabel,
-					$appointmentName,
-				]);
+				$subject = $onBehalfOf !== ''
+					? $l->t('%1$s changed the response of %2$s from %3$s to %4$s on "%5$s"', [
+						$actorLabel,
+						$onBehalfOf,
+						$fromLabel,
+						$toLabel,
+						$appointmentName,
+					])
+					: $l->t('%1$s changed their response from %2$s to %3$s on "%4$s"', [
+						$actorLabel,
+						$fromLabel,
+						$toLabel,
+						$appointmentName,
+					]);
 				break;
 			case 'response_rescinded':
-				$subject = $l->t('%1$s took back their response on "%2$s"', [
-					$actorLabel,
-					$appointmentName,
-				]);
+				$subject = $onBehalfOf !== ''
+					? $l->t('%1$s removed the response of %2$s on "%3$s"', [
+						$actorLabel,
+						$onBehalfOf,
+						$appointmentName,
+					])
+					: $l->t('%1$s took back their response on "%2$s"', [
+						$actorLabel,
+						$appointmentName,
+					]);
 				break;
 			case 'response_submitted':
 			default:
-				$subject = $l->t('%1$s answered %2$s on "%3$s"', [
-					$actorLabel,
-					$toLabel,
-					$appointmentName,
-				]);
+				$subject = $onBehalfOf !== ''
+					? $l->t('%1$s answered %2$s for %3$s on "%4$s"', [
+						$actorLabel,
+						$toLabel,
+						$onBehalfOf,
+						$appointmentName,
+					])
+					: $l->t('%1$s answered %2$s on "%3$s"', [
+						$actorLabel,
+						$toLabel,
+						$appointmentName,
+					]);
 				break;
 		}
 

--- a/lib/ResponseDefinitions.php
+++ b/lib/ResponseDefinitions.php
@@ -164,6 +164,7 @@ namespace OCA\Attendance;
  *   auditLog: bool,
  *   selfCheckin: bool,
  *   organizers: bool,
+ *   respondOnBehalf: bool,
  * }
  * @psalm-type AttendanceAuditUserRef = array{
  *   userId: string,

--- a/lib/ResponseDefinitions.php
+++ b/lib/ResponseDefinitions.php
@@ -147,6 +147,7 @@ namespace OCA\Attendance;
  *   canSeeResponseOverview: bool,
  *   canSeeComments: bool,
  *   canSelfCheckin: bool,
+ *   canRespondForOthers: bool,
  * }
  * @psalm-type AttendanceCapabilities = array{
  *   calendarAvailable: bool,

--- a/lib/Service/AppointmentService.php
+++ b/lib/Service/AppointmentService.php
@@ -857,6 +857,102 @@ class AppointmentService {
 	}
 
 	/**
+	 * Submit or clear an attendance response on behalf of another user.
+	 *
+	 * Managers use this when a person announced their answer out of band
+	 * (e.g. on the phone) and did not respond themselves. The target user's
+	 * own comment survives a value change — only the manager-visible answer
+	 * is touched. Withdrawing ($response = null) restores the "not yet
+	 * responded" state so the person is picked up by reminders again, and
+	 * clears the comment like a self-withdraw would.
+	 */
+	public function submitResponseForUser(
+		int $appointmentId,
+		string $targetUserId,
+		?string $response,
+		string $actorUserId,
+	): AttendanceResponse {
+		if ($response !== null && !in_array($response, ['yes', 'no', 'maybe'])) {
+			throw new \InvalidArgumentException('Invalid response. Must be yes, no, maybe, or null.');
+		}
+
+		$appointment = $this->appointmentMapper->find($appointmentId);
+
+		// The target must be part of the appointment's audience — a manager
+		// cannot invent responses for people the inquiry never reached.
+		if (!$this->visibilityService->canUserSeeAppointment($appointment, $targetUserId)) {
+			throw new \InvalidArgumentException('User is not part of this appointment\'s audience');
+		}
+
+		if ($appointment->isClosed()) {
+			throw new \RuntimeException('This appointment is closed and no longer accepts responses.');
+		}
+
+		if ($appointment->isCancelled()) {
+			throw new \RuntimeException('This appointment was cancelled and no longer accepts responses.');
+		}
+
+		$beforeResponse = null;
+		$beforeComment = '';
+		$afterComment = '';
+
+		try {
+			$existingResponse = $this->responseMapper->findByAppointmentAndUser($appointmentId, $targetUserId);
+			$beforeResponse = $existingResponse->getResponse();
+			$beforeComment = (string)$existingResponse->getComment();
+
+			// Clearing an already-empty response is a no-op — don't churn
+			// responded_at or write a meaningless audit row.
+			if ($response === null && $beforeResponse === null) {
+				return $existingResponse;
+			}
+
+			$afterComment = $response === null ? '' : $beforeComment;
+			$existingResponse->setResponse($response);
+			$existingResponse->setComment($afterComment);
+			$existingResponse->setRespondedAt(gmdate('Y-m-d H:i:s'));
+			$existingResponse->setResponseSource(ResponseService::SOURCE_ADMIN);
+			$result = $this->responseMapper->update($existingResponse);
+		} catch (DoesNotExistException $e) {
+			// No row to clear — return a transient placeholder rather than
+			// inserting a junk row (mirrors submitResponse()).
+			if ($response === null) {
+				$placeholder = new AttendanceResponse();
+				$placeholder->setAppointmentId($appointmentId);
+				$placeholder->setUserId($targetUserId);
+				$placeholder->setResponse(null);
+				return $placeholder;
+			}
+			$attendanceResponse = new AttendanceResponse();
+			$attendanceResponse->setAppointmentId($appointmentId);
+			$attendanceResponse->setUserId($targetUserId);
+			$attendanceResponse->setResponse($response);
+			$attendanceResponse->setComment('');
+			$attendanceResponse->setRespondedAt(gmdate('Y-m-d H:i:s'));
+			$attendanceResponse->setResponseSource(ResponseService::SOURCE_ADMIN);
+			$result = $this->responseMapper->insert($attendanceResponse);
+		}
+
+		$this->auditEventService->recordResponseChange(
+			$appointmentId,
+			$targetUserId,
+			$beforeResponse,
+			$beforeComment,
+			$response,
+			$afterComment,
+			\OCA\Attendance\Audit\Verb::SOURCE_ADMIN_RESPONSE,
+			$actorUserId,
+		);
+
+		// The person no longer counts as "missing a response", so their
+		// pending respond-notifications are stale either way; on a clear the
+		// next reminder run will re-notify them.
+		$this->notificationService->markAppointmentNotificationsProcessed($appointmentId, $targetUserId);
+
+		return $result;
+	}
+
+	/**
 	 * Get user's response for an appointment.
 	 */
 	public function getUserResponse(int $appointmentId, string $userId): ?AttendanceResponse {

--- a/lib/Service/AppointmentService.php
+++ b/lib/Service/AppointmentService.php
@@ -777,15 +777,88 @@ class AppointmentService {
 		?string $response,
 		string $comment = '',
 	): AttendanceResponse {
-		if ($response !== null && !in_array($response, ['yes', 'no', 'maybe'])) {
-			throw new \InvalidArgumentException('Invalid response. Must be yes, no, maybe, or null.');
-		}
+		$this->validateResponseValue($response);
 
 		$appointment = $this->appointmentMapper->find($appointmentId);
 
 		if (!$this->visibilityService->canUserSeeAppointment($appointment, $userId)) {
 			throw new DoesNotExistException('Appointment not found');
 		}
+
+		return $this->applyResponse(
+			$appointment,
+			$userId,
+			$response,
+			$comment,
+			null,
+			\OCA\Attendance\Audit\Verb::SOURCE_APP,
+			null,
+		);
+	}
+
+	/**
+	 * Submit or clear an attendance response on behalf of another user.
+	 *
+	 * Managers use this when a person announced their answer out of band
+	 * (e.g. on the phone) and did not respond themselves. The target user's
+	 * own comment survives a value change — only the manager-visible answer
+	 * is touched. Withdrawing ($response = null) restores the "not yet
+	 * responded" state so the person is picked up by reminders again, and
+	 * clears the comment like a self-withdraw would.
+	 *
+	 * Callers load (and authorize) the appointment themselves, so it is
+	 * passed in rather than re-fetched.
+	 */
+	public function submitResponseForUser(
+		Appointment $appointment,
+		string $targetUserId,
+		?string $response,
+		string $actorUserId,
+	): AttendanceResponse {
+		$this->validateResponseValue($response);
+
+		// The target must be part of the appointment's audience — a manager
+		// cannot invent responses for people the inquiry never reached.
+		if (!$this->visibilityService->canUserSeeAppointment($appointment, $targetUserId)) {
+			throw new \InvalidArgumentException('User is not part of this appointment\'s audience');
+		}
+
+		return $this->applyResponse(
+			$appointment,
+			$targetUserId,
+			$response,
+			null,
+			ResponseService::SOURCE_ADMIN,
+			\OCA\Attendance\Audit\Verb::SOURCE_ADMIN_RESPONSE,
+			$actorUserId,
+		);
+	}
+
+	private function validateResponseValue(?string $response): void {
+		if ($response !== null && !in_array($response, ['yes', 'no', 'maybe'])) {
+			throw new \InvalidArgumentException('Invalid response. Must be yes, no, maybe, or null.');
+		}
+	}
+
+	/**
+	 * Shared persist-and-audit core for self and on-behalf responses.
+	 *
+	 * @param ?string $comment new comment, or null to keep the existing one
+	 *                         (withdrawing always wipes it so an orphan comment
+	 *                         can't survive the response that gave it context)
+	 * @param ?string $responseSource value for response_source, or null to leave it untouched
+	 * @param ?string $actorUserId audit actor when acting on someone else's behalf
+	 */
+	private function applyResponse(
+		Appointment $appointment,
+		string $userId,
+		?string $response,
+		?string $comment,
+		?string $responseSource,
+		string $auditSource,
+		?string $actorUserId,
+	): AttendanceResponse {
+		$appointmentId = $appointment->getId();
 
 		if ($appointment->isClosed()) {
 			throw new \RuntimeException('This appointment is closed and no longer accepts responses.');
@@ -798,8 +871,6 @@ class AppointmentService {
 			throw new \RuntimeException('This appointment was cancelled and no longer accepts responses.');
 		}
 
-		// Withdrawing also wipes the comment so an orphan comment can't survive
-		// the response that gave it context.
 		if ($response === null) {
 			$comment = '';
 		}
@@ -818,9 +889,13 @@ class AppointmentService {
 				return $existingResponse;
 			}
 
+			$afterComment = $comment ?? $beforeComment;
 			$existingResponse->setResponse($response);
-			$existingResponse->setComment($comment);
+			$existingResponse->setComment($afterComment);
 			$existingResponse->setRespondedAt(gmdate('Y-m-d H:i:s'));
+			if ($responseSource !== null) {
+				$existingResponse->setResponseSource($responseSource);
+			}
 			$result = $this->responseMapper->update($existingResponse);
 		} catch (DoesNotExistException $e) {
 			// No row to withdraw from — return a transient placeholder rather
@@ -832,12 +907,16 @@ class AppointmentService {
 				$placeholder->setResponse(null);
 				return $placeholder;
 			}
+			$afterComment = $comment ?? '';
 			$attendanceResponse = new AttendanceResponse();
 			$attendanceResponse->setAppointmentId($appointmentId);
 			$attendanceResponse->setUserId($userId);
 			$attendanceResponse->setResponse($response);
-			$attendanceResponse->setComment($comment);
+			$attendanceResponse->setComment($afterComment);
 			$attendanceResponse->setRespondedAt(gmdate('Y-m-d H:i:s'));
+			if ($responseSource !== null) {
+				$attendanceResponse->setResponseSource($responseSource);
+			}
 			$result = $this->responseMapper->insert($attendanceResponse);
 		}
 
@@ -847,107 +926,15 @@ class AppointmentService {
 			$beforeResponse,
 			$beforeComment,
 			$response,
-			$comment,
-			\OCA\Attendance\Audit\Verb::SOURCE_APP,
-		);
-
-		$this->notificationService->markAppointmentNotificationsProcessed($appointmentId, $userId);
-
-		return $result;
-	}
-
-	/**
-	 * Submit or clear an attendance response on behalf of another user.
-	 *
-	 * Managers use this when a person announced their answer out of band
-	 * (e.g. on the phone) and did not respond themselves. The target user's
-	 * own comment survives a value change — only the manager-visible answer
-	 * is touched. Withdrawing ($response = null) restores the "not yet
-	 * responded" state so the person is picked up by reminders again, and
-	 * clears the comment like a self-withdraw would.
-	 */
-	public function submitResponseForUser(
-		int $appointmentId,
-		string $targetUserId,
-		?string $response,
-		string $actorUserId,
-	): AttendanceResponse {
-		if ($response !== null && !in_array($response, ['yes', 'no', 'maybe'])) {
-			throw new \InvalidArgumentException('Invalid response. Must be yes, no, maybe, or null.');
-		}
-
-		$appointment = $this->appointmentMapper->find($appointmentId);
-
-		// The target must be part of the appointment's audience — a manager
-		// cannot invent responses for people the inquiry never reached.
-		if (!$this->visibilityService->canUserSeeAppointment($appointment, $targetUserId)) {
-			throw new \InvalidArgumentException('User is not part of this appointment\'s audience');
-		}
-
-		if ($appointment->isClosed()) {
-			throw new \RuntimeException('This appointment is closed and no longer accepts responses.');
-		}
-
-		if ($appointment->isCancelled()) {
-			throw new \RuntimeException('This appointment was cancelled and no longer accepts responses.');
-		}
-
-		$beforeResponse = null;
-		$beforeComment = '';
-		$afterComment = '';
-
-		try {
-			$existingResponse = $this->responseMapper->findByAppointmentAndUser($appointmentId, $targetUserId);
-			$beforeResponse = $existingResponse->getResponse();
-			$beforeComment = (string)$existingResponse->getComment();
-
-			// Clearing an already-empty response is a no-op — don't churn
-			// responded_at or write a meaningless audit row.
-			if ($response === null && $beforeResponse === null) {
-				return $existingResponse;
-			}
-
-			$afterComment = $response === null ? '' : $beforeComment;
-			$existingResponse->setResponse($response);
-			$existingResponse->setComment($afterComment);
-			$existingResponse->setRespondedAt(gmdate('Y-m-d H:i:s'));
-			$existingResponse->setResponseSource(ResponseService::SOURCE_ADMIN);
-			$result = $this->responseMapper->update($existingResponse);
-		} catch (DoesNotExistException $e) {
-			// No row to clear — return a transient placeholder rather than
-			// inserting a junk row (mirrors submitResponse()).
-			if ($response === null) {
-				$placeholder = new AttendanceResponse();
-				$placeholder->setAppointmentId($appointmentId);
-				$placeholder->setUserId($targetUserId);
-				$placeholder->setResponse(null);
-				return $placeholder;
-			}
-			$attendanceResponse = new AttendanceResponse();
-			$attendanceResponse->setAppointmentId($appointmentId);
-			$attendanceResponse->setUserId($targetUserId);
-			$attendanceResponse->setResponse($response);
-			$attendanceResponse->setComment('');
-			$attendanceResponse->setRespondedAt(gmdate('Y-m-d H:i:s'));
-			$attendanceResponse->setResponseSource(ResponseService::SOURCE_ADMIN);
-			$result = $this->responseMapper->insert($attendanceResponse);
-		}
-
-		$this->auditEventService->recordResponseChange(
-			$appointmentId,
-			$targetUserId,
-			$beforeResponse,
-			$beforeComment,
-			$response,
 			$afterComment,
-			\OCA\Attendance\Audit\Verb::SOURCE_ADMIN_RESPONSE,
+			$auditSource,
 			$actorUserId,
 		);
 
 		// The person no longer counts as "missing a response", so their
 		// pending respond-notifications are stale either way; on a clear the
 		// next reminder run will re-notify them.
-		$this->notificationService->markAppointmentNotificationsProcessed($appointmentId, $targetUserId);
+		$this->notificationService->markAppointmentNotificationsProcessed($appointmentId, $userId);
 
 		return $result;
 	}

--- a/lib/Service/AppointmentService.php
+++ b/lib/Service/AppointmentService.php
@@ -817,6 +817,13 @@ class AppointmentService {
 	): AttendanceResponse {
 		$this->validateResponseValue($response);
 
+		// The audience check below trusts the permission layer, which treats
+		// unknown users as managers when permissions are unconfigured — so an
+		// explicit existence check is needed to keep junk rows out.
+		if ($this->userManager->get($targetUserId) === null) {
+			throw new \InvalidArgumentException('User not found');
+		}
+
 		// The target must be part of the appointment's audience — a manager
 		// cannot invent responses for people the inquiry never reached.
 		if (!$this->visibilityService->canUserSeeAppointment($appointment, $targetUserId)) {

--- a/lib/Service/PermissionService.php
+++ b/lib/Service/PermissionService.php
@@ -25,11 +25,13 @@ class PermissionService {
 	public const PERMISSION_SEE_COMMENTS = 'see_comments';
 	public const PERMISSION_SELF_CHECKIN = 'self_checkin';
 	public const PERMISSION_CREATE_APPOINTMENTS = 'create_appointments';
+	public const PERMISSION_RESPOND_FOR_OTHERS = 'respond_for_others';
 
 	private const GUEST_BLOCKED_PERMISSIONS = [
 		self::PERMISSION_MANAGE_APPOINTMENTS,
 		self::PERMISSION_CHECKIN,
 		self::PERMISSION_CREATE_APPOINTMENTS,
+		self::PERMISSION_RESPOND_FOR_OTHERS,
 	];
 
 	/**
@@ -40,6 +42,7 @@ class PermissionService {
 	 */
 	private const CLOSED_WHEN_UNCONFIGURED = [
 		self::PERMISSION_CREATE_APPOINTMENTS,
+		self::PERMISSION_RESPOND_FOR_OTHERS,
 	];
 
 	public function __construct(
@@ -144,6 +147,7 @@ class PermissionService {
 			self::PERMISSION_SEE_COMMENTS => $this->getRolesForPermission(self::PERMISSION_SEE_COMMENTS),
 			self::PERMISSION_SELF_CHECKIN => $this->getRolesForPermission(self::PERMISSION_SELF_CHECKIN),
 			self::PERMISSION_CREATE_APPOINTMENTS => $this->getRolesForPermission(self::PERMISSION_CREATE_APPOINTMENTS),
+			self::PERMISSION_RESPOND_FOR_OTHERS => $this->getRolesForPermission(self::PERMISSION_RESPOND_FOR_OTHERS),
 		];
 	}
 
@@ -159,6 +163,7 @@ class PermissionService {
 			'PERMISSION_SEE_COMMENTS' => self::PERMISSION_SEE_COMMENTS,
 			'PERMISSION_SELF_CHECKIN' => self::PERMISSION_SELF_CHECKIN,
 			'PERMISSION_CREATE_APPOINTMENTS' => self::PERMISSION_CREATE_APPOINTMENTS,
+			'PERMISSION_RESPOND_FOR_OTHERS' => self::PERMISSION_RESPOND_FOR_OTHERS,
 		];
 
 		foreach ($permissions as $permission => $roles) {
@@ -172,6 +177,7 @@ class PermissionService {
 				self::PERMISSION_SEE_COMMENTS,
 				self::PERMISSION_SELF_CHECKIN,
 				self::PERMISSION_CREATE_APPOINTMENTS,
+				self::PERMISSION_RESPOND_FOR_OTHERS,
 			])) {
 				$this->setRolesForPermission($permissionValue, $roles);
 			}
@@ -265,6 +271,16 @@ class PermissionService {
 	 */
 	public function canSelfCheckin(string $userId): bool {
 		return $this->hasPermission($userId, self::PERMISSION_SELF_CHECKIN);
+	}
+
+	/**
+	 * Check if user can set or clear responses on behalf of other users.
+	 * Deliberately NOT granted to managers or organizers automatically —
+	 * only members of the explicitly configured groups get it, and with no
+	 * groups configured nobody does (CLOSED_WHEN_UNCONFIGURED).
+	 */
+	public function canRespondForOthers(string $userId): bool {
+		return $this->hasPermission($userId, self::PERMISSION_RESPOND_FOR_OTHERS);
 	}
 
 	/**

--- a/lib/Service/ResponseService.php
+++ b/lib/Service/ResponseService.php
@@ -48,6 +48,7 @@ class ResponseService {
 	// Response source constants
 	public const SOURCE_APP = 'app';
 	public const SOURCE_QUICK_LINK = 'quick_link';
+	public const SOURCE_ADMIN = 'admin';
 
 	/**
 	 * Submit or update an attendance response.

--- a/openapi-administration.json
+++ b/openapi-administration.json
@@ -184,7 +184,8 @@
                     "guestInvitation",
                     "auditLog",
                     "selfCheckin",
-                    "organizers"
+                    "organizers",
+                    "respondOnBehalf"
                 ],
                 "properties": {
                     "calendarAvailable": {
@@ -230,6 +231,9 @@
                         "type": "boolean"
                     },
                     "organizers": {
+                        "type": "boolean"
+                    },
+                    "respondOnBehalf": {
                         "type": "boolean"
                     }
                 }

--- a/openapi-full.json
+++ b/openapi-full.json
@@ -1304,7 +1304,8 @@
                     "canCheckin",
                     "canSeeResponseOverview",
                     "canSeeComments",
-                    "canSelfCheckin"
+                    "canSelfCheckin",
+                    "canRespondForOthers"
                 ],
                 "properties": {
                     "canManageAppointments": {
@@ -1323,6 +1324,9 @@
                         "type": "boolean"
                     },
                     "canSelfCheckin": {
+                        "type": "boolean"
+                    },
+                    "canRespondForOthers": {
                         "type": "boolean"
                     }
                 }
@@ -2526,7 +2530,7 @@
         "/index.php/apps/attendance/api/appointments/{appointmentId}/respond/{targetUserId}": {
             "post": {
                 "operationId": "appointment-respond-for-user",
-                "summary": "Set or clear a response on behalf of another user (requires manage appointments permission or being an organizer)",
+                "summary": "Set or clear a response on behalf of another user (requires the respond-for-others permission)",
                 "tags": [
                     "appointment"
                 ],

--- a/openapi-full.json
+++ b/openapi-full.json
@@ -609,7 +609,8 @@
                     "guestInvitation",
                     "auditLog",
                     "selfCheckin",
-                    "organizers"
+                    "organizers",
+                    "respondOnBehalf"
                 ],
                 "properties": {
                     "calendarAvailable": {
@@ -655,6 +656,9 @@
                         "type": "boolean"
                     },
                     "organizers": {
+                        "type": "boolean"
+                    },
+                    "respondOnBehalf": {
                         "type": "boolean"
                     }
                 }
@@ -2512,6 +2516,161 @@
                                             }
                                         }
                                     ]
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/index.php/apps/attendance/api/appointments/{appointmentId}/respond/{targetUserId}": {
+            "post": {
+                "operationId": "appointment-respond-for-user",
+                "summary": "Set or clear a response on behalf of another user (requires manage appointments permission or being an organizer)",
+                "tags": [
+                    "appointment"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "response": {
+                                        "type": "string",
+                                        "nullable": true,
+                                        "default": null,
+                                        "description": "Response value: yes, no, maybe — or null to clear the response so the person counts as \"not yet responded\" again"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "name": "appointmentId",
+                        "in": "path",
+                        "description": "Appointment ID",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    },
+                    {
+                        "name": "targetUserId",
+                        "in": "path",
+                        "description": "User ID whose response is set",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ResponseData"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Current user is not logged in",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "anyOf": [
+                                        {
+                                            "type": "object",
+                                            "required": [
+                                                "error"
+                                            ],
+                                            "properties": {
+                                                "error": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        },
+                                        {
+                                            "type": "object",
+                                            "required": [
+                                                "message"
+                                            ],
+                                            "properties": {
+                                                "message": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    }
                                 }
                             }
                         }

--- a/openapi.json
+++ b/openapi.json
@@ -462,7 +462,8 @@
                     "guestInvitation",
                     "auditLog",
                     "selfCheckin",
-                    "organizers"
+                    "organizers",
+                    "respondOnBehalf"
                 ],
                 "properties": {
                     "calendarAvailable": {
@@ -508,6 +509,9 @@
                         "type": "boolean"
                     },
                     "organizers": {
+                        "type": "boolean"
+                    },
+                    "respondOnBehalf": {
                         "type": "boolean"
                     }
                 }
@@ -2291,6 +2295,161 @@
                                             }
                                         }
                                     ]
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/index.php/apps/attendance/api/appointments/{appointmentId}/respond/{targetUserId}": {
+            "post": {
+                "operationId": "appointment-respond-for-user",
+                "summary": "Set or clear a response on behalf of another user (requires manage appointments permission or being an organizer)",
+                "tags": [
+                    "appointment"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "response": {
+                                        "type": "string",
+                                        "nullable": true,
+                                        "default": null,
+                                        "description": "Response value: yes, no, maybe — or null to clear the response so the person counts as \"not yet responded\" again"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "name": "appointmentId",
+                        "in": "path",
+                        "description": "Appointment ID",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    },
+                    {
+                        "name": "targetUserId",
+                        "in": "path",
+                        "description": "User ID whose response is set",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ResponseData"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Current user is not logged in",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "anyOf": [
+                                        {
+                                            "type": "object",
+                                            "required": [
+                                                "error"
+                                            ],
+                                            "properties": {
+                                                "error": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        },
+                                        {
+                                            "type": "object",
+                                            "required": [
+                                                "message"
+                                            ],
+                                            "properties": {
+                                                "message": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    }
                                 }
                             }
                         }

--- a/openapi.json
+++ b/openapi.json
@@ -1083,7 +1083,8 @@
                     "canCheckin",
                     "canSeeResponseOverview",
                     "canSeeComments",
-                    "canSelfCheckin"
+                    "canSelfCheckin",
+                    "canRespondForOthers"
                 ],
                 "properties": {
                     "canManageAppointments": {
@@ -1102,6 +1103,9 @@
                         "type": "boolean"
                     },
                     "canSelfCheckin": {
+                        "type": "boolean"
+                    },
+                    "canRespondForOthers": {
                         "type": "boolean"
                     }
                 }
@@ -2305,7 +2309,7 @@
         "/index.php/apps/attendance/api/appointments/{appointmentId}/respond/{targetUserId}": {
             "post": {
                 "operationId": "appointment-respond-for-user",
-                "summary": "Set or clear a response on behalf of another user (requires manage appointments permission or being an organizer)",
+                "summary": "Set or clear a response on behalf of another user (requires the respond-for-others permission)",
                 "tags": [
                     "appointment"
                 ],

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -77,6 +77,8 @@ export default defineConfig({
 				'18-widget-relevance.spec.js',
 				'19-default-view.spec.js',
 				'20-summary-direct-user.spec.js',
+				// Toggles the instance-wide audit log on and off.
+				'23-audit-history.spec.js',
 				// Toggles the instance-wide planning feature on and off.
 				'25-scheduled-out.spec.js',
 			],

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -53,6 +53,7 @@ export default defineConfig({
 				'14-close-inquiry.spec.js',
 				'22-response-rescind.spec.js',
 				'24-close-nav-resort.spec.js',
+				'26-respond-on-behalf.spec.js',
 				'checkin.spec.js',
 			],
 			fullyParallel: false, // tests within a file stay sequential

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -53,7 +53,6 @@ export default defineConfig({
 				'14-close-inquiry.spec.js',
 				'22-response-rescind.spec.js',
 				'24-close-nav-resort.spec.js',
-				'26-respond-on-behalf.spec.js',
 				'checkin.spec.js',
 			],
 			fullyParallel: false, // tests within a file stay sequential
@@ -81,6 +80,8 @@ export default defineConfig({
 				'23-audit-history.spec.js',
 				// Toggles the instance-wide planning feature on and off.
 				'25-scheduled-out.spec.js',
+				// Grants/revokes the respond_for_others permission.
+				'26-respond-on-behalf.spec.js',
 			],
 			fullyParallel: false,
 			workers: 1,

--- a/src/components/appointment/AppointmentCard.vue
+++ b/src/components/appointment/AppointmentCard.vue
@@ -129,7 +129,9 @@
 			:canSeeComments="canSeeComments"
 			:canManageAppointments="canManage"
 			:appointmentId="appointment.id"
-			:isClosed="isClosed" />
+			:isClosed="isClosed"
+			:acceptsResponses="acceptsResponses"
+			@answerSet="emit('refreshAppointment')" />
 	</div>
 </template>
 
@@ -170,6 +172,7 @@ const emit = defineEmits([
 	'submitResponse',
 	'closedToggled',
 	'showAuditLog',
+	'refreshAppointment',
 ])
 
 // NB: pass a getter, never bind it to a name — every top-level binding in

--- a/src/components/appointment/AppointmentCard.vue
+++ b/src/components/appointment/AppointmentCard.vue
@@ -131,7 +131,7 @@
 			:appointmentId="appointment.id"
 			:isClosed="isClosed"
 			:acceptsResponses="acceptsResponses"
-			@answerSet="emit('refreshAppointment')" />
+			@refreshAppointment="emit('refreshAppointment')" />
 	</div>
 </template>
 

--- a/src/components/appointment/NonRespondingUserList.vue
+++ b/src/components/appointment/NonRespondingUserList.vue
@@ -10,26 +10,6 @@
 				class="pending-user"
 				:class="{ 'pending-user--pending': remindingUsers.has(user.userId) }">
 				{{ user.displayName }}
-				<RemindUserPopover
-					v-if="canManageAppointments && appointmentId"
-					:userId="user.userId"
-					:displayName="user.displayName"
-					:pending="remindingUsers.has(user.userId)"
-					@remind="emit('remind', $event)">
-					<template #default="{ pending }">
-						<NcButton
-							variant="secondary"
-							size="small"
-							:disabled="pending"
-							:aria-label="t('attendance', 'Send reminder')"
-							:title="t('attendance', 'Send reminder')"
-							:data-test="`remind-${user.userId}`">
-							<template #icon>
-								<BellRingOutlineIcon :size="16" />
-							</template>
-						</NcButton>
-					</template>
-				</RemindUserPopover>
 				<SetAnswerPopover
 					v-if="canSetAnswer && appointmentId"
 					:userId="user.userId"
@@ -50,6 +30,26 @@
 						</NcButton>
 					</template>
 				</SetAnswerPopover>
+				<RemindUserPopover
+					v-if="canManageAppointments && appointmentId"
+					:userId="user.userId"
+					:displayName="user.displayName"
+					:pending="remindingUsers.has(user.userId)"
+					@remind="emit('remind', $event)">
+					<template #default="{ pending }">
+						<NcButton
+							variant="secondary"
+							size="small"
+							:disabled="pending"
+							:aria-label="t('attendance', 'Send reminder')"
+							:title="t('attendance', 'Send reminder')"
+							:data-test="`remind-${user.userId}`">
+							<template #icon>
+								<BellRingOutlineIcon :size="16" />
+							</template>
+						</NcButton>
+					</template>
+				</RemindUserPopover>
 			</span>
 		</div>
 	</div>

--- a/src/components/appointment/NonRespondingUserList.vue
+++ b/src/components/appointment/NonRespondingUserList.vue
@@ -30,6 +30,26 @@
 						</NcButton>
 					</template>
 				</RemindUserPopover>
+				<SetAnswerPopover
+					v-if="canSetAnswer && appointmentId"
+					:userId="user.userId"
+					:displayName="user.displayName"
+					:pending="settingAnswer.has(user.userId)"
+					@setAnswer="(userId, value) => emit('setAnswer', userId, value)">
+					<template #default="{ pending }">
+						<NcButton
+							variant="secondary"
+							size="small"
+							:disabled="pending"
+							:aria-label="t('attendance', 'Set answer')"
+							:title="t('attendance', 'Set answer')"
+							:data-test="`set-answer-${user.userId}`">
+							<template #icon>
+								<PencilOutlineIcon :size="16" />
+							</template>
+						</NcButton>
+					</template>
+				</SetAnswerPopover>
 			</span>
 		</div>
 	</div>
@@ -39,7 +59,9 @@
 import { NcButton } from '@nextcloud/vue'
 import { computed } from 'vue'
 import BellRingOutlineIcon from 'vue-material-design-icons/BellRingOutline.vue'
+import PencilOutlineIcon from 'vue-material-design-icons/PencilOutline.vue'
 import RemindUserPopover from './RemindUserPopover.vue'
+import SetAnswerPopover from './SetAnswerPopover.vue'
 
 const props = defineProps({
 	users: {
@@ -54,6 +76,10 @@ const props = defineProps({
 		type: Boolean,
 		default: false,
 	},
+	canSetAnswer: {
+		type: Boolean,
+		default: false,
+	},
 	appointmentId: {
 		type: Number,
 		default: null,
@@ -62,9 +88,13 @@ const props = defineProps({
 		type: Set,
 		default: () => new Set(),
 	},
+	settingAnswer: {
+		type: Set,
+		default: () => new Set(),
+	},
 })
 
-const emit = defineEmits(['remind'])
+const emit = defineEmits(['remind', 'setAnswer'])
 
 const sortedUsers = computed(() => [...props.users]
 	.sort((a, b) => a.displayName.localeCompare(b.displayName)))

--- a/src/components/appointment/ResponseDot.vue
+++ b/src/components/appointment/ResponseDot.vue
@@ -28,6 +28,7 @@ const icon = computed(() => ICONS[getResponseIcon(props.response)] ?? HelpCircle
 </script>
 
 <style scoped lang="scss">
+@use "sass:math";
 @use "../../styles/shared.scss";
 
 .response-dot {
@@ -60,7 +61,7 @@ const icon = computed(() => ICONS[getResponseIcon(props.response)] ?? HelpCircle
             content: "";
             position: absolute;
             // The MDI circle is r=10 about (12,12) in a 24-unit viewBox.
-            inset: percentage(calc(2 / 24));
+            inset: math.percentage(math.div(2, 24));
             border-radius: 50%;
             background: #222;
         }

--- a/src/components/appointment/ResponseRow.vue
+++ b/src/components/appointment/ResponseRow.vue
@@ -41,6 +41,30 @@
 					</template>
 					{{ bookingLabel }}
 				</NcButton>
+				<!-- Icon-only on purpose: the row already carries up to two labelled
+					buttons, so the on-behalf editor stays as light as possible. -->
+				<SetAnswerPopover
+					v-if="canSetAnswer"
+					:userId="response.userId"
+					:displayName="response.userName"
+					:currentResponse="response.response"
+					:pending="isSettingAnswer"
+					@setAnswer="(userId, value) => emit('setAnswer', userId, value)">
+					<template #default="{ pending }">
+						<NcButton
+							class="response-row__action"
+							variant="tertiary"
+							size="small"
+							:disabled="pending"
+							:aria-label="setAnswerLabel"
+							:title="setAnswerLabel"
+							:data-test="`set-answer-${response.userId}`">
+							<template #icon>
+								<PencilOutlineIcon :size="16" />
+							</template>
+						</NcButton>
+					</template>
+				</SetAnswerPopover>
 			</div>
 			<div v-if="response.isCheckedIn" class="response-row__checkin">
 				<span>{{ t("attendance", "Checked in?") }}</span>
@@ -63,8 +87,10 @@ import BellRingOutlineIcon from 'vue-material-design-icons/BellRingOutline.vue'
 import CalendarCheckIcon from 'vue-material-design-icons/CalendarCheck.vue'
 import CalendarCheckOutlineIcon from 'vue-material-design-icons/CalendarCheckOutline.vue'
 import CommentIcon from 'vue-material-design-icons/Comment.vue'
+import PencilOutlineIcon from 'vue-material-design-icons/PencilOutline.vue'
 import RemindUserPopover from './RemindUserPopover.vue'
 import ResponseDot from './ResponseDot.vue'
+import SetAnswerPopover from './SetAnswerPopover.vue'
 
 const props = defineProps({
 	response: {
@@ -87,6 +113,10 @@ const props = defineProps({
 		type: Boolean,
 		default: false,
 	},
+	canSetAnswer: {
+		type: Boolean,
+		default: false,
+	},
 	remindingUsers: {
 		type: Set,
 		default: () => new Set(),
@@ -95,13 +125,20 @@ const props = defineProps({
 		type: Set,
 		default: () => new Set(),
 	},
+	settingAnswer: {
+		type: Set,
+		default: () => new Set(),
+	},
 })
 
-const emit = defineEmits(['remind', 'toggleBooking'])
+const emit = defineEmits(['remind', 'toggleBooking', 'setAnswer'])
 
 // Nudging only makes sense for the undecided — a "yes" or "no" is already final.
 const canRemind = computed(() => props.canSendReminders && props.response.response === 'maybe')
 const isReminding = computed(() => props.remindingUsers.has(props.response.userId))
+const isSettingAnswer = computed(() => props.settingAnswer.has(props.response.userId))
+// TRANSLATORS: Tooltip/aria-label on the icon button that lets a manager record the person's answer on their behalf.
+const setAnswerLabel = computed(() => t('attendance', 'Set answer'))
 const isTogglingBooking = computed(() => props.togglingBooking.has(props.response.userId))
 const isBooked = computed(() => props.response.bookingStatus === 'booked')
 const bookingLabel = computed(() => {

--- a/src/components/appointment/ResponseRow.vue
+++ b/src/components/appointment/ResponseRow.vue
@@ -138,7 +138,7 @@ const canRemind = computed(() => props.canSendReminders && props.response.respon
 const isReminding = computed(() => props.remindingUsers.has(props.response.userId))
 const isSettingAnswer = computed(() => props.settingAnswer.has(props.response.userId))
 // TRANSLATORS: Tooltip/aria-label on the icon button that lets a manager record the person's answer on their behalf.
-const setAnswerLabel = computed(() => t('attendance', 'Set answer'))
+const setAnswerLabel = t('attendance', 'Set answer')
 const isTogglingBooking = computed(() => props.togglingBooking.has(props.response.userId))
 const isBooked = computed(() => props.response.bookingStatus === 'booked')
 const bookingLabel = computed(() => {

--- a/src/components/appointment/ResponseRow.vue
+++ b/src/components/appointment/ResponseRow.vue
@@ -4,6 +4,31 @@
 			<div class="response-row__user">
 				<ResponseDot :response="response.response" />
 				<strong>{{ response.userName }}</strong>
+				<!-- Icon-only on purpose: the row already carries up to two labelled
+					buttons, so the on-behalf editor stays as light as possible. It
+					leads the action group because it edits the answer the dot shows. -->
+				<SetAnswerPopover
+					v-if="canSetAnswer"
+					:userId="response.userId"
+					:displayName="response.userName"
+					:currentResponse="response.response"
+					:pending="isSettingAnswer"
+					@setAnswer="(userId, value) => emit('setAnswer', userId, value)">
+					<template #default="{ pending }">
+						<NcButton
+							class="response-row__action"
+							variant="secondary"
+							size="small"
+							:disabled="pending"
+							:aria-label="setAnswerLabel"
+							:title="setAnswerLabel"
+							:data-test="`set-answer-${response.userId}`">
+							<template #icon>
+								<PencilOutlineIcon :size="16" />
+							</template>
+						</NcButton>
+					</template>
+				</SetAnswerPopover>
 				<RemindUserPopover
 					v-if="canRemind"
 					:userId="response.userId"
@@ -41,30 +66,6 @@
 					</template>
 					{{ bookingLabel }}
 				</NcButton>
-				<!-- Icon-only on purpose: the row already carries up to two labelled
-					buttons, so the on-behalf editor stays as light as possible. -->
-				<SetAnswerPopover
-					v-if="canSetAnswer"
-					:userId="response.userId"
-					:displayName="response.userName"
-					:currentResponse="response.response"
-					:pending="isSettingAnswer"
-					@setAnswer="(userId, value) => emit('setAnswer', userId, value)">
-					<template #default="{ pending }">
-						<NcButton
-							class="response-row__action"
-							variant="tertiary"
-							size="small"
-							:disabled="pending"
-							:aria-label="setAnswerLabel"
-							:title="setAnswerLabel"
-							:data-test="`set-answer-${response.userId}`">
-							<template #icon>
-								<PencilOutlineIcon :size="16" />
-							</template>
-						</NcButton>
-					</template>
-				</SetAnswerPopover>
 			</div>
 			<div v-if="response.isCheckedIn" class="response-row__checkin">
 				<span>{{ t("attendance", "Checked in?") }}</span>

--- a/src/components/appointment/ResponseSummary.vue
+++ b/src/components/appointment/ResponseSummary.vue
@@ -115,7 +115,7 @@ const props = defineProps({
 	},
 })
 
-const emit = defineEmits(['answerSet'])
+const emit = defineEmits(['refreshAppointment'])
 
 const { capabilities } = usePermissions()
 
@@ -213,7 +213,7 @@ async function setAnswer(userId, response) {
 		showSuccess(t('attendance', 'Response updated'))
 		// Group buckets, counts and the non-responder list all shift, so let
 		// the parent refetch instead of patching the summary in place.
-		emit('answerSet')
+		emit('refreshAppointment')
 	} catch (error) {
 		console.error('Failed to set answer:', error)
 		showError(t('attendance', 'Failed to update response'))

--- a/src/components/appointment/ResponseSummary.vue
+++ b/src/components/appointment/ResponseSummary.vue
@@ -45,10 +45,13 @@
 							:canSendReminders="canSendReminders"
 							:canManageBooking="canManageBooking"
 							:isClosed="isClosed"
+							:canSetAnswer="canSetAnswer"
 							:remindingUsers="remindingUsers"
 							:togglingBooking="togglingBooking"
+							:settingAnswer="settingAnswer"
 							@remind="remindUser"
-							@toggleBooking="toggleBooking" />
+							@toggleBooking="toggleBooking"
+							@setAnswer="setAnswer" />
 					</div>
 
 					<NonRespondingUserList
@@ -56,9 +59,12 @@
 						:users="section.stats.non_responding_users"
 						:headerText="t('attendance', 'No response yet:')"
 						:canManageAppointments="canSendReminders"
+						:canSetAnswer="canSetAnswer"
 						:appointmentId="appointmentId"
 						:remindingUsers="remindingUsers"
-						@remind="remindUser" />
+						:settingAnswer="settingAnswer"
+						@remind="remindUser"
+						@setAnswer="setAnswer" />
 				</div>
 			</div>
 		</div>
@@ -101,7 +107,15 @@ const props = defineProps({
 		type: Boolean,
 		default: false,
 	},
+	// Whether the appointment still takes responses (open and not cancelled) —
+	// the on-behalf answer editor follows the same rule as self-responses.
+	acceptsResponses: {
+		type: Boolean,
+		default: false,
+	},
 })
+
+const emit = defineEmits(['answerSet'])
 
 const { capabilities } = usePermissions()
 
@@ -112,9 +126,14 @@ const canSendReminders = computed(() => props.canManageAppointments && !props.is
 // "yes" response (handled by the row).
 const canManageBooking = computed(() => props.canManageAppointments && capabilities.bookingEnabled)
 
+// Managers may record an answer on a person's behalf (issue #47) while the
+// inquiry still accepts responses.
+const canSetAnswer = computed(() => props.canManageAppointments && props.acceptsResponses)
+
 const expandedGroups = ref({})
 const remindingUsers = reactive(new Set())
 const togglingBooking = reactive(new Set())
+const settingAnswer = reactive(new Set())
 
 // Groups, teams and the catch-all "Others" bucket all render the same way — the
 // only differences are the label, the leading icon and the data-test hooks.
@@ -183,6 +202,23 @@ async function toggleBooking(response) {
 		showError(t('attendance', 'Failed to update scheduling'))
 	} finally {
 		togglingBooking.delete(response.userId)
+	}
+}
+
+async function setAnswer(userId, response) {
+	if (!props.appointmentId || settingAnswer.has(userId)) return
+	settingAnswer.add(userId)
+	try {
+		await axios.post(generateUrl(`/apps/attendance/api/appointments/${props.appointmentId}/respond/${encodeURIComponent(userId)}`), { response })
+		showSuccess(t('attendance', 'Response updated'))
+		// Group buckets, counts and the non-responder list all shift, so let
+		// the parent refetch instead of patching the summary in place.
+		emit('answerSet')
+	} catch (error) {
+		console.error('Failed to set answer:', error)
+		showError(t('attendance', 'Failed to update response'))
+	} finally {
+		settingAnswer.delete(userId)
 	}
 }
 

--- a/src/components/appointment/ResponseSummary.vue
+++ b/src/components/appointment/ResponseSummary.vue
@@ -117,7 +117,7 @@ const props = defineProps({
 
 const emit = defineEmits(['refreshAppointment'])
 
-const { capabilities } = usePermissions()
+const { capabilities, permissions } = usePermissions()
 
 const canSendReminders = computed(() => props.canManageAppointments && !props.isClosed)
 
@@ -126,9 +126,10 @@ const canSendReminders = computed(() => props.canManageAppointments && !props.is
 // "yes" response (handled by the row).
 const canManageBooking = computed(() => props.canManageAppointments && capabilities.bookingEnabled)
 
-// Managers may record an answer on a person's behalf (issue #47) while the
-// inquiry still accepts responses.
-const canSetAnswer = computed(() => props.canManageAppointments && props.acceptsResponses)
+// Recording an answer on a person's behalf (issue #47) is its own admin-
+// configured permission — deliberately not implied by manage rights — and
+// only while the inquiry still accepts responses.
+const canSetAnswer = computed(() => permissions.canRespondForOthers && props.acceptsResponses)
 
 const expandedGroups = ref({})
 const remindingUsers = reactive(new Set())

--- a/src/components/appointment/SetAnswerPopover.vue
+++ b/src/components/appointment/SetAnswerPopover.vue
@@ -20,7 +20,7 @@
 					:data-test="`set-answer-${option}-${userId}`"
 					@click="choose(option)">
 					<template #icon>
-						<component :is="ANSWER_ICONS[option]" :size="16" />
+						<component :is="ICONS[getResponseIcon(option)]" :size="16" />
 					</template>
 					{{ getResponseText(option) }}
 				</NcButton>
@@ -46,11 +46,11 @@
 <script setup>
 import { NcButton, NcPopover } from '@nextcloud/vue'
 import { ref } from 'vue'
-import CheckCircleIcon from 'vue-material-design-icons/CheckCircle.vue'
-import CloseCircleIcon from 'vue-material-design-icons/CloseCircle.vue'
-import HelpCircleIcon from 'vue-material-design-icons/HelpCircle.vue'
+import CheckCircle from 'vue-material-design-icons/CheckCircle.vue'
+import CloseCircle from 'vue-material-design-icons/CloseCircle.vue'
+import HelpCircle from 'vue-material-design-icons/HelpCircle.vue'
 import UndoVariantIcon from 'vue-material-design-icons/UndoVariant.vue'
-import { getResponseText, getResponseVariant, RESPONSE_ORDER } from '../../utils/response.js'
+import { getResponseIcon, getResponseText, getResponseVariant, RESPONSE_ORDER } from '../../utils/response.js'
 
 const props = defineProps({
 	userId: {
@@ -75,11 +75,9 @@ const props = defineProps({
 
 const emit = defineEmits(['setAnswer'])
 
-const ANSWER_ICONS = {
-	yes: CheckCircleIcon,
-	maybe: HelpCircleIcon,
-	no: CloseCircleIcon,
-}
+// Same shared glyph mapping the response editor uses, so the popover cannot
+// drift from the dots and buttons elsewhere.
+const ICONS = { CheckCircle, HelpCircle, CloseCircle }
 
 const open = ref(false)
 

--- a/src/components/appointment/SetAnswerPopover.vue
+++ b/src/components/appointment/SetAnswerPopover.vue
@@ -1,0 +1,120 @@
+<template>
+	<NcPopover
+		:shown="open"
+		popupRole="dialog"
+		class="set-answer-popover-wrapper"
+		@update:shown="(value) => open = value">
+		<template #trigger>
+			<slot :pending="pending" />
+		</template>
+		<div class="set-answer-popover" role="dialog" aria-modal="true">
+			<!-- TRANSLATORS: Popover title — a manager records the yes/no/maybe answer on behalf of {name} (e.g. after a phone call). -->
+			<p>{{ t('attendance', 'Set answer for {name}', { name: displayName }) }}</p>
+			<div class="set-answer-popover__options">
+				<NcButton
+					v-for="option in RESPONSE_ORDER"
+					:key="option"
+					:variant="option === currentResponse ? getResponseVariant(option) : 'secondary'"
+					size="small"
+					:disabled="pending"
+					:data-test="`set-answer-${option}-${userId}`"
+					@click="choose(option)">
+					<template #icon>
+						<component :is="ANSWER_ICONS[option]" :size="16" />
+					</template>
+					{{ getResponseText(option) }}
+				</NcButton>
+			</div>
+			<NcButton
+				v-if="currentResponse"
+				class="set-answer-popover__clear"
+				variant="tertiary"
+				size="small"
+				:disabled="pending"
+				:data-test="`set-answer-clear-${userId}`"
+				@click="choose(null)">
+				<template #icon>
+					<UndoVariantIcon :size="16" />
+				</template>
+				<!-- TRANSLATORS: Button in the set-answer popover — removes the person's answer so they count as "not yet responded" again. -->
+				{{ t('attendance', 'Clear answer') }}
+			</NcButton>
+		</div>
+	</NcPopover>
+</template>
+
+<script setup>
+import { NcButton, NcPopover } from '@nextcloud/vue'
+import { ref } from 'vue'
+import CheckCircleIcon from 'vue-material-design-icons/CheckCircle.vue'
+import CloseCircleIcon from 'vue-material-design-icons/CloseCircle.vue'
+import HelpCircleIcon from 'vue-material-design-icons/HelpCircle.vue'
+import UndoVariantIcon from 'vue-material-design-icons/UndoVariant.vue'
+import { getResponseText, getResponseVariant, RESPONSE_ORDER } from '../../utils/response.js'
+
+const props = defineProps({
+	userId: {
+		type: String,
+		required: true,
+	},
+	displayName: {
+		type: String,
+		required: true,
+	},
+	// The person's current answer, or null when they have not responded yet.
+	currentResponse: {
+		type: String,
+		default: null,
+	},
+	// An answer for this user is already being saved.
+	pending: {
+		type: Boolean,
+		default: false,
+	},
+})
+
+const emit = defineEmits(['setAnswer'])
+
+const ANSWER_ICONS = {
+	yes: CheckCircleIcon,
+	maybe: HelpCircleIcon,
+	no: CloseCircleIcon,
+}
+
+const open = ref(false)
+
+function choose(response) {
+	open.value = false
+	emit('setAnswer', props.userId, response)
+}
+</script>
+
+<style scoped lang="scss">
+.set-answer-popover-wrapper {
+    display: inline-flex;
+}
+</style>
+
+<style lang="scss">
+// Rendered into the popover teleport target, so it cannot be scoped.
+.set-answer-popover {
+    padding: 12px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+
+    p {
+        margin: 0 0 10px 0;
+    }
+
+    &__options {
+        display: flex;
+        gap: 6px;
+    }
+
+    &__clear {
+        margin-top: 8px;
+    }
+}
+</style>

--- a/src/composables/usePermissions.js
+++ b/src/composables/usePermissions.js
@@ -10,6 +10,7 @@ const state = reactive({
 		canSeeResponseOverview: false,
 		canSeeComments: false,
 		canSelfCheckin: false,
+		canRespondForOthers: false,
 	},
 	capabilities: {
 		calendarAvailable: false,
@@ -69,6 +70,7 @@ export function usePermissions() {
 			state.permissions.canSeeResponseOverview = permissionsRes.data.canSeeResponseOverview || false
 			state.permissions.canSeeComments = permissionsRes.data.canSeeComments || false
 			state.permissions.canSelfCheckin = permissionsRes.data.canSelfCheckin || false
+			state.permissions.canRespondForOthers = permissionsRes.data.canRespondForOthers === true
 
 			state.capabilities.calendarAvailable = capabilitiesRes.data.calendarAvailable || false
 			state.capabilities.calendarSyncEnabled = capabilitiesRes.data.calendarSyncEnabled || false
@@ -96,6 +98,7 @@ export function usePermissions() {
 			state.permissions.canSeeResponseOverview = false
 			state.permissions.canSeeComments = false
 			state.permissions.canSelfCheckin = false
+			state.permissions.canRespondForOthers = false
 			state.capabilities.calendarAvailable = false
 			state.capabilities.calendarSyncEnabled = false
 			state.capabilities.teamsAvailable = false
@@ -129,6 +132,7 @@ export function usePermissions() {
 		state.permissions.canSeeResponseOverview = false
 		state.permissions.canSeeComments = false
 		state.permissions.canSelfCheckin = false
+		state.permissions.canRespondForOthers = false
 	}
 
 	return {

--- a/src/utils/auditFormat.js
+++ b/src/utils/auditFormat.js
@@ -18,6 +18,9 @@ export const SOURCE_LABELS = {
 	// TRANSLATORS: Noun — audit-log source label: the response was recorded
 	// via the check-in screen.
 	admin_checkin: () => t('attendance', 'Check-in'),
+	// TRANSLATORS: Noun — audit-log source label: a manager set the answer
+	// on behalf of the person.
+	admin_response: () => t('attendance', 'Manager'),
 	legacy_backfill: () => t('attendance', 'Historic'),
 	auto_close: () => t('attendance', 'Automatic'),
 }
@@ -33,7 +36,9 @@ export function formatSource(source) {
 // TRANSLATORS: Audit-log entries. {actor}/{subject} are names, {response},
 // {from}, {to} and {state} render as response chips (yes/no/maybe/…).
 t('attendance', '{actor} answered {response}')
+t('attendance', '{actor} answered {response} for {subject}')
 t('attendance', '{actor} changed response from {from} to {to}')
+t('attendance', '{actor} changed the response of {subject} from {from} to {to}')
 t('attendance', '{actor} recorded check-in for {subject}: {state}')
 t('attendance', 'Check-in recorded: {state}')
 t('attendance', '{actor} updated check-in for {subject}: {state}')
@@ -128,30 +133,48 @@ export function formatAuditEvent(event) {
 			return {
 				icon: getResponseIcon(meta.response, 'outline'),
 				iconVariant: getResponseVariant(meta.response),
-				segments: buildSegments(
-					'{actor} answered {response}',
-					{ actor },
-					[{ key: 'response', value: meta.response }],
-				),
+				segments: subject
+					? buildSegments(
+							'{actor} answered {response} for {subject}',
+							{ actor, subject },
+							[{ key: 'response', value: meta.response }],
+						)
+					: buildSegments(
+							'{actor} answered {response}',
+							{ actor },
+							[{ key: 'response', value: meta.response }],
+						),
 			}
 		case 'response.changed':
 			return {
 				icon: getResponseIcon(meta.to, 'outline'),
 				iconVariant: getResponseVariant(meta.to),
-				segments: buildSegments(
-					'{actor} changed response from {from} to {to}',
-					{ actor },
-					[
-						{ key: 'from', value: meta.from },
-						{ key: 'to', value: meta.to },
-					],
-				),
+				segments: subject
+					? buildSegments(
+							'{actor} changed the response of {subject} from {from} to {to}',
+							{ actor, subject },
+							[
+								{ key: 'from', value: meta.from },
+								{ key: 'to', value: meta.to },
+							],
+						)
+					: buildSegments(
+							'{actor} changed response from {from} to {to}',
+							{ actor },
+							[
+								{ key: 'from', value: meta.from },
+								{ key: 'to', value: meta.to },
+							],
+						),
 			}
 		case 'response.rescinded':
 			return {
 				icon: 'UndoVariant',
 				iconVariant: 'default',
-				segments: textOnly(t('attendance', '{actor} took back their response', { actor })),
+				segments: textOnly(subject
+					// TRANSLATORS: Audit-log entry. {actor} removed the yes/no/maybe answer of {subject} (both are names).
+					? t('attendance', '{actor} removed the response of {subject}', { actor, subject })
+					: t('attendance', '{actor} took back their response', { actor })),
 			}
 		case 'response.comment_updated':
 			return {

--- a/src/utils/auditFormat.js
+++ b/src/utils/auditFormat.js
@@ -133,39 +133,28 @@ export function formatAuditEvent(event) {
 			return {
 				icon: getResponseIcon(meta.response, 'outline'),
 				iconVariant: getResponseVariant(meta.response),
-				segments: subject
-					? buildSegments(
-							'{actor} answered {response} for {subject}',
-							{ actor, subject },
-							[{ key: 'response', value: meta.response }],
-						)
-					: buildSegments(
-							'{actor} answered {response}',
-							{ actor },
-							[{ key: 'response', value: meta.response }],
-						),
+				segments: buildSegments(
+					subject
+						? '{actor} answered {response} for {subject}'
+						: '{actor} answered {response}',
+					subject ? { actor, subject } : { actor },
+					[{ key: 'response', value: meta.response }],
+				),
 			}
 		case 'response.changed':
 			return {
 				icon: getResponseIcon(meta.to, 'outline'),
 				iconVariant: getResponseVariant(meta.to),
-				segments: subject
-					? buildSegments(
-							'{actor} changed the response of {subject} from {from} to {to}',
-							{ actor, subject },
-							[
-								{ key: 'from', value: meta.from },
-								{ key: 'to', value: meta.to },
-							],
-						)
-					: buildSegments(
-							'{actor} changed response from {from} to {to}',
-							{ actor },
-							[
-								{ key: 'from', value: meta.from },
-								{ key: 'to', value: meta.to },
-							],
-						),
+				segments: buildSegments(
+					subject
+						? '{actor} changed the response of {subject} from {from} to {to}'
+						: '{actor} changed response from {from} to {to}',
+					subject ? { actor, subject } : { actor },
+					[
+						{ key: 'from', value: meta.from },
+						{ key: 'to', value: meta.to },
+					],
+				),
 			}
 		case 'response.rescinded':
 			return {

--- a/src/views/AdminSettings.vue
+++ b/src/views/AdminSettings.vue
@@ -142,6 +142,22 @@
 				</div>
 
 				<div class="subsection">
+					<h4>{{ t('attendance', 'Can set responses for other users') }}</h4>
+					<p class="subsection-hint">
+						{{ t('attendance', 'Groups that can record or clear an answer on behalf of another person in the response summary. Not granted automatically to managers — if no group is selected, nobody has this permission.') }}
+					</p>
+					<GroupSelect
+						v-model="selectedRespondForOthersRoles"
+						:options="availableGroups"
+						:placeholder="t('attendance', 'Select groups …')"
+						:disabled="loading"
+						data-test="select-respond-for-others-roles" />
+					<p class="hint-text">
+						{{ n('attendance', '%n group selected', '%n groups selected', selectedRespondForOthersRoles.length, { n: selectedRespondForOthersRoles.length }) }}
+					</p>
+				</div>
+
+				<div class="subsection">
 					<h4>{{ t('attendance', 'Self-check-in') }}</h4>
 					<p class="subsection-hint">
 						{{ t('attendance', 'Groups that can self-check-in via NFC sticker or deep link') }}
@@ -655,6 +671,7 @@ const selectedCreateAppointmentsRoles = ref([])
 const selectedCheckinRoles = ref([])
 const selectedSeeResponseOverviewRoles = ref([])
 const selectedSeeCommentsRoles = ref([])
+const selectedRespondForOthersRoles = ref([])
 const selectedSelfCheckinRoles = ref([])
 const selfCheckinWindowMinutes = ref(30)
 const qrDataUrl = ref(null)
@@ -789,6 +806,9 @@ async function loadSettings() {
 			selectedSelfCheckinRoles.value = (config.permissions.self_checkin || [])
 				.map((id) => groups.find((group) => group.id === id))
 				.filter((group) => group !== undefined)
+			selectedRespondForOthersRoles.value = (config.permissions.respond_for_others || [])
+				.map((id) => groups.find((group) => group.id === id))
+				.filter((group) => group !== undefined)
 			selectedCreateAppointmentsRoles.value = (config.permissions.create_appointments || [])
 				.map((id) => groups.find((group) => group.id === id))
 				.filter((group) => group !== undefined)
@@ -885,6 +905,7 @@ async function saveSettings() {
 					PERMISSION_SEE_COMMENTS: selectedSeeCommentsRoles.value.map((g) => g.id),
 					PERMISSION_SELF_CHECKIN: selectedSelfCheckinRoles.value.map((g) => g.id),
 					PERMISSION_CREATE_APPOINTMENTS: selectedCreateAppointmentsRoles.value.map((g) => g.id),
+					PERMISSION_RESPOND_FOR_OTHERS: selectedRespondForOthersRoles.value.map((g) => g.id),
 				},
 				reminders: {
 					enabled: remindersEnabled.value,

--- a/src/views/AppointmentDetail.vue
+++ b/src/views/AppointmentDetail.vue
@@ -28,7 +28,8 @@
 				@export="showExportDialog"
 				@submitResponse="submitResponse"
 				@closedToggled="onClosedToggled"
-				@showAuditLog="scrollToAuditLog" />
+				@showAuditLog="scrollToAuditLog"
+				@refreshAppointment="loadAppointmentSilently" />
 
 			<AuditTimeline v-if="canSeeAuditTimeline" ref="auditTimeline" :appointmentId="appointment.id" />
 		</div>

--- a/tests/e2e/26-respond-on-behalf.spec.js
+++ b/tests/e2e/26-respond-on-behalf.spec.js
@@ -1,0 +1,195 @@
+import {
+	closeAppointmentViaAPI,
+	createAppointmentViaAPI,
+	deleteAllAppointments,
+	expect,
+	listAppointmentsViaAPI,
+	respondForUserViaAPI,
+	respondToAppointmentViaAPI,
+	test,
+} from './fixtures/nextcloud.js'
+
+const BASE_URL = process.env.NEXTCLOUD_URL || 'http://localhost:8080'
+const API_BASE = `${BASE_URL}/index.php`
+const adminAuth = 'Basic ' + Buffer.from('admin:admin').toString('base64')
+
+const FILTER_STORAGE_KEY = 'attendance:list-filters'
+
+async function fetchAudit(request, appointmentId) {
+	const resp = await request.get(
+		`${API_BASE}/apps/attendance/api/appointments/${appointmentId}/audit`,
+		{ headers: { Authorization: adminAuth, 'OCS-APIREQUEST': 'true', Accept: 'application/json' } },
+	)
+	return { status: resp.status(), body: resp.status() === 200 ? await resp.json() : null }
+}
+
+test.describe('Respond on behalf — API', () => {
+	test.afterAll(async ({ request }) => {
+		await deleteAllAppointments(request)
+	})
+
+	test('manager sets an answer for a non-responding user', async ({ request }) => {
+		const apt = await createAppointmentViaAPI(request, {
+			name: 'On-Behalf Set',
+			daysFromNow: 9,
+		})
+
+		const saved = await respondForUserViaAPI(request, apt.id, 'test', { response: 'yes' })
+		expect(saved.userId).toBe('test')
+		expect(saved.response).toBe('yes')
+		// The row is marked as manager-recorded, not self-answered.
+		expect(saved.responseSource).toBe('admin')
+
+		// The target no longer counts as "awaiting a response".
+		const unanswered = await listAppointmentsViaAPI(request, {
+			showPast: false,
+			unansweredOnly: true,
+			username: 'test',
+			password: 'test',
+		})
+		expect(unanswered.map((a) => a.id)).not.toContain(apt.id)
+	})
+
+	test('overriding an answer keeps the person\'s own comment', async ({ request }) => {
+		const apt = await createAppointmentViaAPI(request, {
+			name: 'On-Behalf Comment Kept',
+			daysFromNow: 9,
+		})
+
+		await respondToAppointmentViaAPI(request, apt.id, {
+			response: 'maybe',
+			comment: 'depends on my shift',
+			username: 'test',
+			password: 'test',
+		})
+
+		const saved = await respondForUserViaAPI(request, apt.id, 'test', { response: 'yes' })
+		expect(saved.response).toBe('yes')
+		expect(saved.comment).toBe('depends on my shift')
+	})
+
+	test('clearing restores the "not yet responded" state', async ({ request }) => {
+		const apt = await createAppointmentViaAPI(request, {
+			name: 'On-Behalf Clear',
+			daysFromNow: 9,
+		})
+
+		await respondForUserViaAPI(request, apt.id, 'test', { response: 'no' })
+		const cleared = await respondForUserViaAPI(request, apt.id, 'test', { response: null })
+		expect(cleared.response).toBeNull()
+		expect(cleared.comment).toBe('')
+
+		// Back in the target's unanswered list — reminders pick them up again.
+		const unanswered = await listAppointmentsViaAPI(request, {
+			showPast: false,
+			unansweredOnly: true,
+			username: 'test',
+			password: 'test',
+		})
+		expect(unanswered.map((a) => a.id)).toContain(apt.id)
+	})
+
+	test('setting an answer on a closed inquiry is rejected', async ({ request }) => {
+		const apt = await createAppointmentViaAPI(request, {
+			name: 'On-Behalf Closed',
+			daysFromNow: 9,
+		})
+		await closeAppointmentViaAPI(request, apt.id)
+
+		const blocked = await respondForUserViaAPI(request, apt.id, 'test', { response: 'yes' })
+		expect(blocked.error).toMatch(/closed/i)
+	})
+
+	test('setting an answer for someone outside the audience is rejected', async ({ request }) => {
+		const apt = await createAppointmentViaAPI(request, {
+			name: 'On-Behalf Audience',
+			daysFromNow: 9,
+			visibleUsers: ['test'],
+		})
+
+		const blocked = await respondForUserViaAPI(request, apt.id, 'test2', { response: 'yes' })
+		expect(blocked.error).toMatch(/audience/i)
+	})
+
+	test('audit log records the manager as actor with source admin_response', async ({ request }) => {
+		const apt = await createAppointmentViaAPI(request, {
+			name: 'On-Behalf Audit',
+			daysFromNow: 9,
+		})
+
+		await respondForUserViaAPI(request, apt.id, 'test', { response: 'yes' })
+		await respondForUserViaAPI(request, apt.id, 'test', { response: null })
+
+		const { status, body } = await fetchAudit(request, apt.id)
+		expect(status).toBe(200)
+
+		// Newest-first: the clear, then the set (appointment.created sits below).
+		const [rescinded, submitted] = body.items
+		expect(rescinded.verb).toBe('response.rescinded')
+		expect(submitted.verb).toBe('response.submitted')
+		for (const event of [rescinded, submitted]) {
+			expect(event.actorId).toBe('admin')
+			expect(event.subjectId).toBe('test')
+			expect(event.source).toBe('admin_response')
+		}
+	})
+
+	test('capability flag respondOnBehalf is exposed', async ({ request }) => {
+		const resp = await request.get(`${API_BASE}/apps/attendance/api/capabilities`, {
+			headers: { Authorization: adminAuth, 'OCS-APIREQUEST': 'true' },
+		})
+		const caps = await resp.json()
+		expect(caps.respondOnBehalf).toBe(true)
+	})
+})
+
+test.describe('Respond on behalf — UI', () => {
+	test.describe.configure({ mode: 'serial' })
+
+	const meetingName = 'UI On-Behalf Test'
+
+	test.beforeAll(async ({ request }) => {
+		await createAppointmentViaAPI(request, {
+			name: meetingName,
+			daysFromNow: 8,
+		})
+	})
+
+	test.afterAll(async ({ request }) => {
+		await deleteAllAppointments(request)
+	})
+
+	test.beforeEach(async ({ page, loginAsUser, attendanceApp }) => {
+		await loginAsUser('admin', 'admin')
+		await attendanceApp()
+		await page.evaluate((key) => window.localStorage.removeItem(key), FILTER_STORAGE_KEY)
+		await page.reload()
+		await page.waitForLoadState('networkidle')
+	})
+
+	test('pencil on a non-responder chip sets the answer, pencil on the row clears it again', async ({ page }) => {
+		// Open the detail page — the response summary only renders there.
+		const listCard = page.locator('[data-test="appointment-card"]', { hasText: meetingName }).first()
+		await listCard.locator('[data-test="appointment-title-link"]').click()
+		await expect(page.locator('[data-test="response-summary"]')).toBeVisible()
+
+		// No whitelisted groups in the default config, so everyone sits in
+		// the collapsed "Others" bucket.
+		await page.locator('[data-test="others-header"]').click()
+
+		// test1 has not answered → pencil on their chip opens the picker.
+		await page.locator('.pending-user [data-test="set-answer-test1"]').click()
+		await page.locator('[data-test="set-answer-yes-test1"]').click()
+
+		// The silent refetch moves test1 from the chips into the answered rows.
+		const row = page.locator('[data-test="response-row-test1"]')
+		await expect(row).toBeVisible()
+		await expect(page.locator('.pending-user [data-test="set-answer-test1"]')).toHaveCount(0)
+
+		// Clearing from the row's pencil puts the chip back.
+		await row.locator('[data-test="set-answer-test1"]').click()
+		await page.locator('[data-test="set-answer-clear-test1"]').click()
+		await expect(page.locator('[data-test="response-row-test1"]')).toHaveCount(0)
+		await expect(page.locator('.pending-user [data-test="set-answer-test1"]')).toBeVisible()
+	})
+})

--- a/tests/e2e/26-respond-on-behalf.spec.js
+++ b/tests/e2e/26-respond-on-behalf.spec.js
@@ -6,6 +6,7 @@ import {
 	listAppointmentsViaAPI,
 	respondForUserViaAPI,
 	respondToAppointmentViaAPI,
+	saveAdminSettings,
 	test,
 } from './fixtures/nextcloud.js'
 
@@ -23,8 +24,22 @@ async function fetchAudit(request, appointmentId) {
 	return { status: resp.status(), body: resp.status() === 200 ? await resp.json() : null }
 }
 
+// The respond_for_others permission grants NOBODY when unconfigured — it is
+// deliberately not implied by manage rights. Grant it to the admin group for
+// the duration of this file (which is why it runs in sequential-admin).
+async function grantRespondForOthers(request, groups) {
+	await saveAdminSettings(request, {
+		permissions: { respond_for_others: groups },
+	})
+}
+
 test.describe('Respond on behalf — API', () => {
+	test.beforeAll(async ({ request }) => {
+		await grantRespondForOthers(request, ['admin'])
+	})
+
 	test.afterAll(async ({ request }) => {
+		await grantRespondForOthers(request, [])
 		await deleteAllAppointments(request)
 	})
 
@@ -137,6 +152,35 @@ test.describe('Respond on behalf — API', () => {
 		}
 	})
 
+	test('user outside the configured groups is rejected, manage rights notwithstanding', async ({ request }) => {
+		const apt = await createAppointmentViaAPI(request, {
+			name: 'On-Behalf No Permission',
+			daysFromNow: 9,
+		})
+
+		// "test" holds manage rights (unconfigured = everyone) but is not in
+		// the admin group, which is the only one granted respond_for_others.
+		const blocked = await respondForUserViaAPI(request, apt.id, 'test1', {
+			response: 'yes',
+			username: 'test',
+			password: 'test',
+		})
+		expect(blocked.error).toMatch(/permission/i)
+	})
+
+	test('permission is reported via the user permissions endpoint', async ({ request }) => {
+		const adminPerms = await request.get(`${API_BASE}/apps/attendance/api/user/permissions`, {
+			headers: { Authorization: adminAuth, 'OCS-APIREQUEST': 'true' },
+		})
+		expect((await adminPerms.json()).canRespondForOthers).toBe(true)
+
+		const userAuth = 'Basic ' + Buffer.from('test:test').toString('base64')
+		const userPerms = await request.get(`${API_BASE}/apps/attendance/api/user/permissions`, {
+			headers: { Authorization: userAuth, 'OCS-APIREQUEST': 'true' },
+		})
+		expect((await userPerms.json()).canRespondForOthers).toBe(false)
+	})
+
 	test('capability flag respondOnBehalf is exposed', async ({ request }) => {
 		const resp = await request.get(`${API_BASE}/apps/attendance/api/capabilities`, {
 			headers: { Authorization: adminAuth, 'OCS-APIREQUEST': 'true' },
@@ -152,6 +196,7 @@ test.describe('Respond on behalf — UI', () => {
 	const meetingName = 'UI On-Behalf Test'
 
 	test.beforeAll(async ({ request }) => {
+		await grantRespondForOthers(request, ['admin'])
 		// Directly addressing test1 puts them into the "Others" bucket's
 		// non-responder list — an unrestricted appointment has no known
 		// audience (no whitelisted groups in the default config), so the
@@ -164,6 +209,7 @@ test.describe('Respond on behalf — UI', () => {
 	})
 
 	test.afterAll(async ({ request }) => {
+		await grantRespondForOthers(request, [])
 		await deleteAllAppointments(request)
 	})
 

--- a/tests/e2e/26-respond-on-behalf.spec.js
+++ b/tests/e2e/26-respond-on-behalf.spec.js
@@ -100,15 +100,18 @@ test.describe('Respond on behalf — API', () => {
 		expect(blocked.error).toMatch(/closed/i)
 	})
 
-	test('setting an answer for someone outside the audience is rejected', async ({ request }) => {
+	// NOTE: the audience rejection cannot be exercised here — with the test
+	// instance's unconfigured permissions every user counts as a manager and
+	// managers always pass the visibility check. It is covered by unit tests
+	// (testSubmitResponseForUserRejectsUserOutsideAudience).
+	test('setting an answer for an unknown user is rejected', async ({ request }) => {
 		const apt = await createAppointmentViaAPI(request, {
-			name: 'On-Behalf Audience',
+			name: 'On-Behalf Unknown User',
 			daysFromNow: 9,
-			visibleUsers: ['test'],
 		})
 
-		const blocked = await respondForUserViaAPI(request, apt.id, 'test2', { response: 'yes' })
-		expect(blocked.error).toMatch(/audience/i)
+		const blocked = await respondForUserViaAPI(request, apt.id, 'does-not-exist', { response: 'yes' })
+		expect(blocked.error).toMatch(/not found/i)
 	})
 
 	test('audit log records the manager as actor with source admin_response', async ({ request }) => {
@@ -149,9 +152,14 @@ test.describe('Respond on behalf — UI', () => {
 	const meetingName = 'UI On-Behalf Test'
 
 	test.beforeAll(async ({ request }) => {
+		// Directly addressing test1 puts them into the "Others" bucket's
+		// non-responder list — an unrestricted appointment has no known
+		// audience (no whitelisted groups in the default config), so the
+		// group summary would stay empty and never render a section.
 		await createAppointmentViaAPI(request, {
 			name: meetingName,
 			daysFromNow: 8,
+			visibleUsers: ['test1'],
 		})
 	})
 

--- a/tests/e2e/fixtures/nextcloud.js
+++ b/tests/e2e/fixtures/nextcloud.js
@@ -1,4 +1,4 @@
-import { expect, test as base } from '@playwright/test'
+import { test as base, expect } from '@playwright/test'
 import { existsSync, mkdirSync, readFileSync } from 'fs'
 import { dirname, join } from 'path'
 import { fileURLToPath } from 'url'
@@ -24,7 +24,7 @@ async function resilientJson(responseFn, { retries = 3, delay = 1000 } = {}) {
 		}
 		// Non-JSON (likely HTML error page) — retry unless last attempt.
 		if (attempt < retries) {
-			await new Promise(r => setTimeout(r, delay * attempt))
+			await new Promise((r) => setTimeout(r, delay * attempt))
 		} else {
 			return resp // let the caller deal with the failure
 		}
@@ -72,10 +72,10 @@ function ensureAuthDir() {
  */
 export function authHeaders(username = 'admin', password = 'admin') {
 	return {
-		'Authorization': 'Basic ' + Buffer.from(`${username}:${password}`).toString('base64'),
+		Authorization: 'Basic ' + Buffer.from(`${username}:${password}`).toString('base64'),
 		'Content-Type': 'application/json',
 		'OCS-APIREQUEST': 'true',
-		'Cookie': '',
+		Cookie: '',
 	}
 }
 
@@ -159,12 +159,10 @@ export async function createAppointmentViaAPI(request, {
 		sendNotification,
 		...(responseDeadline ? { responseDeadline: responseDeadline.toISOString() } : {}),
 	}
-	const resp = await resilientJson(() =>
-		request.post(`${API_BASE}/apps/attendance/api/appointments`, {
-			headers: authHeaders(username, password),
-			data,
-		}),
-	)
+	const resp = await resilientJson(() => request.post(`${API_BASE}/apps/attendance/api/appointments`, {
+		headers: authHeaders(username, password),
+		data,
+	}))
 	return resp.json()
 }
 
@@ -172,11 +170,9 @@ export async function createAppointmentViaAPI(request, {
  * Delete a single appointment via the REST API
  */
 export async function deleteAppointmentViaAPI(request, id, { username = 'admin', password = 'admin' } = {}) {
-	await resilientJson(() =>
-		request.delete(`${API_BASE}/apps/attendance/api/appointments/${id}`, {
-			headers: authHeaders(username, password),
-		}),
-	)
+	await resilientJson(() => request.delete(`${API_BASE}/apps/attendance/api/appointments/${id}`, {
+		headers: authHeaders(username, password),
+	}))
 }
 
 /**
@@ -193,12 +189,10 @@ export async function listAppointmentsViaAPI(request, { showPast = true, unanswe
 	})
 	if (unansweredOnly) params.set('unansweredOnly', 'true')
 	if (notScheduledOut) params.set('notScheduledOut', 'true')
-	const resp = await resilientJson(() =>
-		request.get(
-			`${API_BASE}/apps/attendance/api/appointments?${params.toString()}`,
-			{ headers: authHeaders(username, password) },
-		),
-	)
+	const resp = await resilientJson(() => request.get(
+		`${API_BASE}/apps/attendance/api/appointments?${params.toString()}`,
+		{ headers: authHeaders(username, password) },
+	))
 	return resp.json()
 }
 
@@ -206,11 +200,9 @@ export async function listAppointmentsViaAPI(request, { showPast = true, unanswe
  * Close an appointment inquiry. Returns the updated appointment payload.
  */
 export async function closeAppointmentViaAPI(request, id, { username = 'admin', password = 'admin' } = {}) {
-	const resp = await resilientJson(() =>
-		request.post(`${API_BASE}/apps/attendance/api/appointments/${id}/close`, {
-			headers: authHeaders(username, password),
-		}),
-	)
+	const resp = await resilientJson(() => request.post(`${API_BASE}/apps/attendance/api/appointments/${id}/close`, {
+		headers: authHeaders(username, password),
+	}))
 	return { status: resp.status(), body: await resp.json() }
 }
 
@@ -218,11 +210,9 @@ export async function closeAppointmentViaAPI(request, id, { username = 'admin', 
  * Re-open a previously closed appointment inquiry.
  */
 export async function reopenAppointmentViaAPI(request, id, { username = 'admin', password = 'admin' } = {}) {
-	const resp = await resilientJson(() =>
-		request.post(`${API_BASE}/apps/attendance/api/appointments/${id}/reopen`, {
-			headers: authHeaders(username, password),
-		}),
-	)
+	const resp = await resilientJson(() => request.post(`${API_BASE}/apps/attendance/api/appointments/${id}/reopen`, {
+		headers: authHeaders(username, password),
+	}))
 	return { status: resp.status(), body: await resp.json() }
 }
 
@@ -263,7 +253,7 @@ export async function forceWipeAllAppointments(request, { username = 'admin', pa
 		for (const id of ids) {
 			await deleteAppointmentViaAPI(request, id, { username, password })
 		}
-		await new Promise(r => setTimeout(r, 200))
+		await new Promise((r) => setTimeout(r, 200))
 	}
 }
 
@@ -276,15 +266,13 @@ export async function respondToAppointmentViaAPI(request, appointmentId, {
 	username = 'admin',
 	password = 'admin',
 } = {}) {
-	const resp = await resilientJson(() =>
-		request.post(
-			`${API_BASE}/apps/attendance/api/appointments/${appointmentId}/respond`,
-			{
-				headers: authHeaders(username, password),
-				data: { response: vote, comment },
-			},
-		),
-	)
+	const resp = await resilientJson(() => request.post(
+		`${API_BASE}/apps/attendance/api/appointments/${appointmentId}/respond`,
+		{
+			headers: authHeaders(username, password),
+			data: { response: vote, comment },
+		},
+	))
 	return resp.json()
 }
 
@@ -297,15 +285,32 @@ export async function checkinUserViaAPI(request, appointmentId, targetUserId, {
 	username = 'admin',
 	password = 'admin',
 } = {}) {
-	const resp = await resilientJson(() =>
-		request.post(
-			`${API_BASE}/apps/attendance/api/appointments/${appointmentId}/checkin/${targetUserId}`,
-			{
-				headers: authHeaders(username, password),
-				data: { response, comment },
-			},
-		),
-	)
+	const resp = await resilientJson(() => request.post(
+		`${API_BASE}/apps/attendance/api/appointments/${appointmentId}/checkin/${targetUserId}`,
+		{
+			headers: authHeaders(username, password),
+			data: { response, comment },
+		},
+	))
+	return resp.json()
+}
+
+/**
+ * Set or clear a response on behalf of another user via the REST API
+ * (issue #47). Pass response: null to clear the target's answer.
+ */
+export async function respondForUserViaAPI(request, appointmentId, targetUserId, {
+	response = 'yes',
+	username = 'admin',
+	password = 'admin',
+} = {}) {
+	const resp = await resilientJson(() => request.post(
+		`${API_BASE}/apps/attendance/api/appointments/${appointmentId}/respond/${targetUserId}`,
+		{
+			headers: authHeaders(username, password),
+			data: { response },
+		},
+	))
 	return resp.json()
 }
 
@@ -313,12 +318,10 @@ export async function checkinUserViaAPI(request, appointmentId, targetUserId, {
  * Save admin settings via the REST API
  */
 export async function saveAdminSettings(request, settings = {}) {
-	const resp = await resilientJson(() =>
-		request.post(`${API_BASE}/apps/attendance/api/admin/settings`, {
-			headers: authHeaders('admin', 'admin'),
-			data: settings,
-		}),
-	)
+	const resp = await resilientJson(() => request.post(`${API_BASE}/apps/attendance/api/admin/settings`, {
+		headers: authHeaders('admin', 'admin'),
+		data: settings,
+	}))
 	return resp.json()
 }
 
@@ -375,7 +378,7 @@ export async function createFileViaWebDAV(request, { filename, content = 'Test c
 		`${API_BASE}/remote.php/dav/files/${username}/${filename}`,
 		{
 			headers: {
-				'Authorization': 'Basic ' + Buffer.from(`${username}:${password}`).toString('base64'),
+				Authorization: 'Basic ' + Buffer.from(`${username}:${password}`).toString('base64'),
 				'Content-Type': 'text/plain',
 			},
 			data: content,

--- a/tests/unit/Service/AppointmentServiceTest.php
+++ b/tests/unit/Service/AppointmentServiceTest.php
@@ -569,10 +569,10 @@ class AppointmentServiceTest extends TestCase {
 		$appointment = new Appointment();
 		$appointment->setId($appointmentId);
 
-		$this->appointmentMapper->expects($this->once())
-			->method('find')
-			->with($appointmentId)
-			->willReturn($appointment);
+		// The controller already loaded the appointment, so the service must
+		// not fetch it again.
+		$this->appointmentMapper->expects($this->never())
+			->method('find');
 
 		$this->visibilityService->expects($this->once())
 			->method('canUserSeeAppointment')
@@ -611,7 +611,7 @@ class AppointmentServiceTest extends TestCase {
 			->method('markAppointmentNotificationsProcessed')
 			->with($appointmentId, $targetUserId);
 
-		$result = $this->service->submitResponseForUser($appointmentId, $targetUserId, 'yes', $actorUserId);
+		$result = $this->service->submitResponseForUser($appointment, $targetUserId, 'yes', $actorUserId);
 		$this->assertInstanceOf(AttendanceResponse::class, $result);
 	}
 
@@ -623,7 +623,6 @@ class AppointmentServiceTest extends TestCase {
 		$appointment = new Appointment();
 		$appointment->setId($appointmentId);
 
-		$this->appointmentMapper->method('find')->willReturn($appointment);
 		$this->visibilityService->method('canUserSeeAppointment')->willReturn(true);
 
 		$existingResponse = new AttendanceResponse();
@@ -659,7 +658,7 @@ class AppointmentServiceTest extends TestCase {
 				$actorUserId,
 			);
 
-		$result = $this->service->submitResponseForUser($appointmentId, $targetUserId, 'yes', $actorUserId);
+		$result = $this->service->submitResponseForUser($appointment, $targetUserId, 'yes', $actorUserId);
 		$this->assertInstanceOf(AttendanceResponse::class, $result);
 	}
 
@@ -671,7 +670,6 @@ class AppointmentServiceTest extends TestCase {
 		$appointment = new Appointment();
 		$appointment->setId($appointmentId);
 
-		$this->appointmentMapper->method('find')->willReturn($appointment);
 		$this->visibilityService->method('canUserSeeAppointment')->willReturn(true);
 
 		$existingResponse = new AttendanceResponse();
@@ -704,17 +702,14 @@ class AppointmentServiceTest extends TestCase {
 				$actorUserId,
 			);
 
-		$result = $this->service->submitResponseForUser($appointmentId, $targetUserId, null, $actorUserId);
+		$result = $this->service->submitResponseForUser($appointment, $targetUserId, null, $actorUserId);
 		$this->assertInstanceOf(AttendanceResponse::class, $result);
 	}
 
 	public function testSubmitResponseForUserRejectsUserOutsideAudience(): void {
-		$appointmentId = 1;
-
 		$appointment = new Appointment();
-		$appointment->setId($appointmentId);
+		$appointment->setId(1);
 
-		$this->appointmentMapper->method('find')->willReturn($appointment);
 		$this->visibilityService->expects($this->once())
 			->method('canUserSeeAppointment')
 			->with($appointment, 'stranger')
@@ -724,31 +719,28 @@ class AppointmentServiceTest extends TestCase {
 		$this->responseMapper->expects($this->never())->method('update');
 
 		$this->expectException(\InvalidArgumentException::class);
-		$this->service->submitResponseForUser($appointmentId, 'stranger', 'yes', 'manager');
+		$this->service->submitResponseForUser($appointment, 'stranger', 'yes', 'manager');
 	}
 
 	public function testSubmitResponseForUserThrowsForInvalidResponse(): void {
 		$this->expectException(\InvalidArgumentException::class);
 		$this->expectExceptionMessage('Invalid response. Must be yes, no, maybe, or null.');
 
-		$this->service->submitResponseForUser(1, 'user', 'invalid', 'manager');
+		$this->service->submitResponseForUser(new Appointment(), 'user', 'invalid', 'manager');
 	}
 
 	public function testSubmitResponseForUserRejectsClosedAppointment(): void {
-		$appointmentId = 1;
-
 		$appointment = new Appointment();
-		$appointment->setId($appointmentId);
+		$appointment->setId(1);
 		$appointment->setClosedAt('2026-01-01 12:00:00');
 
-		$this->appointmentMapper->method('find')->willReturn($appointment);
 		$this->visibilityService->method('canUserSeeAppointment')->willReturn(true);
 
 		$this->responseMapper->expects($this->never())->method('update');
 		$this->responseMapper->expects($this->never())->method('insert');
 
 		$this->expectException(\RuntimeException::class);
-		$this->service->submitResponseForUser($appointmentId, 'phoneuser', 'yes', 'manager');
+		$this->service->submitResponseForUser($appointment, 'phoneuser', 'yes', 'manager');
 	}
 
 	public function testGetUserResponseReturnsNullWhenNotFound(): void {

--- a/tests/unit/Service/AppointmentServiceTest.php
+++ b/tests/unit/Service/AppointmentServiceTest.php
@@ -561,6 +561,196 @@ class AppointmentServiceTest extends TestCase {
 		$this->service->submitResponse($appointmentId, $userId, null);
 	}
 
+	public function testSubmitResponseForUserCreatesNewResponseWithAdminSource(): void {
+		$appointmentId = 1;
+		$targetUserId = 'phoneuser';
+		$actorUserId = 'manager';
+
+		$appointment = new Appointment();
+		$appointment->setId($appointmentId);
+
+		$this->appointmentMapper->expects($this->once())
+			->method('find')
+			->with($appointmentId)
+			->willReturn($appointment);
+
+		$this->visibilityService->expects($this->once())
+			->method('canUserSeeAppointment')
+			->with($appointment, $targetUserId)
+			->willReturn(true);
+
+		$this->responseMapper->expects($this->once())
+			->method('findByAppointmentAndUser')
+			->with($appointmentId, $targetUserId)
+			->willThrowException(new DoesNotExistException(''));
+
+		$this->responseMapper->expects($this->once())
+			->method('insert')
+			->willReturnCallback(function (AttendanceResponse $r) use ($targetUserId) {
+				$this->assertSame($targetUserId, $r->getUserId());
+				$this->assertSame('yes', $r->getResponse());
+				$this->assertSame('', $r->getComment());
+				$this->assertSame('admin', $r->getResponseSource());
+				return $r;
+			});
+
+		$this->auditEventService->expects($this->once())
+			->method('recordResponseChange')
+			->with(
+				$appointmentId,
+				$targetUserId,
+				null,
+				'',
+				'yes',
+				'',
+				Verb::SOURCE_ADMIN_RESPONSE,
+				$actorUserId,
+			);
+
+		$this->notificationService->expects($this->once())
+			->method('markAppointmentNotificationsProcessed')
+			->with($appointmentId, $targetUserId);
+
+		$result = $this->service->submitResponseForUser($appointmentId, $targetUserId, 'yes', $actorUserId);
+		$this->assertInstanceOf(AttendanceResponse::class, $result);
+	}
+
+	public function testSubmitResponseForUserPreservesExistingComment(): void {
+		$appointmentId = 1;
+		$targetUserId = 'phoneuser';
+		$actorUserId = 'manager';
+
+		$appointment = new Appointment();
+		$appointment->setId($appointmentId);
+
+		$this->appointmentMapper->method('find')->willReturn($appointment);
+		$this->visibilityService->method('canUserSeeAppointment')->willReturn(true);
+
+		$existingResponse = new AttendanceResponse();
+		$existingResponse->setId(1);
+		$existingResponse->setResponse('maybe');
+		$existingResponse->setComment('depends on my shift');
+
+		$this->responseMapper->expects($this->once())
+			->method('findByAppointmentAndUser')
+			->with($appointmentId, $targetUserId)
+			->willReturn($existingResponse);
+
+		$this->responseMapper->expects($this->once())
+			->method('update')
+			->willReturnCallback(function (AttendanceResponse $r) {
+				$this->assertSame('yes', $r->getResponse());
+				// The person's own comment must survive a manager override.
+				$this->assertSame('depends on my shift', $r->getComment());
+				$this->assertSame('admin', $r->getResponseSource());
+				return $r;
+			});
+
+		$this->auditEventService->expects($this->once())
+			->method('recordResponseChange')
+			->with(
+				$appointmentId,
+				$targetUserId,
+				'maybe',
+				'depends on my shift',
+				'yes',
+				'depends on my shift',
+				Verb::SOURCE_ADMIN_RESPONSE,
+				$actorUserId,
+			);
+
+		$result = $this->service->submitResponseForUser($appointmentId, $targetUserId, 'yes', $actorUserId);
+		$this->assertInstanceOf(AttendanceResponse::class, $result);
+	}
+
+	public function testSubmitResponseForUserWithNullClearsResponseAndComment(): void {
+		$appointmentId = 1;
+		$targetUserId = 'phoneuser';
+		$actorUserId = 'manager';
+
+		$appointment = new Appointment();
+		$appointment->setId($appointmentId);
+
+		$this->appointmentMapper->method('find')->willReturn($appointment);
+		$this->visibilityService->method('canUserSeeAppointment')->willReturn(true);
+
+		$existingResponse = new AttendanceResponse();
+		$existingResponse->setId(1);
+		$existingResponse->setResponse('yes');
+		$existingResponse->setComment('see you there');
+
+		$this->responseMapper->expects($this->once())
+			->method('findByAppointmentAndUser')
+			->willReturn($existingResponse);
+
+		$this->responseMapper->expects($this->once())
+			->method('update')
+			->willReturnCallback(function (AttendanceResponse $r) {
+				$this->assertNull($r->getResponse());
+				$this->assertSame('', $r->getComment());
+				return $r;
+			});
+
+		$this->auditEventService->expects($this->once())
+			->method('recordResponseChange')
+			->with(
+				$appointmentId,
+				$targetUserId,
+				'yes',
+				'see you there',
+				null,
+				'',
+				Verb::SOURCE_ADMIN_RESPONSE,
+				$actorUserId,
+			);
+
+		$result = $this->service->submitResponseForUser($appointmentId, $targetUserId, null, $actorUserId);
+		$this->assertInstanceOf(AttendanceResponse::class, $result);
+	}
+
+	public function testSubmitResponseForUserRejectsUserOutsideAudience(): void {
+		$appointmentId = 1;
+
+		$appointment = new Appointment();
+		$appointment->setId($appointmentId);
+
+		$this->appointmentMapper->method('find')->willReturn($appointment);
+		$this->visibilityService->expects($this->once())
+			->method('canUserSeeAppointment')
+			->with($appointment, 'stranger')
+			->willReturn(false);
+
+		$this->responseMapper->expects($this->never())->method('insert');
+		$this->responseMapper->expects($this->never())->method('update');
+
+		$this->expectException(\InvalidArgumentException::class);
+		$this->service->submitResponseForUser($appointmentId, 'stranger', 'yes', 'manager');
+	}
+
+	public function testSubmitResponseForUserThrowsForInvalidResponse(): void {
+		$this->expectException(\InvalidArgumentException::class);
+		$this->expectExceptionMessage('Invalid response. Must be yes, no, maybe, or null.');
+
+		$this->service->submitResponseForUser(1, 'user', 'invalid', 'manager');
+	}
+
+	public function testSubmitResponseForUserRejectsClosedAppointment(): void {
+		$appointmentId = 1;
+
+		$appointment = new Appointment();
+		$appointment->setId($appointmentId);
+		$appointment->setClosedAt('2026-01-01 12:00:00');
+
+		$this->appointmentMapper->method('find')->willReturn($appointment);
+		$this->visibilityService->method('canUserSeeAppointment')->willReturn(true);
+
+		$this->responseMapper->expects($this->never())->method('update');
+		$this->responseMapper->expects($this->never())->method('insert');
+
+		$this->expectException(\RuntimeException::class);
+		$this->service->submitResponseForUser($appointmentId, 'phoneuser', 'yes', 'manager');
+	}
+
 	public function testGetUserResponseReturnsNullWhenNotFound(): void {
 		$appointmentId = 1;
 		$userId = 'testuser';

--- a/tests/unit/Service/AppointmentServiceTest.php
+++ b/tests/unit/Service/AppointmentServiceTest.php
@@ -574,6 +574,8 @@ class AppointmentServiceTest extends TestCase {
 		$this->appointmentMapper->expects($this->never())
 			->method('find');
 
+		$this->userManager->method('get')->willReturn($this->createMock(\OCP\IUser::class));
+
 		$this->visibilityService->expects($this->once())
 			->method('canUserSeeAppointment')
 			->with($appointment, $targetUserId)
@@ -623,6 +625,7 @@ class AppointmentServiceTest extends TestCase {
 		$appointment = new Appointment();
 		$appointment->setId($appointmentId);
 
+		$this->userManager->method('get')->willReturn($this->createMock(\OCP\IUser::class));
 		$this->visibilityService->method('canUserSeeAppointment')->willReturn(true);
 
 		$existingResponse = new AttendanceResponse();
@@ -670,6 +673,7 @@ class AppointmentServiceTest extends TestCase {
 		$appointment = new Appointment();
 		$appointment->setId($appointmentId);
 
+		$this->userManager->method('get')->willReturn($this->createMock(\OCP\IUser::class));
 		$this->visibilityService->method('canUserSeeAppointment')->willReturn(true);
 
 		$existingResponse = new AttendanceResponse();
@@ -706,10 +710,27 @@ class AppointmentServiceTest extends TestCase {
 		$this->assertInstanceOf(AttendanceResponse::class, $result);
 	}
 
+	public function testSubmitResponseForUserRejectsUnknownUser(): void {
+		$appointment = new Appointment();
+		$appointment->setId(1);
+
+		// userManager->get returns null for unknown users; the guard must
+		// fire before the permission-based visibility check, which treats
+		// unknown users as managers when permissions are unconfigured.
+		$this->visibilityService->expects($this->never())->method('canUserSeeAppointment');
+		$this->responseMapper->expects($this->never())->method('insert');
+		$this->responseMapper->expects($this->never())->method('update');
+
+		$this->expectException(\InvalidArgumentException::class);
+		$this->expectExceptionMessage('User not found');
+		$this->service->submitResponseForUser($appointment, 'ghost', 'yes', 'manager');
+	}
+
 	public function testSubmitResponseForUserRejectsUserOutsideAudience(): void {
 		$appointment = new Appointment();
 		$appointment->setId(1);
 
+		$this->userManager->method('get')->willReturn($this->createMock(\OCP\IUser::class));
 		$this->visibilityService->expects($this->once())
 			->method('canUserSeeAppointment')
 			->with($appointment, 'stranger')
@@ -734,6 +755,7 @@ class AppointmentServiceTest extends TestCase {
 		$appointment->setId(1);
 		$appointment->setClosedAt('2026-01-01 12:00:00');
 
+		$this->userManager->method('get')->willReturn($this->createMock(\OCP\IUser::class));
 		$this->visibilityService->method('canUserSeeAppointment')->willReturn(true);
 
 		$this->responseMapper->expects($this->never())->method('update');

--- a/tests/unit/Service/PermissionServiceTest.php
+++ b/tests/unit/Service/PermissionServiceTest.php
@@ -244,7 +244,7 @@ class PermissionServiceTest extends TestCase {
 	}
 
 	public function testGetAllPermissionSettings(): void {
-		$this->config->expects($this->exactly(6))
+		$this->config->expects($this->exactly(7))
 			->method('getAppValue')
 			->willReturnMap([
 				['attendance', 'permission_manage_appointments', '[]', '["admin"]'],
@@ -252,7 +252,8 @@ class PermissionServiceTest extends TestCase {
 				['attendance', 'permission_see_response_overview', '[]', '["admin"]'],
 				['attendance', 'permission_see_comments', '[]', '["admin","managers"]'],
 				['attendance', 'permission_self_checkin', '[]', '["users"]'],
-				['attendance', 'permission_create_appointments', '[]', '["members"]']
+				['attendance', 'permission_create_appointments', '[]', '["members"]'],
+				['attendance', 'permission_respond_for_others', '[]', '["staff"]']
 			]);
 
 		$result = $this->service->getAllPermissionSettings();
@@ -263,7 +264,8 @@ class PermissionServiceTest extends TestCase {
 			PermissionService::PERMISSION_SEE_RESPONSE_OVERVIEW => ['admin'],
 			PermissionService::PERMISSION_SEE_COMMENTS => ['admin', 'managers'],
 			PermissionService::PERMISSION_SELF_CHECKIN => ['users'],
-			PermissionService::PERMISSION_CREATE_APPOINTMENTS => ['members']
+			PermissionService::PERMISSION_CREATE_APPOINTMENTS => ['members'],
+			PermissionService::PERMISSION_RESPOND_FOR_OTHERS => ['staff']
 		];
 
 		$this->assertEquals($expected, $result);
@@ -418,6 +420,56 @@ class PermissionServiceTest extends TestCase {
 			]);
 
 		$this->assertFalse($this->service->canCreateAppointments('guestuser'));
+	}
+
+	// --- respond_for_others: empty config must mean "nobody", not even managers ---
+
+	public function testRespondForOthersEmptyConfigDeniesEveryone(): void {
+		$this->guestService->method('isGuestUser')->willReturn(false);
+		// Unconfigured: manage_appointments would default to "everyone", but
+		// respond_for_others is closed-when-unconfigured — nobody gets it.
+		$this->config->method('getAppValue')->willReturn('[]');
+
+		$this->assertFalse($this->service->canRespondForOthers('regularuser'));
+	}
+
+	public function testRespondForOthersNotImpliedByManagePermission(): void {
+		$this->guestService->method('isGuestUser')->willReturn(false);
+		// User is a manager, but respond_for_others is granted to a group
+		// they are not in — manage rights must not bleed through.
+		$this->config->method('getAppValue')
+			->willReturnMap([
+				['attendance', 'permission_manage_appointments', '[]', '["managers"]'],
+				['attendance', 'permission_respond_for_others', '[]', '["office"]'],
+			]);
+		$user = $this->createMock(IUser::class);
+		$this->userManager->method('get')->willReturn($user);
+		$this->groupManager->method('getUserGroupIds')->willReturn(['managers']);
+
+		$this->assertTrue($this->service->canManageAppointments('manageruser'));
+		$this->assertFalse($this->service->canRespondForOthers('manageruser'));
+	}
+
+	public function testRespondForOthersGrantedViaConfiguredGroup(): void {
+		$this->guestService->method('isGuestUser')->willReturn(false);
+		$this->config->method('getAppValue')
+			->willReturnMap([
+				['attendance', 'permission_respond_for_others', '[]', '["office"]'],
+			]);
+		$user = $this->createMock(IUser::class);
+		$this->userManager->method('get')->willReturn($user);
+		$this->groupManager->method('getUserGroupIds')->willReturn(['office']);
+
+		$this->assertTrue($this->service->canRespondForOthers('officeuser'));
+	}
+
+	public function testRespondForOthersBlockedForGuests(): void {
+		$this->guestService->method('isGuestUser')->with('guestuser')->willReturn(true);
+		// Guest hard-block runs before the role lookup, even when the guest
+		// group was accidentally whitelisted.
+		$this->config->expects($this->never())->method('getAppValue');
+
+		$this->assertFalse($this->service->canRespondForOthers('guestuser'));
 	}
 
 	// --- organizer checks ---

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,7 +1,6 @@
 import { createAppConfig } from "@nextcloud/vite-config";
 import { readFileSync } from "fs";
 import { join, resolve } from "path";
-import { createLogger } from "vite";
 
 // Read app id/version from appinfo/info.xml so we can inject them as globals.
 // @nextcloud/vue expects top-level `appName` / `appVersion` identifiers; since Vite 7
@@ -10,18 +9,6 @@ import { createLogger } from "vite";
 const infoXml = readFileSync(resolve("appinfo", "info.xml"), "utf8");
 const appId = infoXml.match(/<id>([^<]+)<\/id>/i)[1];
 const appVersion = infoXml.match(/<version>([^<]+)<\/version>/i)[1];
-
-// Nextcloud apps emit js/, css/ and img/ into the repo root, which is why
-// @nextcloud/vite-config sets outDir to '' — vite's warning about that layout
-// is unavoidable noise here, everything else still gets through.
-const logger = createLogger();
-const loggerWarn = logger.warn.bind(logger);
-logger.warn = (msg, options) => {
-  if (msg.includes("build.outDir must not be the same directory of root")) {
-    return;
-  }
-  loggerWarn(msg, options);
-};
 
 export default (env) => {
   const isDev = env.mode === "development";
@@ -45,7 +32,6 @@ export default (env) => {
       // (duplicate-object-key in fast-xml-parser via webdav) on every build.
       minify: false,
       config: {
-        customLogger: logger,
         define: {
           appName: JSON.stringify(appId),
           appVersion: JSON.stringify(appVersion),

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,6 +1,7 @@
 import { createAppConfig } from "@nextcloud/vite-config";
 import { readFileSync } from "fs";
 import { join, resolve } from "path";
+import { createLogger } from "vite";
 
 // Read app id/version from appinfo/info.xml so we can inject them as globals.
 // @nextcloud/vue expects top-level `appName` / `appVersion` identifiers; since Vite 7
@@ -10,28 +11,68 @@ const infoXml = readFileSync(resolve("appinfo", "info.xml"), "utf8");
 const appId = infoXml.match(/<id>([^<]+)<\/id>/i)[1];
 const appVersion = infoXml.match(/<version>([^<]+)<\/version>/i)[1];
 
-export default createAppConfig(
-  {
-    main: resolve(join("src", "main.js")),
-    dashboard: resolve(join("src", "dashboard.js")),
-    settings: resolve(join("src", "settings.js")),
-    personal: resolve(join("src", "personal.js")),
-    quickresponse: resolve(join("src", "quickresponse.js")),
-    selfcheckin: resolve(join("src", "selfcheckin.js")),
-  },
-  {
-    createEmptyCSSEntryPoints: true,
-    extractLicenseInformation: true,
-    thirdPartyLicense: false,
-    config: {
-      define: {
-        appName: JSON.stringify(appId),
-        appVersion: JSON.stringify(appVersion),
-      },
-      build: {
-        // Suppress chunk size warning - Nextcloud apps typically have large chunks
-        chunkSizeWarningLimit: 1500,
-      },
-    },
+// Nextcloud apps emit js/, css/ and img/ into the repo root, which is why
+// @nextcloud/vite-config sets outDir to '' — vite's warning about that layout
+// is unavoidable noise here, everything else still gets through.
+const logger = createLogger();
+const loggerWarn = logger.warn.bind(logger);
+logger.warn = (msg, options) => {
+  if (msg.includes("build.outDir must not be the same directory of root")) {
+    return;
   }
-);
+  loggerWarn(msg, options);
+};
+
+export default (env) => {
+  const isDev = env.mode === "development";
+
+  const config = createAppConfig(
+    {
+      main: resolve(join("src", "main.js")),
+      dashboard: resolve(join("src", "dashboard.js")),
+      settings: resolve(join("src", "settings.js")),
+      personal: resolve(join("src", "personal.js")),
+      quickresponse: resolve(join("src", "quickresponse.js")),
+      selfcheckin: resolve(join("src", "selfcheckin.js")),
+    },
+    {
+      createEmptyCSSEntryPoints: true,
+      extractLicenseInformation: true,
+      thirdPartyLicense: false,
+      // Skip the extra rollup-plugin-esbuild-minify pass: vite's own esbuild
+      // minifier (re-enabled below) produces the same output, while the
+      // plugin loudly warns about vendored code it cannot change
+      // (duplicate-object-key in fast-xml-parser via webdav) on every build.
+      minify: false,
+      config: {
+        customLogger: logger,
+        define: {
+          appName: JSON.stringify(appId),
+          appVersion: JSON.stringify(appVersion),
+        },
+        build: {
+          // `minify: false` above also disabled vite's internal minifier —
+          // bring it back for production builds.
+          minify: isDev ? false : "esbuild",
+          // Suppress chunk size warning - Nextcloud apps typically have large chunks
+          chunkSizeWarningLimit: 1500,
+          rollupOptions: {
+            onwarn(warning, warn) {
+              // Dependencies ship /*#__PURE__*/ annotations in positions
+              // Rollup cannot interpret (@vueuse/core) — not actionable here.
+              if (
+                warning.code === "INVALID_ANNOTATION" &&
+                warning.id?.includes("node_modules")
+              ) {
+                return;
+              }
+              warn(warning);
+            },
+          },
+        },
+      },
+    }
+  );
+
+  return typeof config === "function" ? config(env) : config;
+};


### PR DESCRIPTION
Closes #47

Sometimes a person announces their answer out of band — on the phone, in the hallway — and never responds themselves. Users with the new permission can now record (or clear) that answer for them straight from the response summary, exactly where the issue asked for it.

## Permission

Answering on behalf is guarded by its own admin-configured permission **"Can set responses for other users"** (`respond_for_others`) — deliberately **not** implied by manage or organizer rights:

- Closed when unconfigured: with no groups selected, nobody has it, so the upgrade grants nothing silently (same rationale as `create_appointments`).
- Guests are hard-blocked like the other management permissions.
- Exposed per user via `getPermissions().canRespondForOthers`; group selector in the admin settings.

## Server

- New endpoint `POST /api/appointments/{appointmentId}/respond/{targetUserId}`, guarded by the permission (check-in pattern).
- The target user must exist and be part of the appointment's audience; closed/cancelled inquiries are rejected (same rule as self-responses).
- The person's own comment survives a value change; `response_source` is stamped `admin`.
- `response = null` clears the answer and restores the "not yet responded" state, so reminders pick the person up again — also the undo path for a mistaken entry.
- **Audit trail (ref #58):** the audit log records the actor ("X answered yes **for** Y", source label "Manager"), and response-change notifications to other managers carry the on-behalf wording too.
- New `respondOnBehalf` capability in `getCapabilities()` so older mobile builds keep hiding the affordance (paired PR: luflow/attendance-flutter#53).

## UI placement

The rows in the response summary already carry up to two labelled buttons, so the new affordance is deliberately minimal:

- Each response row gets a compact **icon-only pencil** that opens a small popover with the three answers (plus "Clear answer" where one exists).
- The **"No response yet" chips** — the issue's main use case — get the same pencil next to the existing reminder bell.
- After saving, the detail view silently refetches (buckets, counts and non-responder lists shift across groups).

## Tests

- 206 PHPUnit tests green (service + permission coverage, incl. "manage rights must not bleed through").
- e2e spec `26-respond-on-behalf` (sequential-admin, since it grants/revokes the permission): set / comment preserved / clear / closed / unknown user / no-permission 403 / permissions endpoint / audit rows / capability, plus a UI round-trip via the pencil popover.
- Also enables the previously never-running `23-audit-history.spec.js` in CI.

## Notes

- No schema change needed — `response_source` already existed.
- A post-review refactor commit deduplicates the persistence core (`applyResponse()`) shared by self- and on-behalf responses.
- OpenAPI specs regenerated, ESLint clean, `npm run build` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018yxgfuCx7X2baKDfddVo76