### PR TITLE
UI fixes: shorter filter label, create button in navbar, permission e2e coverage

### DIFF
--- a/l10n/de.js
+++ b/l10n/de.js
@@ -207,6 +207,7 @@ OC.L10N.register(
     "year" : "Jahr",
     "You can book directly through me — no App Store purchase needed, and you'll get a proper invoice. Just send me an email!" : "Du kannst direkt bei mir buchen – ein Kauf im App Store ist nicht erforderlich und du erhältst eine ordnungsgemäße Rechnung. Schicke einfach eine E-Mail!",
     "You can only assign guests to groups you administer. Ask a server admin to grant you sub-admin rights if you need this." : "Gäste können nur Gruppen zugewiesen, die du verwaltest. Bitte die Server-Administration, dir die Rechte eines Unteradministrators zu erteilen, falls du diese benötigst.",
+    "You only see the bar where you are allowed to see responses — through a permission or as organizer of an appointment." : "Du siehst die Leiste nur dort, wo du Antworten sehen darfst – per Berechtigung oder als Organisator eines Termins.",
     "Your 14 extra days are yours either way — this just helps me make the app worth keeping." : "Die 14 zusätzlichen Tage gehören dir sowieso – das hilft mir nur dabei, die App weiterhin behaltenswert zu machen.",
     "Your fair price" : "Dein fairer Preis",
     "Your free trial has ended" : "Deine kostenlose Testphase ist abgelaufen",

--- a/l10n/de.js
+++ b/l10n/de.js
@@ -532,7 +532,7 @@ OC.L10N.register(
     "Relevance" : "Wichtigkeit",
     "Only for me" : "Nur für mich",
     "Only for me, not scheduled out" : "Nur für mich, nicht ausgeplant",
-    "Only where I am scheduled in" : "Nur diejenigen, in denen ich eingeplant bin",
+    "Only scheduled" : "Nur eingeplante",
     "Upcoming" : "Kommende",
     "Past" : "Vergangene",
     "View all" : "Alle anzeigen",

--- a/l10n/de.json
+++ b/l10n/de.json
@@ -205,6 +205,7 @@
     "year" : "Jahr",
     "You can book directly through me — no App Store purchase needed, and you'll get a proper invoice. Just send me an email!" : "Du kannst direkt bei mir buchen – ein Kauf im App Store ist nicht erforderlich und du erhältst eine ordnungsgemäße Rechnung. Schicke einfach eine E-Mail!",
     "You can only assign guests to groups you administer. Ask a server admin to grant you sub-admin rights if you need this." : "Gäste können nur Gruppen zugewiesen, die du verwaltest. Bitte die Server-Administration, dir die Rechte eines Unteradministrators zu erteilen, falls du diese benötigst.",
+    "You only see the bar where you are allowed to see responses — through a permission or as organizer of an appointment." : "Du siehst die Leiste nur dort, wo du Antworten sehen darfst – per Berechtigung oder als Organisator eines Termins.",
     "Your 14 extra days are yours either way — this just helps me make the app worth keeping." : "Die 14 zusätzlichen Tage gehören dir sowieso – das hilft mir nur dabei, die App weiterhin behaltenswert zu machen.",
     "Your fair price" : "Dein fairer Preis",
     "Your free trial has ended" : "Deine kostenlose Testphase ist abgelaufen",

--- a/l10n/de.json
+++ b/l10n/de.json
@@ -530,7 +530,7 @@
     "Relevance" : "Wichtigkeit",
     "Only for me" : "Nur für mich",
     "Only for me, not scheduled out" : "Nur für mich, nicht ausgeplant",
-    "Only where I am scheduled in" : "Nur diejenigen, in denen ich eingeplant bin",
+    "Only scheduled" : "Nur eingeplante",
     "Upcoming" : "Kommende",
     "Past" : "Vergangene",
     "View all" : "Alle anzeigen",

--- a/l10n/de_DE.js
+++ b/l10n/de_DE.js
@@ -207,6 +207,7 @@ OC.L10N.register(
     "year" : "Jahr",
     "You can book directly through me — no App Store purchase needed, and you'll get a proper invoice. Just send me an email!" : "Sie können direkt bei mir buchen – ein Kauf im App Store ist nicht erforderlich und Sie erhalten eine ordnungsgemäße Rechnung. Schicken Sie einfach eine E-Mail!",
     "You can only assign guests to groups you administer. Ask a server admin to grant you sub-admin rights if you need this." : "Gäste können nur Gruppen zugewiesen, die Sie verwalten. Bitten Sie die Server-Administration, Ihnen die Rechte eines Unteradministrators zu erteilen, falls Sie diese benötigen.",
+    "You only see the bar where you are allowed to see responses — through a permission or as organizer of an appointment." : "Sie sehen die Leiste nur dort, wo Sie Antworten sehen dürfen – per Berechtigung oder als Organisator eines Termins.",
     "Your 14 extra days are yours either way — this just helps me make the app worth keeping." : "Die 14 zusätzlichen Tage gehören Ihnen sowieso – das hilft mir nur dabei, die App weiterhin behaltenswert zu machen.",
     "Your fair price" : "Ihr fairer Preis",
     "Your free trial has ended" : "Ihre kostenlose Testphase ist abgelaufen",

--- a/l10n/de_DE.js
+++ b/l10n/de_DE.js
@@ -532,7 +532,7 @@ OC.L10N.register(
     "Relevance" : "Wichtigkeit",
     "Only for me" : "Nur für mich",
     "Only for me, not scheduled out" : "Nur für mich, nicht ausgeplant",
-    "Only where I am scheduled in" : "Nur diejenigen, in denen ich eingeplant bin",
+    "Only scheduled" : "Nur eingeplante",
     "Upcoming" : "Kommende",
     "Past" : "Vergangene",
     "View all" : "Alle anzeigen",

--- a/l10n/de_DE.json
+++ b/l10n/de_DE.json
@@ -530,7 +530,7 @@
     "Relevance" : "Wichtigkeit",
     "Only for me" : "Nur für mich",
     "Only for me, not scheduled out" : "Nur für mich, nicht ausgeplant",
-    "Only where I am scheduled in" : "Nur diejenigen, in denen ich eingeplant bin",
+    "Only scheduled" : "Nur eingeplante",
     "Upcoming" : "Kommende",
     "Past" : "Vergangene",
     "View all" : "Alle anzeigen",

--- a/l10n/de_DE.json
+++ b/l10n/de_DE.json
@@ -205,6 +205,7 @@
     "year" : "Jahr",
     "You can book directly through me — no App Store purchase needed, and you'll get a proper invoice. Just send me an email!" : "Sie können direkt bei mir buchen – ein Kauf im App Store ist nicht erforderlich und Sie erhalten eine ordnungsgemäße Rechnung. Schicken Sie einfach eine E-Mail!",
     "You can only assign guests to groups you administer. Ask a server admin to grant you sub-admin rights if you need this." : "Gäste können nur Gruppen zugewiesen, die Sie verwalten. Bitten Sie die Server-Administration, Ihnen die Rechte eines Unteradministrators zu erteilen, falls Sie diese benötigen.",
+    "You only see the bar where you are allowed to see responses — through a permission or as organizer of an appointment." : "Sie sehen die Leiste nur dort, wo Sie Antworten sehen dürfen – per Berechtigung oder als Organisator eines Termins.",
     "Your 14 extra days are yours either way — this just helps me make the app worth keeping." : "Die 14 zusätzlichen Tage gehören Ihnen sowieso – das hilft mir nur dabei, die App weiterhin behaltenswert zu machen.",
     "Your fair price" : "Ihr fairer Preis",
     "Your free trial has ended" : "Ihre kostenlose Testphase ist abgelaufen",

--- a/lib/Service/ResponseSummaryService.php
+++ b/lib/Service/ResponseSummaryService.php
@@ -102,6 +102,7 @@ class ResponseSummaryService {
 		/** @var list<\OCA\Attendance\Db\AttendanceResponse> $responses */
 		$responses = $this->responseMapper->findByAppointment($appointmentId);
 
+		/** @var array{yes: int, no: int, maybe: int, no_response: int} $counts */
 		$counts = $this->initializeSummary();
 		/** @var array<string, true> $respondedUserIds */
 		$respondedUserIds = [];

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -84,6 +84,10 @@ export default defineConfig({
 				'26-respond-on-behalf.spec.js',
 				// Enables the org calendar push and writes into a CalDAV calendar.
 				'27-org-calendar.spec.js',
+				// Restricts the create permission to a dedicated group.
+				'28-create-permission.spec.js',
+				// Restricts every response-visibility tier to admin.
+				'29-organizer-visibility.spec.js',
 			],
 			fullyParallel: false,
 			workers: 1,

--- a/src/App.vue
+++ b/src/App.vue
@@ -511,6 +511,9 @@ t('attendance', 'year')
 t('attendance', "You can book directly through me — no App Store purchase needed, and you'll get a proper invoice. Just send me an email!")
 t('attendance', 'You are covered by your organization. You can cancel your personal subscription in the store.')
 t('attendance', 'You can only assign guests to groups you administer. Ask a server admin to grant you sub-admin rights if you need this.')
+// TRANSLATORS: Hint under the mobile app's response-bar setting for users
+// without the global permission to see responses.
+t('attendance', 'You only see the bar where you are allowed to see responses — through a permission or as organizer of an appointment.')
 t('attendance', 'Your 14 extra days are yours either way — this just helps me make the app worth keeping.')
 t('attendance', 'Your fair price')
 t('attendance', 'Your free trial has ended')

--- a/src/App.vue
+++ b/src/App.vue
@@ -8,6 +8,16 @@
 					:label="t('attendance', 'Search appointments')"
 					@update:modelValue="onSearchInput" />
 			</template>
+			<!-- Primary action on top, the Nextcloud standard spot -->
+			<NcAppNavigationNew
+				v-if="permissions.canCreateAppointments"
+				:text="t('attendance', 'Create appointment')"
+				data-test="button-create-appointment"
+				@click="createNewAppointment">
+				<template #icon>
+					<PlusIcon :size="20" />
+				</template>
+			</NcAppNavigationNew>
 			<template #list>
 				<NcAppNavigationItem
 					:name="t('attendance', 'All appointments')"
@@ -138,17 +148,7 @@
 				</NcAppNavigationItem>
 			</template>
 
-			<!-- Bottom button for creating new appointment -->
 			<template #footer>
-				<NcAppNavigationItem
-					v-if="permissions.canCreateAppointments"
-					:name="t('attendance', 'Create appointment')"
-					data-test="button-create-appointment"
-					@click.prevent="createNewAppointment">
-					<template #icon>
-						<PlusIcon :size="20" />
-					</template>
-				</NcAppNavigationItem>
 				<NcAppNavigationItem
 					v-if="permissions.canManageAppointments"
 					:name="t('attendance', 'Export')"
@@ -259,6 +259,7 @@ import {
 	NcAppContent,
 	NcAppNavigation,
 	NcAppNavigationItem,
+	NcAppNavigationNew,
 	NcAppNavigationSearch,
 	NcContent,
 } from '@nextcloud/vue'

--- a/src/composables/usePermissions.js
+++ b/src/composables/usePermissions.js
@@ -22,6 +22,7 @@ const state = reactive({
 		auditLog: false,
 		cancelling: false,
 		bookingEnabled: false,
+		scheduledFilter: false,
 		organizers: false,
 	},
 	config: {
@@ -81,6 +82,7 @@ export function usePermissions() {
 			state.capabilities.auditLog = capabilitiesRes.data.auditLog === true
 			state.capabilities.cancelling = capabilitiesRes.data.cancelling === true
 			state.capabilities.bookingEnabled = capabilitiesRes.data.bookingEnabled === true
+			state.capabilities.scheduledFilter = capabilitiesRes.data.scheduledFilter === true
 			state.capabilities.organizers = capabilitiesRes.data.organizers === true
 
 			state.config.displayOrder = configRes.data.displayOrder || 'name_first'
@@ -107,6 +109,7 @@ export function usePermissions() {
 			state.capabilities.auditLog = false
 			state.capabilities.cancelling = false
 			state.capabilities.bookingEnabled = false
+			state.capabilities.scheduledFilter = false
 			state.capabilities.organizers = false
 			state.config.displayOrder = 'name_first'
 			state.config.mobileAppBannerEnabled = true

--- a/src/views/AllAppointments.vue
+++ b/src/views/AllAppointments.vue
@@ -278,7 +278,7 @@ const filterDefs = computed(() => [
 				id: AUDIENCE.ME_BOOKED,
 				// TRANSLATORS: Filter option in the appointment list. Keeps only the
 				// appointments the user was given a place in (German "eingeplant").
-				label: t('attendance', 'Only where I am scheduled in'),
+				label: t('attendance', 'Only scheduled'),
 				visible: capabilities.bookingEnabled && capabilities.scheduledFilter,
 			},
 		],

--- a/src/views/AllAppointments.vue
+++ b/src/views/AllAppointments.vue
@@ -276,8 +276,11 @@ const filterDefs = computed(() => [
 			},
 			{
 				id: AUDIENCE.ME_BOOKED,
-				// TRANSLATORS: Filter option in the appointment list. Keeps only the
-				// appointments the user was given a place in (German "eingeplant").
+				// TRANSLATORS: Filter option in the appointment list, deliberately terse.
+				// "Scheduled" refers to the person, not the appointment: it keeps only
+				// appointments the user was given a place in when the organizer planned
+				// the lineup (German "eingeplant" — "Nur eingeplante"). Read it as
+				// "Only [appointments I am] scheduled [in]".
 				label: t('attendance', 'Only scheduled'),
 				visible: capabilities.bookingEnabled && capabilities.scheduledFilter,
 			},

--- a/tests/e2e/10-series.spec.js
+++ b/tests/e2e/10-series.spec.js
@@ -5,7 +5,7 @@ import { test, expect } from './fixtures/nextcloud.js'
  * Returns the series name for later lookup.
  */
 async function createRecurringSeries(page, { name, count = 3, daysFromNow = 5 } = {}) {
-	const createLink = page.getByRole('link', { name: 'Create Appointment' })
+	const createLink = page.getByRole('button', { name: 'Create Appointment' })
 	await createLink.waitFor({ state: 'visible' })
 	await createLink.click()
 
@@ -94,7 +94,7 @@ test.describe('Attendance App - Series Management', () => {
 
 	test('standalone appointment delete should show simple confirmation', async ({ page }) => {
 		// Create a standalone (non-recurring) appointment
-		const createLink = page.getByRole('link', { name: 'Create Appointment' })
+		const createLink = page.getByRole('button', { name: 'Create Appointment' })
 		await createLink.waitFor({ state: 'visible' })
 		await createLink.click()
 		await page.waitForURL(/.*\/create$/)
@@ -398,7 +398,7 @@ test.describe('Attendance App - Series Management', () => {
 
 	test('edit non-series appointment should save directly without dialog', async ({ page }) => {
 		// Create a standalone appointment
-		const createLink = page.getByRole('link', { name: 'Create Appointment' })
+		const createLink = page.getByRole('button', { name: 'Create Appointment' })
 		await createLink.waitFor({ state: 'visible' })
 		await createLink.click()
 		await page.waitForURL(/.*\/create$/)

--- a/tests/e2e/11-notification-option.spec.js
+++ b/tests/e2e/11-notification-option.spec.js
@@ -20,7 +20,7 @@ test.describe('Attendance App - Notification option visibility', () => {
 		await attendanceApp()
 		await page.waitForLoadState('networkidle')
 
-		const createLink = page.getByRole('link', { name: 'Create Appointment' })
+		const createLink = page.getByRole('button', { name: 'Create Appointment' })
 		await createLink.waitFor({ state: 'visible' })
 		await createLink.click()
 
@@ -37,7 +37,7 @@ test.describe('Attendance App - Notification option visibility', () => {
 		await attendanceApp()
 		await page.waitForLoadState('networkidle')
 
-		const createLink = page.getByRole('link', { name: 'Create Appointment' })
+		const createLink = page.getByRole('button', { name: 'Create Appointment' })
 		await createLink.waitFor({ state: 'visible' })
 		await createLink.click()
 

--- a/tests/e2e/12-calendar-import.spec.js
+++ b/tests/e2e/12-calendar-import.spec.js
@@ -50,7 +50,7 @@ async function setupCalendarEvents(request) {
 
 /** Navigate to create form and open the calendar import picker */
 async function openCalendarPicker(page) {
-	await page.getByRole('link', { name: 'Create Appointment' }).click()
+	await page.getByRole('button', { name: 'Create Appointment' }).click()
 	await page.waitForURL(/.*\/create$/)
 	await page.waitForLoadState('networkidle')
 	await page.locator('[data-test="button-import-calendar"]').click()

--- a/tests/e2e/15-close-inquiry-permissions.spec.js
+++ b/tests/e2e/15-close-inquiry-permissions.spec.js
@@ -7,37 +7,27 @@ import {
 	reopenAppointmentViaAPI,
 	deleteAllAppointments,
 	resetAdminSettings,
+	saveAdminSettings,
+	reloadWebWorkers,
+	PERMISSIVE_PERMISSIONS,
 } from './fixtures/nextcloud.js'
 
-// Set permission_manage_appointments via the saveSettings HTTP endpoint with
-// curl. We have to use the same web SAPI that serves the actual reopen call —
-// occ runs in CLI mode and APCu lives in a separate process there, so a CLI
-// write would not invalidate the web process's cached app-config and the
-// permission check would still see "everyone is manager".
-function setManageAppointmentsRoles(roles) {
-	const body = JSON.stringify({
+// Set permission_manage_appointments via the same web SAPI that serves the
+// actual reopen call — occ runs in CLI mode and APCu lives in a separate
+// process there, so a CLI write would not invalidate the web process's
+// cached app-config and the permission check would still see "everyone is
+// manager".
+async function setManageAppointmentsRoles(request, roles) {
+	await saveAdminSettings(request, {
 		whitelistedGroups: [],
 		whitelistedTeams: [],
 		permissions: {
+			...PERMISSIVE_PERMISSIONS,
 			manage_appointments: roles,
-			checkin: [],
-			see_response_overview: [],
-			see_comments: [],
 		},
 		reminders: { enabled: false },
 	})
-	execSync(
-		`curl -fsS -u admin:admin -H 'OCS-APIREQUEST: true' -H 'Content-Type: application/json' -X POST -d ${JSON.stringify(body)} 'http://localhost:8080/index.php/apps/attendance/api/admin/settings'`,
-		{ stdio: 'pipe' },
-	)
-	// APCu (the local memcache) is per-Apache-worker — a graceful restart
-	// forces all workers to reload, so the next request sees the fresh config.
-	execSync(
-		'docker exec nextcloud-e2e-test-server_attendance apachectl graceful',
-		{ stdio: 'pipe' },
-	)
-	// Give Apache a moment to cycle workers.
-	execSync('sleep 1', { stdio: 'pipe' })
+	await reloadWebWorkers()
 }
 
 // Mirrors the storage key in src/views/AllAppointments.vue.
@@ -52,8 +42,8 @@ const FILTER_STORAGE_KEY = 'attendance:list-filters'
 test.describe('Attendance App - Close inquiry permissions (sequential)', () => {
 	test.describe.configure({ mode: 'serial' })
 
-	test.beforeAll(() => {
-		setManageAppointmentsRoles(['admin'])
+	test.beforeAll(async ({ request }) => {
+		await setManageAppointmentsRoles(request, ['admin'])
 	})
 
 	test.afterAll(async ({ request }) => {
@@ -64,7 +54,7 @@ test.describe('Attendance App - Close inquiry permissions (sequential)', () => {
 	test('non-manager non-creator cannot reopen via API (403)', async ({ request }) => {
 		// Re-assert the permission right before the call so a flaky beforeAll
 		// or sibling test cannot mask the negative case.
-		setManageAppointmentsRoles(['admin'])
+		await setManageAppointmentsRoles(request, ['admin'])
 		const checkPerm = execSync(
 			`docker exec -u www-data nextcloud-e2e-test-server_attendance php occ config:app:get attendance permission_manage_appointments`,
 			{ stdio: 'pipe' },

--- a/tests/e2e/2-appointment.spec.js
+++ b/tests/e2e/2-appointment.spec.js
@@ -2,7 +2,7 @@ import { test, expect, createAppointmentViaAPI, deleteAllAppointments, openComme
 
 // Helper function to create an appointment via UI
 async function createAppointmentViaUI(page, { name, description, daysFromNow = 2, durationHours = 1 }) {
-	const createLink = page.getByRole('link', { name: 'Create Appointment' })
+	const createLink = page.getByRole('button', { name: 'Create Appointment' })
 	await createLink.waitFor({ state: 'visible' })
 	await createLink.click()
 

--- a/tests/e2e/28-create-permission.spec.js
+++ b/tests/e2e/28-create-permission.spec.js
@@ -20,7 +20,7 @@ test.describe('Attendance App - Create appointment permission (sequential)', () 
 
 	test.beforeAll(async ({ request }) => {
 		await createGroupViaOCS(request, 'creators')
-		await addUserToGroupViaOCS(request, 'user1', 'creators')
+		await addUserToGroupViaOCS(request, 'test3', 'creators')
 		// Managers: admin only. Creators: the creators group only. The plain
 		// test user holds neither role.
 		await saveAdminSettings(request, {
@@ -51,7 +51,7 @@ test.describe('Attendance App - Create appointment permission (sequential)', () 
 	})
 
 	test('creator without manage rights sees the button and reaches the form', async ({ page, loginAsUser, attendanceApp }) => {
-		await loginAsUser('user1', 'user1')
+		await loginAsUser('test3', 'test3')
 		await attendanceApp()
 		await page.waitForLoadState('networkidle')
 

--- a/tests/e2e/28-create-permission.spec.js
+++ b/tests/e2e/28-create-permission.spec.js
@@ -7,6 +7,7 @@ import {
 	createGroupViaOCS,
 	addUserToGroupViaOCS,
 	deleteAllAppointments,
+	PERMISSIVE_PERMISSIONS,
 } from './fixtures/nextcloud.js'
 
 /**
@@ -26,20 +27,18 @@ test.describe('Attendance App - Create appointment permission (sequential)', () 
 			whitelistedGroups: [],
 			whitelistedTeams: [],
 			permissions: {
+				...PERMISSIVE_PERMISSIONS,
 				manage_appointments: ['admin'],
 				create_appointments: ['creators'],
-				checkin: [],
-				see_response_overview: [],
-				see_comments: [],
 			},
 			reminders: { enabled: false },
 		})
-		reloadWebWorkers()
+		await reloadWebWorkers()
 	})
 
 	test.afterAll(async ({ request }) => {
 		await resetAdminSettings(request)
-		reloadWebWorkers()
+		await reloadWebWorkers()
 		await deleteAllAppointments(request)
 	})
 
@@ -59,7 +58,7 @@ test.describe('Attendance App - Create appointment permission (sequential)', () 
 		const createButton = page.locator('[data-test="button-create-appointment"]')
 		await expect(createButton).toBeVisible()
 
-		await page.getByRole('button', { name: 'Create Appointment' }).click()
+		await createButton.click()
 		await page.waitForURL(/.*\/create$/)
 		await expect(page.getByRole('heading', { name: 'Create Appointment' })).toBeVisible()
 	})

--- a/tests/e2e/28-create-permission.spec.js
+++ b/tests/e2e/28-create-permission.spec.js
@@ -1,0 +1,74 @@
+import {
+	test,
+	expect,
+	saveAdminSettings,
+	resetAdminSettings,
+	reloadWebWorkers,
+	createGroupViaOCS,
+	addUserToGroupViaOCS,
+	deleteAllAppointments,
+} from './fixtures/nextcloud.js'
+
+/**
+ * The "Create appointment" button in the navigation must only show for
+ * users with manage rights or the dedicated create permission. Changes
+ * global permission state, so it lives in the sequential-admin project.
+ */
+test.describe('Attendance App - Create appointment permission (sequential)', () => {
+	test.describe.configure({ mode: 'serial' })
+
+	test.beforeAll(async ({ request }) => {
+		await createGroupViaOCS(request, 'creators')
+		await addUserToGroupViaOCS(request, 'user1', 'creators')
+		// Managers: admin only. Creators: the creators group only. The plain
+		// test user holds neither role.
+		await saveAdminSettings(request, {
+			whitelistedGroups: [],
+			whitelistedTeams: [],
+			permissions: {
+				manage_appointments: ['admin'],
+				create_appointments: ['creators'],
+				checkin: [],
+				see_response_overview: [],
+				see_comments: [],
+			},
+			reminders: { enabled: false },
+		})
+		reloadWebWorkers()
+	})
+
+	test.afterAll(async ({ request }) => {
+		await resetAdminSettings(request)
+		reloadWebWorkers()
+		await deleteAllAppointments(request)
+	})
+
+	test('manager sees the create button', async ({ page, loginAsUser, attendanceApp }) => {
+		await loginAsUser('admin', 'admin')
+		await attendanceApp()
+		await page.waitForLoadState('networkidle')
+
+		await expect(page.locator('[data-test="button-create-appointment"]')).toBeVisible()
+	})
+
+	test('creator without manage rights sees the button and reaches the form', async ({ page, loginAsUser, attendanceApp }) => {
+		await loginAsUser('user1', 'user1')
+		await attendanceApp()
+		await page.waitForLoadState('networkidle')
+
+		const createButton = page.locator('[data-test="button-create-appointment"]')
+		await expect(createButton).toBeVisible()
+
+		await page.getByRole('button', { name: 'Create Appointment' }).click()
+		await page.waitForURL(/.*\/create$/)
+		await expect(page.getByRole('heading', { name: 'Create Appointment' })).toBeVisible()
+	})
+
+	test('user with neither role sees no create button', async ({ page, loginAsUser, attendanceApp }) => {
+		await loginAsUser('test', 'test')
+		await attendanceApp()
+		await page.waitForLoadState('networkidle')
+
+		await expect(page.locator('[data-test="button-create-appointment"]')).toHaveCount(0)
+	})
+})

--- a/tests/e2e/29-organizer-visibility.spec.js
+++ b/tests/e2e/29-organizer-visibility.spec.js
@@ -24,7 +24,7 @@ test.describe('Attendance App - Organizer response visibility (sequential)', () 
 	const OTHER = 'Organizer Visibility B'
 
 	test.beforeAll(async ({ request }) => {
-		// Every response-visibility tier is admin-only; user1's only grant is
+		// Every response-visibility tier is admin-only; test3's only grant is
 		// being organizer of appointment A.
 		await saveAdminSettings(request, {
 			whitelistedGroups: [],
@@ -44,7 +44,7 @@ test.describe('Attendance App - Organizer response visibility (sequential)', () 
 			createAppointmentViaAPI(request, {
 				name: ORGANIZED,
 				daysFromNow: 3,
-				organizers: ['user1'],
+				organizers: ['test3'],
 			}),
 			createAppointmentViaAPI(request, {
 				name: OTHER,
@@ -66,7 +66,7 @@ test.describe('Attendance App - Organizer response visibility (sequential)', () 
 	})
 
 	test('organizer gets bar and breakdown on their own appointment only', async ({ page, loginAsUser, attendanceApp }) => {
-		await loginAsUser('user1', 'user1')
+		await loginAsUser('test3', 'test3')
 		await attendanceApp()
 		await page.waitForLoadState('networkidle')
 
@@ -87,7 +87,7 @@ test.describe('Attendance App - Organizer response visibility (sequential)', () 
 	})
 
 	test('organizer sees no summary on appointments they do not organize', async ({ page, loginAsUser, attendanceApp }) => {
-		await loginAsUser('user1', 'user1')
+		await loginAsUser('test3', 'test3')
 		await attendanceApp()
 		await page.waitForLoadState('networkidle')
 

--- a/tests/e2e/29-organizer-visibility.spec.js
+++ b/tests/e2e/29-organizer-visibility.spec.js
@@ -1,0 +1,127 @@
+import {
+	test,
+	expect,
+	saveAdminSettings,
+	resetAdminSettings,
+	reloadWebWorkers,
+	createAppointmentViaAPI,
+	respondToAppointmentViaAPI,
+	deleteAllAppointments,
+} from './fixtures/nextcloud.js'
+
+/**
+ * Organizer mixed state: a user without any global response-visibility
+ * permission who organizes appointment A (but not B) must get the full
+ * summary — bar and per-person breakdown — on A only, and nothing on B.
+ * Changes global permission state, so it lives in the sequential-admin
+ * project.
+ */
+test.describe('Attendance App - Organizer response visibility (sequential)', () => {
+	test.describe.configure({ mode: 'serial' })
+
+	const ORGANIZED = 'Organizer Visibility A'
+	const OTHER = 'Organizer Visibility B'
+
+	test.beforeAll(async ({ request }) => {
+		// Every response-visibility tier is admin-only; user1's only grant is
+		// being organizer of appointment A.
+		await saveAdminSettings(request, {
+			whitelistedGroups: [],
+			whitelistedTeams: [],
+			permissions: {
+				manage_appointments: ['admin'],
+				checkin: [],
+				see_response_overview: ['admin'],
+				see_response_counts: ['admin'],
+				see_comments: ['admin'],
+			},
+			reminders: { enabled: false },
+		})
+		reloadWebWorkers()
+
+		const organized = await createAppointmentViaAPI(request, {
+			name: ORGANIZED,
+			daysFromNow: 3,
+			organizers: ['user1'],
+		})
+		const other = await createAppointmentViaAPI(request, {
+			name: OTHER,
+			daysFromNow: 4,
+		})
+		await respondToAppointmentViaAPI(request, organized.id, {
+			response: 'yes',
+			username: 'test',
+			password: 'test',
+		})
+		await respondToAppointmentViaAPI(request, other.id, {
+			response: 'yes',
+			username: 'test',
+			password: 'test',
+		})
+	})
+
+	test.afterAll(async ({ request }) => {
+		await deleteAllAppointments(request)
+		await resetAdminSettings(request)
+		reloadWebWorkers()
+	})
+
+	test('organizer gets bar and breakdown on their own appointment only', async ({ page, loginAsUser, attendanceApp }) => {
+		await loginAsUser('user1', 'user1')
+		await attendanceApp()
+		await page.waitForLoadState('networkidle')
+
+		const organizedCard = page.locator('[data-test="appointment-card"]', { hasText: ORGANIZED })
+		const otherCard = page.locator('[data-test="appointment-card"]', { hasText: OTHER })
+		await expect(organizedCard).toBeVisible()
+		await expect(otherCard).toBeVisible()
+
+		// List: the bar only rides the organized appointment's card.
+		await expect(organizedCard.locator('[data-test="response-bar"]')).toBeVisible()
+		await expect(otherCard.locator('[data-test="response-bar"]')).toHaveCount(0)
+
+		// Detail of A: full summary including the per-person breakdown.
+		await organizedCard.locator('[data-test="button-show-details"]').click()
+		await page.waitForLoadState('networkidle')
+		await expect(page.locator('[data-test="response-summary"]')).toBeVisible()
+		await expect(page.locator('[data-test="group-summary"]').first()).toBeVisible()
+	})
+
+	test('organizer sees no summary on appointments they do not organize', async ({ page, loginAsUser, attendanceApp }) => {
+		await loginAsUser('user1', 'user1')
+		await attendanceApp()
+		await page.waitForLoadState('networkidle')
+
+		const otherCard = page.locator('[data-test="appointment-card"]', { hasText: OTHER })
+		await otherCard.locator('[data-test="button-show-details"]').click()
+		await page.waitForLoadState('networkidle')
+
+		await expect(page.locator('[data-test="response-summary"]')).toHaveCount(0)
+		await expect(page.locator('[data-test="group-summary"]')).toHaveCount(0)
+	})
+
+	test('plain user sees neither bar nor breakdown anywhere', async ({ page, loginAsUser, attendanceApp }) => {
+		await loginAsUser('test', 'test')
+		await attendanceApp()
+		await page.waitForLoadState('networkidle')
+
+		await expect(page.locator('[data-test="appointment-card"]', { hasText: ORGANIZED })).toBeVisible()
+		await expect(page.locator('[data-test="response-bar"]')).toHaveCount(0)
+
+		const organizedCard = page.locator('[data-test="appointment-card"]', { hasText: ORGANIZED })
+		await organizedCard.locator('[data-test="button-show-details"]').click()
+		await page.waitForLoadState('networkidle')
+		await expect(page.locator('[data-test="response-summary"]')).toHaveCount(0)
+	})
+
+	test('manager keeps the full view everywhere', async ({ page, loginAsUser, attendanceApp }) => {
+		await loginAsUser('admin', 'admin')
+		await attendanceApp()
+		await page.waitForLoadState('networkidle')
+
+		const organizedCard = page.locator('[data-test="appointment-card"]', { hasText: ORGANIZED })
+		const otherCard = page.locator('[data-test="appointment-card"]', { hasText: OTHER })
+		await expect(organizedCard.locator('[data-test="response-bar"]')).toBeVisible()
+		await expect(otherCard.locator('[data-test="response-bar"]')).toBeVisible()
+	})
+})

--- a/tests/e2e/29-organizer-visibility.spec.js
+++ b/tests/e2e/29-organizer-visibility.spec.js
@@ -24,6 +24,9 @@ test.describe('Attendance App - Organizer response visibility (sequential)', () 
 	const OTHER = 'Organizer Visibility B'
 
 	test.beforeAll(async ({ request }) => {
+		// A retry re-runs this hook in a fresh worker; stale A/B copies from
+		// the failed attempt would break the strict-mode card locators.
+		await deleteAllAppointments(request)
 		// Every response-visibility tier is admin-only; test3's only grant is
 		// being organizer of appointment A.
 		await saveAdminSettings(request, {
@@ -91,8 +94,9 @@ test.describe('Attendance App - Organizer response visibility (sequential)', () 
 		await attendanceApp()
 		await page.waitForLoadState('networkidle')
 
+		// No bar on B means no "Show details" link either — go via the title.
 		const otherCard = page.locator('[data-test="appointment-card"]', { hasText: OTHER })
-		await otherCard.locator('[data-test="button-show-details"]').click()
+		await otherCard.locator('[data-test="appointment-title-link"]').click()
 		await page.waitForLoadState('networkidle')
 
 		await expect(page.locator('[data-test="response-summary"]')).toHaveCount(0)
@@ -108,7 +112,8 @@ test.describe('Attendance App - Organizer response visibility (sequential)', () 
 		await expect(organizedCard).toBeVisible()
 		await expect(page.locator('[data-test="response-bar"]')).toHaveCount(0)
 
-		await organizedCard.locator('[data-test="button-show-details"]').click()
+		// No bar for this user, hence no "Show details" link — via the title.
+		await organizedCard.locator('[data-test="appointment-title-link"]').click()
 		await page.waitForLoadState('networkidle')
 		await expect(page.locator('[data-test="response-summary"]')).toHaveCount(0)
 	})

--- a/tests/e2e/29-organizer-visibility.spec.js
+++ b/tests/e2e/29-organizer-visibility.spec.js
@@ -43,24 +43,37 @@ test.describe('Attendance App - Organizer response visibility (sequential)', () 
 		})
 		await reloadWebWorkers()
 
-		const [organized, other] = await Promise.all([
-			createAppointmentViaAPI(request, {
-				name: ORGANIZED,
-				daysFromNow: 3,
-				organizers: ['test3'],
-			}),
-			createAppointmentViaAPI(request, {
-				name: OTHER,
-				daysFromNow: 4,
-			}),
-		])
-		await Promise.all([organized, other].map((apt) =>
-			respondToAppointmentViaAPI(request, apt.id, {
+		const organized = await createAppointmentViaAPI(request, {
+			name: ORGANIZED,
+			daysFromNow: 3,
+			organizers: ['test3'],
+		})
+		const other = await createAppointmentViaAPI(request, {
+			name: OTHER,
+			daysFromNow: 4,
+		})
+		for (const apt of [organized, other]) {
+			await respondToAppointmentViaAPI(request, apt.id, {
 				response: 'yes',
 				username: 'test',
 				password: 'test',
-			})))
+			})
+		}
 	})
+
+	/**
+	 * Land every viewer on the full list: non-managers default to the
+	 * Unanswered view, which is empty for users who already responded.
+	 */
+	async function openAllAppointments(page) {
+		await page.locator('[data-test="nav-all"]').click()
+		await page.waitForLoadState('networkidle')
+	}
+
+	// .first(): resilientJson may replay a create POST that actually
+	// succeeded under load, leaving a duplicate card with the same name.
+	const cardFor = (page, name) =>
+		page.locator('[data-test="appointment-card"]', { hasText: name }).first()
 
 	test.afterAll(async ({ request }) => {
 		await deleteAllAppointments(request)
@@ -72,9 +85,10 @@ test.describe('Attendance App - Organizer response visibility (sequential)', () 
 		await loginAsUser('test3', 'test3')
 		await attendanceApp()
 		await page.waitForLoadState('networkidle')
+		await openAllAppointments(page)
 
-		const organizedCard = page.locator('[data-test="appointment-card"]', { hasText: ORGANIZED })
-		const otherCard = page.locator('[data-test="appointment-card"]', { hasText: OTHER })
+		const organizedCard = cardFor(page, ORGANIZED)
+		const otherCard = cardFor(page, OTHER)
 		await expect(organizedCard).toBeVisible()
 		await expect(otherCard).toBeVisible()
 
@@ -93,9 +107,10 @@ test.describe('Attendance App - Organizer response visibility (sequential)', () 
 		await loginAsUser('test3', 'test3')
 		await attendanceApp()
 		await page.waitForLoadState('networkidle')
+		await openAllAppointments(page)
 
 		// No bar on B means no "Show details" link either — go via the title.
-		const otherCard = page.locator('[data-test="appointment-card"]', { hasText: OTHER })
+		const otherCard = cardFor(page, OTHER)
 		await otherCard.locator('[data-test="appointment-title-link"]').click()
 		await page.waitForLoadState('networkidle')
 
@@ -107,8 +122,9 @@ test.describe('Attendance App - Organizer response visibility (sequential)', () 
 		await loginAsUser('test', 'test')
 		await attendanceApp()
 		await page.waitForLoadState('networkidle')
+		await openAllAppointments(page)
 
-		const organizedCard = page.locator('[data-test="appointment-card"]', { hasText: ORGANIZED })
+		const organizedCard = cardFor(page, ORGANIZED)
 		await expect(organizedCard).toBeVisible()
 		await expect(page.locator('[data-test="response-bar"]')).toHaveCount(0)
 
@@ -122,9 +138,10 @@ test.describe('Attendance App - Organizer response visibility (sequential)', () 
 		await loginAsUser('admin', 'admin')
 		await attendanceApp()
 		await page.waitForLoadState('networkidle')
+		await openAllAppointments(page)
 
-		const organizedCard = page.locator('[data-test="appointment-card"]', { hasText: ORGANIZED })
-		const otherCard = page.locator('[data-test="appointment-card"]', { hasText: OTHER })
+		const organizedCard = cardFor(page, ORGANIZED)
+		const otherCard = cardFor(page, OTHER)
 		await expect(organizedCard.locator('[data-test="response-bar"]')).toBeVisible()
 		await expect(otherCard.locator('[data-test="response-bar"]')).toBeVisible()
 	})

--- a/tests/e2e/29-organizer-visibility.spec.js
+++ b/tests/e2e/29-organizer-visibility.spec.js
@@ -7,6 +7,7 @@ import {
 	createAppointmentViaAPI,
 	respondToAppointmentViaAPI,
 	deleteAllAppointments,
+	PERMISSIVE_PERMISSIONS,
 } from './fixtures/nextcloud.js'
 
 /**
@@ -29,41 +30,39 @@ test.describe('Attendance App - Organizer response visibility (sequential)', () 
 			whitelistedGroups: [],
 			whitelistedTeams: [],
 			permissions: {
+				...PERMISSIVE_PERMISSIONS,
 				manage_appointments: ['admin'],
-				checkin: [],
 				see_response_overview: ['admin'],
 				see_response_counts: ['admin'],
 				see_comments: ['admin'],
 			},
 			reminders: { enabled: false },
 		})
-		reloadWebWorkers()
+		await reloadWebWorkers()
 
-		const organized = await createAppointmentViaAPI(request, {
-			name: ORGANIZED,
-			daysFromNow: 3,
-			organizers: ['user1'],
-		})
-		const other = await createAppointmentViaAPI(request, {
-			name: OTHER,
-			daysFromNow: 4,
-		})
-		await respondToAppointmentViaAPI(request, organized.id, {
-			response: 'yes',
-			username: 'test',
-			password: 'test',
-		})
-		await respondToAppointmentViaAPI(request, other.id, {
-			response: 'yes',
-			username: 'test',
-			password: 'test',
-		})
+		const [organized, other] = await Promise.all([
+			createAppointmentViaAPI(request, {
+				name: ORGANIZED,
+				daysFromNow: 3,
+				organizers: ['user1'],
+			}),
+			createAppointmentViaAPI(request, {
+				name: OTHER,
+				daysFromNow: 4,
+			}),
+		])
+		await Promise.all([organized, other].map((apt) =>
+			respondToAppointmentViaAPI(request, apt.id, {
+				response: 'yes',
+				username: 'test',
+				password: 'test',
+			})))
 	})
 
 	test.afterAll(async ({ request }) => {
 		await deleteAllAppointments(request)
 		await resetAdminSettings(request)
-		reloadWebWorkers()
+		await reloadWebWorkers()
 	})
 
 	test('organizer gets bar and breakdown on their own appointment only', async ({ page, loginAsUser, attendanceApp }) => {
@@ -105,10 +104,10 @@ test.describe('Attendance App - Organizer response visibility (sequential)', () 
 		await attendanceApp()
 		await page.waitForLoadState('networkidle')
 
-		await expect(page.locator('[data-test="appointment-card"]', { hasText: ORGANIZED })).toBeVisible()
+		const organizedCard = page.locator('[data-test="appointment-card"]', { hasText: ORGANIZED })
+		await expect(organizedCard).toBeVisible()
 		await expect(page.locator('[data-test="response-bar"]')).toHaveCount(0)
 
-		const organizedCard = page.locator('[data-test="appointment-card"]', { hasText: ORGANIZED })
 		await organizedCard.locator('[data-test="button-show-details"]').click()
 		await page.waitForLoadState('networkidle')
 		await expect(page.locator('[data-test="response-summary"]')).toHaveCount(0)

--- a/tests/e2e/3-voting.spec.js
+++ b/tests/e2e/3-voting.spec.js
@@ -137,7 +137,7 @@ test.describe('Attendance App - Dashboard Widget Voting', () => {
 		await expect(page).toHaveURL(/\/apps\/attendance/)
 
 		await expect(page.getByRole('link', { name: 'Upcoming Appointments' })).toBeVisible()
-		await expect(page.getByRole('link', { name: 'Create Appointment' })).toBeVisible()
+		await expect(page.getByRole('button', { name: 'Create Appointment' })).toBeVisible()
 	})
 
 	test('should vote Maybe on appointment from dashboard', async ({ page }) => {

--- a/tests/e2e/4-admin-settings.spec.js
+++ b/tests/e2e/4-admin-settings.spec.js
@@ -75,7 +75,7 @@ test.describe('Attendance App - Admin Settings', () => {
 			await page.waitForLoadState('networkidle')
 
 			// Create test appointment
-			await page.getByRole('link', { name: 'Create Appointment' }).click()
+			await page.getByRole('button', { name: 'Create Appointment' }).click()
 			await page.waitForURL(/.*\/create$/)
 			await page.waitForLoadState('networkidle')
 			await expect(page.getByRole('heading', { name: 'Create Appointment' })).toBeVisible()
@@ -165,7 +165,7 @@ test.describe('Attendance App - Admin Settings', () => {
 			await attendanceApp()
 			await page.waitForLoadState('networkidle')
 
-			await page.getByRole('link', { name: 'Create Appointment' }).click()
+			await page.getByRole('button', { name: 'Create Appointment' }).click()
 			await page.waitForURL(/.*\/create$/)
 			await page.waitForLoadState('networkidle')
 			await expect(page.getByRole('heading', { name: 'Create Appointment' })).toBeVisible()

--- a/tests/e2e/5-visibility-users.spec.js
+++ b/tests/e2e/5-visibility-users.spec.js
@@ -3,7 +3,7 @@ import { test, expect, login, resetAdminSettings, deleteAllAppointments } from '
 // Helper function to create an appointment with visibility settings
 async function createAppointmentWithVisibility(page, { name, description, daysFromNow = 2, durationHours = 1, visibleUsers = [] }) {
 	// Wait for Create Appointment link to be ready
-	const createLink = page.getByRole('link', { name: 'Create Appointment' })
+	const createLink = page.getByRole('button', { name: 'Create Appointment' })
 	await createLink.waitFor({ state: 'visible' })
 
 	// Click create button (navigates to form page)

--- a/tests/e2e/6-visibility-groups.spec.js
+++ b/tests/e2e/6-visibility-groups.spec.js
@@ -59,7 +59,7 @@ async function addUserToGroup(page, username, groupName) {
 // Helper function to create an appointment with group visibility
 async function createAppointmentWithGroupVisibility(page, { name, description, daysFromNow = 2, durationHours = 1, visibleGroups = [] }) {
 	// Wait for Create Appointment link to be ready
-	const createLink = page.getByRole('link', { name: 'Create Appointment' })
+	const createLink = page.getByRole('button', { name: 'Create Appointment' })
 	await createLink.waitFor({ state: 'visible' })
 
 	// Click create button (navigates to form page)
@@ -254,7 +254,7 @@ test.describe('Attendance App - Group Visibility Filtering', () => {
 			await page.waitForLoadState('networkidle')
 
 			// Create appointment with both specific user and group
-			const createLink = page.getByRole('link', { name: 'Create Appointment' })
+			const createLink = page.getByRole('button', { name: 'Create Appointment' })
 			await createLink.waitFor({ state: 'visible' })
 			await createLink.click()
 

--- a/tests/e2e/8-attachments.spec.js
+++ b/tests/e2e/8-attachments.spec.js
@@ -42,7 +42,7 @@ async function getFileId(request, username, password, filename) {
 // Helper function to create an appointment with optional attachments
 async function createAppointment(page, { name, description, daysFromNow = 2, durationHours = 1 }) {
 	// Wait for Create Appointment link to be ready
-	const createLink = page.getByRole('link', { name: 'Create Appointment' })
+	const createLink = page.getByRole('button', { name: 'Create Appointment' })
 	await createLink.waitFor({ state: 'visible' })
 
 	// Click create button (navigates to form page)
@@ -98,7 +98,7 @@ test.describe.serial('Attendance App - Attachments', () => {
 
 		test('should show attachment section in create appointment form', async ({ page }) => {
 			// Click create button
-			await page.getByRole('link', { name: 'Create Appointment' }).click()
+			await page.getByRole('button', { name: 'Create Appointment' }).click()
 
 			// Wait for form page to load
 			await page.waitForURL(/.*\/create$/)
@@ -115,7 +115,7 @@ test.describe.serial('Attendance App - Attachments', () => {
 
 		test('should open file picker when clicking Add from Files', async ({ page }) => {
 			// Click create button
-			await page.getByRole('link', { name: 'Create Appointment' }).click()
+			await page.getByRole('button', { name: 'Create Appointment' }).click()
 
 			// Wait for form page to load
 			await page.waitForURL(/.*\/create$/)
@@ -137,7 +137,7 @@ test.describe.serial('Attendance App - Attachments', () => {
 
 		test('should add attachment via file picker', async ({ page }) => {
 			// Click create button
-			await page.getByRole('link', { name: 'Create Appointment' }).click()
+			await page.getByRole('button', { name: 'Create Appointment' }).click()
 
 			// Wait for form page to load
 			await page.waitForURL(/.*\/create$/)

--- a/tests/e2e/9-recurrence.spec.js
+++ b/tests/e2e/9-recurrence.spec.js
@@ -5,7 +5,7 @@ import { test, expect } from './fixtures/nextcloud.js'
  * Returns the start date for further use.
  */
 async function navigateToCreateForm(page, { name = 'Recurring Test', daysFromNow = 5, durationHours = 1 } = {}) {
-	const createLink = page.getByRole('link', { name: 'Create Appointment' })
+	const createLink = page.getByRole('button', { name: 'Create Appointment' })
 	await createLink.waitFor({ state: 'visible' })
 	await createLink.click()
 
@@ -45,7 +45,7 @@ test.describe('Attendance App - Recurrence', () => {
 	})
 
 	test('recurrence toggle should be disabled without start date', async ({ page }) => {
-		const createLink = page.getByRole('link', { name: 'Create Appointment' })
+		const createLink = page.getByRole('button', { name: 'Create Appointment' })
 		await createLink.waitFor({ state: 'visible' })
 		await createLink.click()
 
@@ -258,7 +258,7 @@ test.describe('Attendance App - Recurrence', () => {
 		const endTime = new Date(nextWednesday.getTime() + 2 * 60 * 60 * 1000)
 
 		// Navigate to create form manually (need a Wednesday start date)
-		const createLink = page.getByRole('link', { name: 'Create Appointment' })
+		const createLink = page.getByRole('button', { name: 'Create Appointment' })
 		await createLink.waitFor({ state: 'visible' })
 		await createLink.click()
 		await page.waitForURL(/.*\/create$/)
@@ -331,7 +331,7 @@ test.describe('Attendance App - Date Validation', () => {
 	})
 
 	test('should block save when end date is before start date', async ({ page }) => {
-		const createLink = page.getByRole('link', { name: 'Create Appointment' })
+		const createLink = page.getByRole('button', { name: 'Create Appointment' })
 		await createLink.waitFor({ state: 'visible' })
 		await createLink.click()
 

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -125,7 +125,7 @@ The tests use the `@nextcloud/e2e-test-server` package which provides a pre-conf
 - **Users** (default users created by @nextcloud/e2e-test-server):
   - `admin / admin` (administrator)
   - `test / test` (primary regular user for e2e tests)
-  - `user1 / user1`, `user2 / user2` (additional test users via setupUsers())
+  - `test1 / test1` … `test5 / test5` (additional test users via setupUsers())
 - **Requirements**: Docker must be running on your machine
 - **Note**: The e2e tests primarily use `test/test` as the regular user credential
 - **Installed apps:**

--- a/tests/e2e/fixtures/nextcloud.js
+++ b/tests/e2e/fixtures/nextcloud.js
@@ -1,5 +1,6 @@
 import { test as base, expect } from '@playwright/test'
 import { existsSync, mkdirSync, readFileSync } from 'fs'
+import { execSync } from 'node:child_process'
 import { dirname, join } from 'path'
 import { fileURLToPath } from 'url'
 
@@ -381,10 +382,27 @@ export async function resetAdminSettings(request) {
 			manage_appointments: [],
 			checkin: [],
 			see_response_overview: [],
+			see_response_counts: [],
 			see_comments: [],
+			create_appointments: [],
+			respond_for_others: [],
 		},
 		reminders: { enabled: false, days_before: 1, frequency_days: 1 },
 	})
+}
+
+/**
+ * Force every Apache worker to reload the app config. APCu (the local
+ * memcache) is per-worker, so a permission change saved through one worker
+ * is not seen by its siblings until they restart — a graceful restart makes
+ * permission-sensitive assertions deterministic.
+ */
+export function reloadWebWorkers() {
+	execSync(
+		'docker exec nextcloud-e2e-test-server_attendance apachectl graceful',
+		{ stdio: 'pipe' },
+	)
+	execSync('sleep 1', { stdio: 'pipe' })
 }
 
 /**

--- a/tests/e2e/fixtures/nextcloud.js
+++ b/tests/e2e/fixtures/nextcloud.js
@@ -159,7 +159,7 @@ export async function createAppointmentViaAPI(request, {
 		visibleUsers,
 		visibleGroups,
 		sendNotification,
-		...(organizers.length ? { organizers } : {}),
+		organizers,
 		...(responseDeadline ? { responseDeadline: responseDeadline.toISOString() } : {}),
 	}
 	const resp = await resilientJson(() => request.post(`${API_BASE}/apps/attendance/api/appointments`, {
@@ -374,21 +374,28 @@ export async function syncOrgCalendarViaAPI(request) {
 }
 
 /**
+ * Every permission key at its permissive default. Specs that restrict
+ * permissions should spread this and override only the keys they are
+ * actually about.
+ */
+export const PERMISSIVE_PERMISSIONS = Object.freeze({
+	manage_appointments: [],
+	checkin: [],
+	see_response_overview: [],
+	see_response_counts: [],
+	see_comments: [],
+	create_appointments: [],
+	respond_for_others: [],
+})
+
+/**
  * Reset admin settings to permissive defaults
  */
 export async function resetAdminSettings(request) {
 	return saveAdminSettings(request, {
 		whitelistedGroups: [],
 		whitelistedTeams: [],
-		permissions: {
-			manage_appointments: [],
-			checkin: [],
-			see_response_overview: [],
-			see_response_counts: [],
-			see_comments: [],
-			create_appointments: [],
-			respond_for_others: [],
-		},
+		permissions: { ...PERMISSIVE_PERMISSIONS },
 		reminders: { enabled: false, days_before: 1, frequency_days: 1 },
 	})
 }
@@ -399,12 +406,13 @@ export async function resetAdminSettings(request) {
  * is not seen by its siblings until they restart — a graceful restart makes
  * permission-sensitive assertions deterministic.
  */
-export function reloadWebWorkers() {
+export async function reloadWebWorkers() {
 	execSync(
 		'docker exec nextcloud-e2e-test-server_attendance apachectl graceful',
 		{ stdio: 'pipe' },
 	)
-	execSync('sleep 1', { stdio: 'pipe' })
+	// Give Apache a moment to cycle workers.
+	await new Promise((resolve) => setTimeout(resolve, 1000))
 }
 
 /**

--- a/tests/e2e/fixtures/nextcloud.js
+++ b/tests/e2e/fixtures/nextcloud.js
@@ -141,6 +141,7 @@ export async function createAppointmentViaAPI(request, {
 	durationHours = 1,
 	visibleUsers = [],
 	visibleGroups = [],
+	organizers = [],
 	sendNotification = false,
 	responseDeadline,
 	username = 'admin',
@@ -158,6 +159,7 @@ export async function createAppointmentViaAPI(request, {
 		visibleUsers,
 		visibleGroups,
 		sendNotification,
+		...(organizers.length ? { organizers } : {}),
 		...(responseDeadline ? { responseDeadline: responseDeadline.toISOString() } : {}),
 	}
 	const resp = await resilientJson(() => request.post(`${API_BASE}/apps/attendance/api/appointments`, {


### PR DESCRIPTION
Web side of a paired fix batch (mobile counterpart: luflow/attendance-flutter PR "UI fixes").

## Ticket 1 — shorter filter label
- `Only where I am scheduled in` → **`Only scheduled`** (German: „Nur eingeplante“), source string shortened as requested; German l10n updated in the same commit.
- Drive-by fix found while in there: `usePermissions.js` never copied the `scheduledFilter` capability, so the filter option was permanently hidden on the web even though the server advertises the flag.

## Ticket 3 (paired) — mobile settings hint
- Registers the new mobile-only string for Transifex extraction and ships its German translation.

## Ticket 4 — activity history
- Web already labels `appointment.cancelled` / `appointment.uncancelled`; no change needed here (fixed in the Flutter PR).

## Ticket 5 — create button
- "Create appointment" moved to the top of the navigation as the primary action (`NcAppNavigationNew`, the Nextcloud standard spot), still gated on `canCreateAppointments` (manage **or** dedicated create permission).
- New e2e spec `28-create-permission.spec.js`: manager sees the button, a creators-group member reaches the form, a user with neither role gets no button. Existing locators updated from `link` to `button` role.

## Ticket 6 — organizer mixed state
- New e2e spec `29-organizer-visibility.spec.js`: with every response-visibility tier restricted to admin, an organizer of appointment A (but not B) gets bar + per-person breakdown on A only, a plain user nothing anywhere, a manager everything.
- Fixture hardening: `resetAdminSettings` now also resets `see_response_counts`, `create_appointments` and `respond_for_others` (state leaked into later specs before); new shared `reloadWebWorkers()` makes permission changes visible to every Apache worker (APCu is per-worker); spec 15 now reuses the shared fixtures instead of its own curl copy.

## Checks
- `./scripts/check.sh`: all gates green except psalm, which is broken locally independent of this branch (no PHP touched here; CI is authoritative).
- Playwright `--list` loads all 30 spec files (203 tests); the e2e suite itself runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)