### PR TITLE
Refactor permissions UI with explicit access modes

### DIFF
--- a/lib/Controller/AdminController.php
+++ b/lib/Controller/AdminController.php
@@ -182,13 +182,16 @@ class AdminController extends Controller {
 	/**
 	 * Save admin settings
 	 *
-	 * @param list<string> $whitelistedGroups Group IDs allowed to use the app
-	 * @param list<string> $whitelistedTeams Team IDs allowed to use the app
-	 * @param array<string, list<string>> $permissions Permission name to group IDs mapping
-	 * @param array{enabled?: bool, reminderDays?: int, reminderFrequency?: int, reminderTarget?: string} $reminders Reminder settings
-	 * @param array{enabled?: bool} $calendarSync Calendar sync settings
-	 * @param array{enabled?: bool, calendarUri?: string} $orgCalendar Organization calendar settings (target calendar for automatic event creation)
-	 * @param array{enabled?: bool, visibility?: string} $audit Audit log settings (master switch + read visibility)
+	 * All parameters are optional so the settings UI can auto-save partial
+	 * payloads; omitted settings stay untouched.
+	 *
+	 * @param ?list<string> $whitelistedGroups Group IDs allowed to use the app
+	 * @param ?list<string> $whitelistedTeams Team IDs allowed to use the app
+	 * @param ?array<string, array{mode: string, groups: list<string>}> $permissions Permission name to access mode (all|groups|nobody) and group IDs
+	 * @param ?array{enabled?: bool, reminderDays?: int, reminderFrequency?: int, reminderTarget?: string} $reminders Reminder settings
+	 * @param ?array{enabled?: bool} $calendarSync Calendar sync settings
+	 * @param ?array{enabled?: bool, calendarUri?: string} $orgCalendar Organization calendar settings (target calendar for automatic event creation)
+	 * @param ?array{enabled?: bool, visibility?: string} $audit Audit log settings (master switch + read visibility)
 	 * @param ?string $displayOrder Display order for appointments: chronological, name, or group
 	 * @param ?bool $pushEnabled Whether push notifications are enabled
 	 * @param ?bool $mobileAppBannerEnabled Whether the mobile app promotion banner is enabled
@@ -199,13 +202,13 @@ class AdminController extends Controller {
 	#[NoCSRFRequired]
 	#[OpenAPI(OpenAPI::SCOPE_ADMINISTRATION)]
 	public function saveSettings(
-		array $whitelistedGroups = [],
-		array $whitelistedTeams = [],
-		array $permissions = [],
-		array $reminders = [],
-		array $calendarSync = [],
-		array $orgCalendar = [],
-		array $audit = [],
+		?array $whitelistedGroups = null,
+		?array $whitelistedTeams = null,
+		?array $permissions = null,
+		?array $reminders = null,
+		?array $calendarSync = null,
+		?array $orgCalendar = null,
+		?array $audit = null,
 		?string $displayOrder = null,
 		?bool $pushEnabled = null,
 		?bool $mobileAppBannerEnabled = null,
@@ -224,11 +227,14 @@ class AdminController extends Controller {
 		}
 
 		try {
-			$this->configService->setWhitelistedGroups($whitelistedGroups);
-			$this->configService->setWhitelistedTeams($whitelistedTeams);
+			if ($whitelistedGroups !== null) {
+				$this->configService->setWhitelistedGroups($whitelistedGroups);
+			}
+			if ($whitelistedTeams !== null) {
+				$this->configService->setWhitelistedTeams($whitelistedTeams);
+			}
 
-			// Save permissions
-			if (isset($permissions) && is_array($permissions)) {
+			if ($permissions !== null) {
 				$this->permissionService->setAllPermissionSettings($permissions);
 			}
 
@@ -255,7 +261,9 @@ class AdminController extends Controller {
 			}
 
 			// Save organization calendar settings (backfills on enable/re-point)
-			$this->orgCalendarSyncService->applySettings($orgCalendar, $user->getUID());
+			if ($orgCalendar !== null) {
+				$this->orgCalendarSyncService->applySettings($orgCalendar, $user->getUID());
+			}
 
 			// Save audit log settings
 			if (isset($audit['enabled'])) {

--- a/lib/Migration/Version000018Date20260803120000.php
+++ b/lib/Migration/Version000018Date20260803120000.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\Attendance\Migration;
+
+use Closure;
+use OCA\Attendance\AppInfo\Application;
+use OCA\Attendance\Service\PermissionService;
+use OCP\DB\ISchemaWrapper;
+use OCP\IAppConfig;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * Make permission access modes explicit. Previously an empty group list
+ * meant "everyone" for most permissions but "nobody" for the additive ones
+ * (create_appointments, respond_for_others). Each permission now stores an
+ * explicit permission_<name>_mode (all|groups|nobody); this backfills the
+ * mode every install currently has, so effective access does not change.
+ */
+class Version000018Date20260803120000 extends SimpleMigrationStep {
+
+	public function __construct(
+		private IAppConfig $appConfig,
+		private PermissionService $permissionService,
+	) {
+	}
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		return null;
+	}
+
+	public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void {
+		// getModeForPermission() returns the stored mode when one exists, so
+		// re-writing it is a no-op and the backfill stays idempotent.
+		foreach (PermissionService::ALL_PERMISSIONS as $permission) {
+			$this->appConfig->setValueString(
+				Application::APP_ID,
+				'permission_' . $permission . '_mode',
+				$this->permissionService->getModeForPermission($permission),
+			);
+		}
+	}
+}

--- a/lib/ResponseDefinitions.php
+++ b/lib/ResponseDefinitions.php
@@ -140,7 +140,8 @@ namespace OCA\Attendance;
  * }
  * @psalm-type AttendanceGroupOption = array{id: string, displayName: string}
  * @psalm-type AttendanceTeamOption = array{id: string, displayName: string}
- * @psalm-type AttendancePermissionSettings = array<string, list<string>>
+ * @psalm-type AttendancePermissionSetting = array{mode: string, groups: list<string>}
+ * @psalm-type AttendancePermissionSettings = array<string, AttendancePermissionSetting>
  * @psalm-type AttendanceUserPermissions = array{
  *   canManageAppointments: bool,
  *   canCreateAppointments: bool,

--- a/lib/Service/ConfigService.php
+++ b/lib/Service/ConfigService.php
@@ -197,29 +197,6 @@ class ConfigService {
 	}
 
 	/**
-	 * Get a permission setting (list of group IDs that have the permission).
-	 *
-	 * @param string $permission The permission name
-	 * @return array<string> List of group IDs
-	 */
-	public function getPermissionRoles(string $permission): array {
-		$configKey = 'permission_' . $permission;
-		$rolesJson = $this->config->getAppValue(self::APP_ID, $configKey, '[]');
-		return json_decode($rolesJson, true) ?: [];
-	}
-
-	/**
-	 * Set a permission setting.
-	 *
-	 * @param string $permission The permission name
-	 * @param array<string> $roles List of group IDs
-	 */
-	public function setPermissionRoles(string $permission, array $roles): void {
-		$configKey = 'permission_' . $permission;
-		$this->config->setAppValue(self::APP_ID, $configKey, json_encode($roles));
-	}
-
-	/**
 	 * Check if calendar sync is enabled.
 	 * When enabled, changes to linked calendar events will automatically
 	 * update the corresponding attendance appointments.

--- a/lib/Service/PermissionService.php
+++ b/lib/Service/PermissionService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace OCA\Attendance\Service;
 
 use OCA\Attendance\Db\Appointment;
+use OCP\IAppConfig;
 use OCP\IConfig;
 use OCP\IGroupManager;
 use OCP\IUserManager;
@@ -12,12 +13,22 @@ use OCP\IUserSession;
 
 class PermissionService {
 	private IConfig $config;
+	private IAppConfig $appConfig;
 	private IGroupManager $groupManager;
 	private IUserSession $userSession;
 	private IUserManager $userManager;
 	private GuestService $guestService;
 	/** @var array<string, list<string>> per-request cache for getUsersWith() */
 	private array $usersWithCache = [];
+	/**
+	 * Per-request caches: hasPermission() runs per appointment/response in
+	 * list endpoints, so the JSON decode and mode lookup must not repeat.
+	 *
+	 * @var array<string, list<string>>
+	 */
+	private array $rolesCache = [];
+	/** @var array<string, string> */
+	private array $modeCache = [];
 
 	public const PERMISSION_MANAGE_APPOINTMENTS = 'manage_appointments';
 	public const PERMISSION_CHECKIN = 'checkin';
@@ -28,6 +39,23 @@ class PermissionService {
 	public const PERMISSION_CREATE_APPOINTMENTS = 'create_appointments';
 	public const PERMISSION_RESPOND_FOR_OTHERS = 'respond_for_others';
 
+	public const MODE_ALL = 'all';
+	public const MODE_GROUPS = 'groups';
+	public const MODE_NOBODY = 'nobody';
+
+	public const MODES = [self::MODE_ALL, self::MODE_GROUPS, self::MODE_NOBODY];
+
+	public const ALL_PERMISSIONS = [
+		self::PERMISSION_MANAGE_APPOINTMENTS,
+		self::PERMISSION_CHECKIN,
+		self::PERMISSION_SEE_RESPONSE_OVERVIEW,
+		self::PERMISSION_SEE_RESPONSE_COUNTS,
+		self::PERMISSION_SEE_COMMENTS,
+		self::PERMISSION_SELF_CHECKIN,
+		self::PERMISSION_CREATE_APPOINTMENTS,
+		self::PERMISSION_RESPOND_FOR_OTHERS,
+	];
+
 	private const GUEST_BLOCKED_PERMISSIONS = [
 		self::PERMISSION_MANAGE_APPOINTMENTS,
 		self::PERMISSION_CHECKIN,
@@ -36,24 +64,27 @@ class PermissionService {
 	];
 
 	/**
-	 * Permissions that grant NOBODY when no groups are configured. All other
-	 * permissions default to "everyone" on empty config. Additive permissions
-	 * (rights on top of manage_appointments) belong here — otherwise an
-	 * upgrade would silently grant them to all users.
+	 * Permissions that default to "nobody" while no mode is stored — the
+	 * additive ones, which must never open up on their own. Everything else
+	 * defaults to "all". This is the live default policy: it also decides the
+	 * starting mode of any permission added in a future release, and it is
+	 * what an empty group list meant before modes were explicit.
 	 */
-	private const CLOSED_WHEN_UNCONFIGURED = [
+	private const DEFAULT_NOBODY = [
 		self::PERMISSION_CREATE_APPOINTMENTS,
 		self::PERMISSION_RESPOND_FOR_OTHERS,
 	];
 
 	public function __construct(
 		IConfig $config,
+		IAppConfig $appConfig,
 		IGroupManager $groupManager,
 		IUserSession $userSession,
 		IUserManager $userManager,
 		GuestService $guestService,
 	) {
 		$this->config = $config;
+		$this->appConfig = $appConfig;
 		$this->groupManager = $groupManager;
 		$this->userSession = $userSession;
 		$this->userManager = $userManager;
@@ -62,21 +93,84 @@ class PermissionService {
 
 	/**
 	 * Get roles that have a specific permission
+	 *
+	 * @return list<string>
 	 */
 	public function getRolesForPermission(string $permission): array {
-		$configKey = 'permission_' . $permission;
-		$rolesJson = $this->config->getAppValue('attendance', $configKey, '[]');
-		$roles = json_decode($rolesJson, true) ?: [];
+		if (isset($this->rolesCache[$permission])) {
+			return $this->rolesCache[$permission];
+		}
 
-		return $roles;
+		$rolesJson = $this->config->getAppValue('attendance', 'permission_' . $permission, '[]');
+		$roles = json_decode($rolesJson, true);
+		if (!is_array($roles)) {
+			return $this->rolesCache[$permission] = [];
+		}
+
+		return $this->rolesCache[$permission] = array_values(array_filter($roles, 'is_string'));
 	}
 
 	/**
 	 * Set roles that have a specific permission
+	 *
+	 * @param list<string> $roles
 	 */
 	public function setRolesForPermission(string $permission, array $roles): void {
 		$configKey = 'permission_' . $permission;
-		$this->config->setAppValue('attendance', $configKey, json_encode($roles));
+		$this->config->setAppValue('attendance', $configKey, json_encode($roles, JSON_THROW_ON_ERROR));
+		$this->rolesCache[$permission] = $roles;
+		unset($this->usersWithCache[$permission]);
+	}
+
+	/**
+	 * Get the access mode for a permission. With no mode stored, derive it
+	 * from the group list and the default policy — the same semantics the
+	 * pre-mode storage had, and what a brand-new permission starts with.
+	 *
+	 * The mode keys are new and live on the typed IAppConfig API; the group
+	 * lists predate it and stay on IConfig so older app versions keep
+	 * reading them after a downgrade.
+	 */
+	public function getModeForPermission(string $permission): string {
+		if (isset($this->modeCache[$permission])) {
+			return $this->modeCache[$permission];
+		}
+
+		$mode = $this->appConfig->getValueString('attendance', 'permission_' . $permission . '_mode');
+		if (!in_array($mode, self::MODES, true)) {
+			$mode = $this->impliedModeFor($permission, $this->getRolesForPermission($permission));
+		}
+
+		return $this->modeCache[$permission] = $mode;
+	}
+
+	/**
+	 * The mode a bare group list implies: configured groups, otherwise the
+	 * default policy for the permission.
+	 *
+	 * @param list<string> $roles
+	 */
+	private function impliedModeFor(string $permission, array $roles): string {
+		if (!empty($roles)) {
+			return self::MODE_GROUPS;
+		}
+		return in_array($permission, self::DEFAULT_NOBODY, true)
+			? self::MODE_NOBODY
+			: self::MODE_ALL;
+	}
+
+	/**
+	 * Set mode and groups for a permission in one go.
+	 *
+	 * @param list<string> $groups
+	 */
+	public function setPermission(string $permission, string $mode, array $groups): void {
+		if (!in_array($mode, self::MODES, true)) {
+			throw new \InvalidArgumentException('Invalid permission mode: ' . $mode);
+		}
+		$this->appConfig->setValueString('attendance', 'permission_' . $permission . '_mode', $mode);
+		$this->modeCache[$permission] = $mode;
+		$this->setRolesForPermission($permission, $groups);
 	}
 
 	/**
@@ -91,10 +185,12 @@ class PermissionService {
 			return false;
 		}
 
-		$allowedRoles = $this->getRolesForPermission($permission);
-
-		if (empty($allowedRoles)) {
-			return !in_array($permission, self::CLOSED_WHEN_UNCONFIGURED, true);
+		$mode = $this->getModeForPermission($permission);
+		if ($mode === self::MODE_ALL) {
+			return true;
+		}
+		if ($mode === self::MODE_NOBODY) {
+			return false;
 		}
 
 		// Get user object and their groups
@@ -105,7 +201,7 @@ class PermissionService {
 
 		$userGroups = $this->groupManager->getUserGroupIds($user);
 
-		return !empty(array_intersect($allowedRoles, $userGroups));
+		return !empty(array_intersect($this->getRolesForPermission($permission), $userGroups));
 	}
 
 	/**
@@ -138,52 +234,49 @@ class PermissionService {
 	}
 
 	/**
-	 * Get all permission settings
+	 * Get all permission settings as explicit mode + groups pairs
+	 *
+	 * @return array<string, array{mode: string, groups: list<string>}>
 	 */
 	public function getAllPermissionSettings(): array {
-		return [
-			self::PERMISSION_MANAGE_APPOINTMENTS => $this->getRolesForPermission(self::PERMISSION_MANAGE_APPOINTMENTS),
-			self::PERMISSION_CHECKIN => $this->getRolesForPermission(self::PERMISSION_CHECKIN),
-			self::PERMISSION_SEE_RESPONSE_OVERVIEW => $this->getRolesForPermission(self::PERMISSION_SEE_RESPONSE_OVERVIEW),
-			self::PERMISSION_SEE_RESPONSE_COUNTS => $this->getRolesForPermission(self::PERMISSION_SEE_RESPONSE_COUNTS),
-			self::PERMISSION_SEE_COMMENTS => $this->getRolesForPermission(self::PERMISSION_SEE_COMMENTS),
-			self::PERMISSION_SELF_CHECKIN => $this->getRolesForPermission(self::PERMISSION_SELF_CHECKIN),
-			self::PERMISSION_CREATE_APPOINTMENTS => $this->getRolesForPermission(self::PERMISSION_CREATE_APPOINTMENTS),
-			self::PERMISSION_RESPOND_FOR_OTHERS => $this->getRolesForPermission(self::PERMISSION_RESPOND_FOR_OTHERS),
-		];
+		$settings = [];
+		foreach (self::ALL_PERMISSIONS as $permission) {
+			$settings[$permission] = [
+				'mode' => $this->getModeForPermission($permission),
+				'groups' => $this->getRolesForPermission($permission),
+			];
+		}
+		return $settings;
 	}
 
 	/**
-	 * Set all permission settings
+	 * Set all permission settings. Accepts the explicit shape
+	 * `{mode: string, groups: list<string>}` per permission, and — for
+	 * older clients — a bare group list, interpreted with the legacy
+	 * empty-list semantics.
+	 *
+	 * @param array<string, array{mode: string, groups?: list<string>}|list<string>> $permissions
 	 */
 	public function setAllPermissionSettings(array $permissions): void {
-		// Map of uppercase constant names to actual permission values
-		$permissionMap = [
-			'PERMISSION_MANAGE_APPOINTMENTS' => self::PERMISSION_MANAGE_APPOINTMENTS,
-			'PERMISSION_CHECKIN' => self::PERMISSION_CHECKIN,
-			'PERMISSION_SEE_RESPONSE_OVERVIEW' => self::PERMISSION_SEE_RESPONSE_OVERVIEW,
-			'PERMISSION_SEE_RESPONSE_COUNTS' => self::PERMISSION_SEE_RESPONSE_COUNTS,
-			'PERMISSION_SEE_COMMENTS' => self::PERMISSION_SEE_COMMENTS,
-			'PERMISSION_SELF_CHECKIN' => self::PERMISSION_SELF_CHECKIN,
-			'PERMISSION_CREATE_APPOINTMENTS' => self::PERMISSION_CREATE_APPOINTMENTS,
-			'PERMISSION_RESPOND_FOR_OTHERS' => self::PERMISSION_RESPOND_FOR_OTHERS,
-		];
+		foreach ($permissions as $permission => $value) {
+			// Older clients send uppercase constant names ("PERMISSION_CHECKIN")
+			$permissionValue = str_starts_with($permission, 'PERMISSION_')
+				? strtolower(substr($permission, strlen('PERMISSION_')))
+				: $permission;
 
-		foreach ($permissions as $permission => $roles) {
-			// Convert uppercase constant name to actual value if needed
-			$permissionValue = $permissionMap[$permission] ?? $permission;
+			if (!in_array($permissionValue, self::ALL_PERMISSIONS, true)) {
+				continue;
+			}
 
-			if (in_array($permissionValue, [
-				self::PERMISSION_MANAGE_APPOINTMENTS,
-				self::PERMISSION_CHECKIN,
-				self::PERMISSION_SEE_RESPONSE_OVERVIEW,
-				self::PERMISSION_SEE_RESPONSE_COUNTS,
-				self::PERMISSION_SEE_COMMENTS,
-				self::PERMISSION_SELF_CHECKIN,
-				self::PERMISSION_CREATE_APPOINTMENTS,
-				self::PERMISSION_RESPOND_FOR_OTHERS,
-			])) {
-				$this->setRolesForPermission($permissionValue, $roles);
+			if (isset($value['mode'])) {
+				$this->setPermission($permissionValue, $value['mode'], $value['groups'] ?? []);
+			} else {
+				$groups = array_values(array_filter($value, 'is_string'));
+				$this->setPermission(
+					$permissionValue,
+					$this->impliedModeFor($permissionValue, $groups),
+					$groups,
+				);
 			}
 		}
 	}
@@ -289,8 +382,7 @@ class PermissionService {
 	/**
 	 * Check if user can set or clear responses on behalf of other users.
 	 * Deliberately NOT granted to managers or organizers automatically —
-	 * only members of the explicitly configured groups get it, and with no
-	 * groups configured nobody does (CLOSED_WHEN_UNCONFIGURED).
+	 * only the configured mode/groups decide, defaulting to nobody.
 	 */
 	public function canRespondForOthers(string $userId): bool {
 		return $this->hasPermission($userId, self::PERMISSION_RESPOND_FOR_OTHERS);
@@ -304,13 +396,12 @@ class PermissionService {
 	}
 
 	/**
-	 * Get all user IDs that have the given permission. When no roles are
-	 * configured for a permission, every existing user is considered to have
-	 * it (matches hasPermission()'s "empty roles = allow all" semantics).
+	 * Get all user IDs that have the given permission, following the
+	 * permission's mode (all users, configured groups, or nobody).
 	 *
-	 * Cached per request — on a large instance the unconfigured-permission
-	 * branch walks every user via userManager->search(''), so the per-event
-	 * audit-notification listener must not pay that cost N times.
+	 * Cached per request — on a large instance the "all" mode walks every
+	 * user via userManager->search(''), so the per-event audit-notification
+	 * listener must not pay that cost N times.
 	 *
 	 * @return list<string>
 	 */
@@ -319,13 +410,17 @@ class PermissionService {
 			return $this->usersWithCache[$permission];
 		}
 
-		$allowedRoles = $this->getRolesForPermission($permission);
+		$mode = $this->getModeForPermission($permission);
+		if ($mode === self::MODE_NOBODY) {
+			return $this->usersWithCache[$permission] = [];
+		}
+
 		$guestBlocked = in_array($permission, self::GUEST_BLOCKED_PERMISSIONS, true);
 		$userIds = [];
 
-		$candidates = empty($allowedRoles)
+		$candidates = $mode === self::MODE_ALL
 			? $this->userManager->search('')
-			: $this->collectGroupMembers($allowedRoles);
+			: $this->collectGroupMembers($this->getRolesForPermission($permission));
 
 		foreach ($candidates as $user) {
 			$uid = $user->getUID();

--- a/openapi-administration.json
+++ b/openapi-administration.json
@@ -301,13 +301,28 @@
                     }
                 }
             },
+            "PermissionSetting": {
+                "type": "object",
+                "required": [
+                    "mode",
+                    "groups"
+                ],
+                "properties": {
+                    "mode": {
+                        "type": "string"
+                    },
+                    "groups": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                }
+            },
             "PermissionSettings": {
                 "type": "object",
                 "additionalProperties": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
+                    "$ref": "#/components/schemas/PermissionSetting"
                 }
             },
             "TeamOption": {
@@ -505,7 +520,7 @@
             "post": {
                 "operationId": "admin-save-settings",
                 "summary": "Save admin settings",
-                "description": "This endpoint requires admin access",
+                "description": "All parameters are optional so the settings UI can auto-save partial payloads; omitted settings stay untouched.\nThis endpoint requires admin access",
                 "tags": [
                     "admin"
                 ],
@@ -526,7 +541,8 @@
                                 "properties": {
                                     "whitelistedGroups": {
                                         "type": "array",
-                                        "default": [],
+                                        "nullable": true,
+                                        "default": null,
                                         "description": "Group IDs allowed to use the app",
                                         "items": {
                                             "type": "string"
@@ -534,7 +550,8 @@
                                     },
                                     "whitelistedTeams": {
                                         "type": "array",
-                                        "default": [],
+                                        "nullable": true,
+                                        "default": null,
                                         "description": "Team IDs allowed to use the app",
                                         "items": {
                                             "type": "string"
@@ -542,18 +559,32 @@
                                     },
                                     "permissions": {
                                         "type": "object",
-                                        "default": {},
-                                        "description": "Permission name to group IDs mapping",
+                                        "nullable": true,
+                                        "default": null,
+                                        "description": "Permission name to access mode (all|groups|nobody) and group IDs",
                                         "additionalProperties": {
-                                            "type": "array",
-                                            "items": {
-                                                "type": "string"
+                                            "type": "object",
+                                            "required": [
+                                                "mode",
+                                                "groups"
+                                            ],
+                                            "properties": {
+                                                "mode": {
+                                                    "type": "string"
+                                                },
+                                                "groups": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "string"
+                                                    }
+                                                }
                                             }
                                         }
                                     },
                                     "reminders": {
                                         "type": "object",
-                                        "default": {},
+                                        "nullable": true,
+                                        "default": null,
                                         "description": "Reminder settings",
                                         "properties": {
                                             "enabled": {
@@ -574,7 +605,8 @@
                                     },
                                     "calendarSync": {
                                         "type": "object",
-                                        "default": {},
+                                        "nullable": true,
+                                        "default": null,
                                         "description": "Calendar sync settings",
                                         "properties": {
                                             "enabled": {
@@ -584,7 +616,8 @@
                                     },
                                     "orgCalendar": {
                                         "type": "object",
-                                        "default": {},
+                                        "nullable": true,
+                                        "default": null,
                                         "description": "Organization calendar settings (target calendar for automatic event creation)",
                                         "properties": {
                                             "enabled": {
@@ -597,7 +630,8 @@
                                     },
                                     "audit": {
                                         "type": "object",
-                                        "default": {},
+                                        "nullable": true,
+                                        "default": null,
                                         "description": "Audit log settings (master switch + read visibility)",
                                         "properties": {
                                             "enabled": {

--- a/openapi-full.json
+++ b/openapi-full.json
@@ -897,13 +897,28 @@
                     }
                 }
             },
+            "PermissionSetting": {
+                "type": "object",
+                "required": [
+                    "mode",
+                    "groups"
+                ],
+                "properties": {
+                    "mode": {
+                        "type": "string"
+                    },
+                    "groups": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                }
+            },
             "PermissionSettings": {
                 "type": "object",
                 "additionalProperties": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
+                    "$ref": "#/components/schemas/PermissionSetting"
                 }
             },
             "PushConfig": {
@@ -6097,7 +6112,7 @@
             "post": {
                 "operationId": "admin-save-settings",
                 "summary": "Save admin settings",
-                "description": "This endpoint requires admin access",
+                "description": "All parameters are optional so the settings UI can auto-save partial payloads; omitted settings stay untouched.\nThis endpoint requires admin access",
                 "tags": [
                     "admin"
                 ],
@@ -6118,7 +6133,8 @@
                                 "properties": {
                                     "whitelistedGroups": {
                                         "type": "array",
-                                        "default": [],
+                                        "nullable": true,
+                                        "default": null,
                                         "description": "Group IDs allowed to use the app",
                                         "items": {
                                             "type": "string"
@@ -6126,7 +6142,8 @@
                                     },
                                     "whitelistedTeams": {
                                         "type": "array",
-                                        "default": [],
+                                        "nullable": true,
+                                        "default": null,
                                         "description": "Team IDs allowed to use the app",
                                         "items": {
                                             "type": "string"
@@ -6134,18 +6151,32 @@
                                     },
                                     "permissions": {
                                         "type": "object",
-                                        "default": {},
-                                        "description": "Permission name to group IDs mapping",
+                                        "nullable": true,
+                                        "default": null,
+                                        "description": "Permission name to access mode (all|groups|nobody) and group IDs",
                                         "additionalProperties": {
-                                            "type": "array",
-                                            "items": {
-                                                "type": "string"
+                                            "type": "object",
+                                            "required": [
+                                                "mode",
+                                                "groups"
+                                            ],
+                                            "properties": {
+                                                "mode": {
+                                                    "type": "string"
+                                                },
+                                                "groups": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "string"
+                                                    }
+                                                }
                                             }
                                         }
                                     },
                                     "reminders": {
                                         "type": "object",
-                                        "default": {},
+                                        "nullable": true,
+                                        "default": null,
                                         "description": "Reminder settings",
                                         "properties": {
                                             "enabled": {
@@ -6166,7 +6197,8 @@
                                     },
                                     "calendarSync": {
                                         "type": "object",
-                                        "default": {},
+                                        "nullable": true,
+                                        "default": null,
                                         "description": "Calendar sync settings",
                                         "properties": {
                                             "enabled": {
@@ -6176,7 +6208,8 @@
                                     },
                                     "orgCalendar": {
                                         "type": "object",
-                                        "default": {},
+                                        "nullable": true,
+                                        "default": null,
                                         "description": "Organization calendar settings (target calendar for automatic event creation)",
                                         "properties": {
                                             "enabled": {
@@ -6189,7 +6222,8 @@
                                     },
                                     "audit": {
                                         "type": "object",
-                                        "default": {},
+                                        "nullable": true,
+                                        "default": null,
                                         "description": "Audit log settings (master switch + read visibility)",
                                         "properties": {
                                             "enabled": {

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -107,11 +107,6 @@
       <code><![CDATA[(int)$reminders['reminderDays']]]></code>
       <code><![CDATA[(int)$reminders['reminderFrequency']]]></code>
     </RedundantCastGivenDocblockType>
-    <RedundantCondition>
-      <code><![CDATA[is_array($permissions)]]></code>
-      <code><![CDATA[isset($permissions)]]></code>
-      <code><![CDATA[isset($permissions) && is_array($permissions)]]></code>
-    </RedundantCondition>
     <RedundantConditionGivenDocblockType>
       <code><![CDATA[is_string($audit['visibility'])]]></code>
       <code><![CDATA[isset($audit['visibility']) && is_string($audit['visibility'])]]></code>
@@ -1095,6 +1090,18 @@
       <code><![CDATA[Version000017Date20260724120000]]></code>
     </UnusedClass>
   </file>
+  <file src="lib/Migration/Version000018Date20260803120000.php">
+    <ClassMustBeFinal>
+      <code><![CDATA[Version000018Date20260803120000]]></code>
+    </ClassMustBeFinal>
+    <MissingOverrideAttribute>
+      <code><![CDATA[public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {]]></code>
+      <code><![CDATA[public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void {]]></code>
+    </MissingOverrideAttribute>
+    <UnusedClass>
+      <code><![CDATA[Version000018Date20260803120000]]></code>
+    </UnusedClass>
+  </file>
   <file src="lib/Notification/Notifier.php">
     <ClassMustBeFinal>
       <code><![CDATA[Notifier]]></code>
@@ -1553,10 +1560,8 @@
       <code><![CDATA[getAppValue]]></code>
       <code><![CDATA[getAppValue]]></code>
       <code><![CDATA[getAppValue]]></code>
-      <code><![CDATA[getAppValue]]></code>
       <code><![CDATA[getUserValue]]></code>
       <code><![CDATA[getUserValue]]></code>
-      <code><![CDATA[setAppValue]]></code>
       <code><![CDATA[setAppValue]]></code>
       <code><![CDATA[setAppValue]]></code>
       <code><![CDATA[setAppValue]]></code>
@@ -1581,26 +1586,21 @@
     <MixedReturnStatement>
       <code><![CDATA[json_decode($groupsJson, true) ?: []]]></code>
       <code><![CDATA[json_decode($groupsJson, true) ?: []]]></code>
-      <code><![CDATA[json_decode($rolesJson, true) ?: []]]></code>
-      <code><![CDATA[json_decode($rolesJson, true) ?: []]]></code>
       <code><![CDATA[json_decode($teamsJson, true) ?: []]]></code>
       <code><![CDATA[json_decode($teamsJson, true) ?: []]]></code>
     </MixedReturnStatement>
     <PossiblyFalseArgument>
       <code><![CDATA[json_encode($filtered)]]></code>
       <code><![CDATA[json_encode($groups)]]></code>
-      <code><![CDATA[json_encode($roles)]]></code>
       <code><![CDATA[json_encode($teams)]]></code>
     </PossiblyFalseArgument>
     <PossiblyUnusedMethod>
       <code><![CDATA[__construct]]></code>
-      <code><![CDATA[getPermissionRoles]]></code>
       <code><![CDATA[getPushProxyServer]]></code>
       <code><![CDATA[getReminderSettings]]></code>
       <code><![CDATA[isGroupAllowed]]></code>
       <code><![CDATA[isMobileAppBannerEnabled]]></code>
       <code><![CDATA[isPushEnabled]]></code>
-      <code><![CDATA[setPermissionRoles]]></code>
       <code><![CDATA[setPushProxyServer]]></code>
       <code><![CDATA[setReminderSettings]]></code>
     </PossiblyUnusedMethod>
@@ -1892,9 +1892,6 @@
     </RedundantCastGivenDocblockType>
   </file>
   <file src="lib/Service/PermissionService.php">
-    <ArgumentTypeCoercion>
-      <code><![CDATA[$allowedRoles]]></code>
-    </ArgumentTypeCoercion>
     <ClassMustBeFinal>
       <code><![CDATA[PermissionService]]></code>
     </ClassMustBeFinal>
@@ -1903,23 +1900,6 @@
       <code><![CDATA[search]]></code>
       <code><![CDATA[setAppValue]]></code>
     </DeprecatedMethod>
-    <MixedArgument>
-      <code><![CDATA[$roles]]></code>
-    </MixedArgument>
-    <MixedArgumentTypeCoercion>
-      <code><![CDATA[$permissionValue]]></code>
-    </MixedArgumentTypeCoercion>
-    <MixedAssignment>
-      <code><![CDATA[$roles]]></code>
-      <code><![CDATA[$roles]]></code>
-    </MixedAssignment>
-    <MixedReturnStatement>
-      <code><![CDATA[$roles]]></code>
-      <code><![CDATA[$roles]]></code>
-    </MixedReturnStatement>
-    <PossiblyFalseArgument>
-      <code><![CDATA[json_encode($roles)]]></code>
-    </PossiblyFalseArgument>
     <PossiblyUnusedMethod>
       <code><![CDATA[__construct]]></code>
       <code><![CDATA[canRespondForOthers]]></code>

--- a/src/components/admin/PermissionRow.vue
+++ b/src/components/admin/PermissionRow.vue
@@ -1,0 +1,144 @@
+<template>
+	<div class="permission-row" :data-test="dataTest">
+		<h5 class="permission-row__title">
+			{{ title }}
+		</h5>
+		<p class="permission-row__hint">
+			{{ hint }}
+		</p>
+		<div class="permission-row__modes">
+			<NcCheckboxRadioSwitch v-for="mode in MODES"
+				:key="mode.value"
+				:modelValue="modelValue.mode"
+				:value="mode.value"
+				:name="`${dataTest}-mode`"
+				type="radio"
+				buttonVariant
+				buttonVariantGrouped="horizontal"
+				:data-test="`${dataTest}-mode-${mode.value}`"
+				@update:modelValue="setMode">
+				{{ mode.label }}
+			</NcCheckboxRadioSwitch>
+		</div>
+		<template v-if="modelValue.mode === 'groups'">
+			<GroupSelect
+				:modelValue="modelValue.groups"
+				:options="options"
+				:placeholder="t('attendance', 'Select groups …')"
+				:data-test="`${dataTest}-groups`"
+				@update:modelValue="setGroups" />
+			<p v-if="modelValue.groups.length === 0" class="permission-row__note permission-row__note--warning">
+				{{ t('attendance', 'No groups selected yet — currently nobody is granted this.') }}
+			</p>
+		</template>
+		<p v-if="warningWhenAll && modelValue.mode === 'all'" class="permission-row__note permission-row__note--warning">
+			<AlertIcon :size="16" />
+			{{ warningWhenAll }}
+		</p>
+		<p v-if="implication" class="permission-row__note">
+			<InformationIcon :size="16" />
+			{{ implication }}
+		</p>
+	</div>
+</template>
+
+<script setup>
+import { NcCheckboxRadioSwitch } from '@nextcloud/vue'
+import AlertIcon from 'vue-material-design-icons/Alert.vue'
+import InformationIcon from 'vue-material-design-icons/InformationOutline.vue'
+import GroupSelect from '../common/GroupSelect.vue'
+
+const props = defineProps({
+	title: {
+		type: String,
+		required: true,
+	},
+	hint: {
+		type: String,
+		required: true,
+	},
+	/** { mode: 'all'|'groups'|'nobody', groups: Array<{id, displayName}> } */
+	modelValue: {
+		type: Object,
+		required: true,
+	},
+	options: {
+		type: Array,
+		default: () => [],
+	},
+	/** Rendered as an info note, e.g. inherited grants ("managers always …") */
+	implication: {
+		type: String,
+		default: '',
+	},
+	/** Warning note shown while the "all users" mode is selected */
+	warningWhenAll: {
+		type: String,
+		default: '',
+	},
+	dataTest: {
+		type: String,
+		required: true,
+	},
+})
+
+const emit = defineEmits(['update:modelValue'])
+
+const MODES = [
+	{ value: 'all', label: t('attendance', 'All users') },
+	{ value: 'groups', label: t('attendance', 'Specific groups') },
+	{ value: 'nobody', label: t('attendance', 'Nobody') },
+]
+
+function setMode(mode) {
+	emit('update:modelValue', { ...props.modelValue, mode })
+}
+
+function setGroups(groups) {
+	emit('update:modelValue', { ...props.modelValue, groups })
+}
+</script>
+
+<style scoped>
+.permission-row {
+	margin: 20px 0;
+	padding-bottom: 20px;
+	border-bottom: 1px solid var(--color-border);
+}
+
+.permission-row:last-child {
+	border-bottom: none;
+	padding-bottom: 0;
+}
+
+.permission-row__title {
+	margin: 0 0 4px 0;
+	font-size: 15px;
+	font-weight: 600;
+}
+
+.permission-row__hint {
+	margin: 0 0 12px 0;
+	color: var(--color-text-maxcontrast);
+	font-size: 14px;
+}
+
+.permission-row__modes {
+	display: flex;
+	flex-wrap: wrap;
+	margin-bottom: 12px;
+}
+
+.permission-row__note {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	margin-top: 8px;
+	color: var(--color-text-maxcontrast);
+	font-size: 13px;
+}
+
+.permission-row__note--warning {
+	color: var(--color-warning-text, var(--color-text-maxcontrast));
+}
+</style>

--- a/src/views/AdminSettings.vue
+++ b/src/views/AdminSettings.vue
@@ -1,23 +1,53 @@
 <template>
 	<div id="attendance-admin-settings" data-test="admin-settings">
 		<NcSettingsSection :name="t('attendance', 'Attendance')"
-			:description="t('attendance', 'Configure attendance management and reminders')" />
+			:description="t('attendance', 'Configure attendance management and reminders. Changes are saved automatically.')">
+			<nav class="anchor-nav" :aria-label="t('attendance', 'Settings sections')">
+				<a v-for="section in navSections"
+					:key="section.id"
+					:href="`#${section.id}`"
+					class="anchor-nav__link"
+					@click.prevent="scrollToSection(section.id)">
+					{{ section.label }}
+				</a>
+			</nav>
+		</NcSettingsSection>
 
 		<div v-if="loadingData" class="loading-section">
 			<NcLoadingIcon :size="32" />
-			<p>{{ t('attendance', 'Loading settings\u00A0…') }}</p>
+			<p>{{ t('attendance', 'Loading settings …') }}</p>
 		</div>
 
 		<template v-else>
+			<NcSettingsSection id="permissions"
+				:name="t('attendance', 'Permissions')"
+				:description="t('attendance', 'Control who can do what. Every permission is either open to all users, limited to specific groups, or granted to nobody.')">
+				<div v-for="group in permissionGroups" :key="group.key" class="permission-group">
+					<h4 class="permission-group__title">
+						{{ group.label }}
+					</h4>
+					<PermissionRow v-for="row in group.rows"
+						:key="row.name"
+						:modelValue="permissions[row.name]"
+						:title="row.title"
+						:hint="row.hint"
+						:implication="row.implication"
+						:warningWhenAll="row.warningWhenAll"
+						:options="availableGroups"
+						:dataTest="`permission-${row.name}`"
+						@update:modelValue="onPermissionChange(row.name, $event)" />
+				</div>
+			</NcSettingsSection>
+
 			<!-- TRANSLATORS: Admin settings section title. The "Response summary" is the main feature of this app - it shows attendance statistics on the appointment detail page, counting users by their Nextcloud group membership. Groups selected here will have their own sections in the summary; users not in these groups appear under "Others". -->
-			<NcSettingsSection :name="t('attendance', 'Response summary groups')"
+			<NcSettingsSection id="response-summary"
+				:name="t('attendance', 'Response summary groups')"
 				:description="t('attendance', 'Select which groups to include in response summaries. Users outside these groups will appear under Others. Leave empty to include all groups.')"
 				data-test="section-tracking-groups">
 				<GroupSelect
 					v-model="selectedGroups"
 					:options="availableGroups"
-					:placeholder="t('attendance', 'Select groups\u00A0…')"
-					:disabled="loading"
+					:placeholder="t('attendance', 'Select groups …')"
 					data-test="select-whitelisted-groups" />
 				<p class="hint-text">
 					{{ n('attendance', '%n group selected', '%n groups selected', selectedGroups.length, { n: selectedGroups.length }) }}
@@ -32,9 +62,8 @@
 				<NcSelect
 					v-model="selectedTeams"
 					:options="teamSearchResults"
-					:placeholder="t('attendance', 'Search and select teams\u00A0…')"
+					:placeholder="t('attendance', 'Search and select teams …')"
 					:multiple="true"
-					:disabled="loading"
 					:loading="isSearchingTeams"
 					:filterable="false"
 					label="label"
@@ -59,196 +88,65 @@
 				</p>
 			</NcSettingsSection>
 
-			<NcSettingsSection :name="t('attendance', 'Permissions')"
-				:description="t('attendance', 'Configure which groups can perform specific actions. Users must belong to at least one of the selected groups to access the feature. If no group is selected, all users have access to the feature.')">
-				<div class="subsection">
-					<h4>{{ t('attendance', 'Manage appointments') }}</h4>
-					<p class="subsection-hint">
-						{{ t('attendance', 'Groups that can create, update, and delete appointments') }}
-					</p>
-					<GroupSelect
-						v-model="selectedManageAppointmentsRoles"
-						:options="availableGroups"
-						:placeholder="t('attendance', 'Select groups\u00A0…')"
-						:disabled="loading"
-						data-test="select-manage-appointments-roles" />
-					<p class="hint-text">
-						{{ n('attendance', '%n group selected', '%n groups selected', selectedManageAppointmentsRoles.length, { n: selectedManageAppointmentsRoles.length }) }}
-					</p>
+			<NcSettingsSection id="self-checkin"
+				:name="t('attendance', 'Self-check-in')"
+				:description="t('attendance', 'Attendees check themselves in via QR code or NFC tag. One code works for all appointments — the app matches by time.')">
+				<!-- Wrapper div: scoped attrs don't reach the NcInputField root,
+				     so the spacing lives on an own template element. -->
+				<div class="self-checkin-window-field">
+					<NcInputField
+						v-model.number="selfCheckinWindowMinutes"
+						type="number"
+						:label="t('attendance', 'Check-in window (minutes before start)')"
+						:helperText="t('attendance', 'How many minutes before an appointment starts attendees can check in. The window always closes when the appointment ends.')"
+						data-test="input-self-checkin-window"
+						:inputProps="{ min: 0, max: 1440 }" />
 				</div>
 
-				<div class="subsection">
-					<h4>{{ t('attendance', 'Create own appointments') }}</h4>
+				<div class="self-checkin-qr">
+					<h6>{{ t('attendance', 'QR code') }}</h6>
 					<p class="subsection-hint">
-						{{ t('attendance', 'Groups that can create appointments and manage them as organizers, in addition to the groups above. If no group is selected, only the groups above can create appointments.') }}
+						{{ t('attendance', 'Print this QR code and put it up at the entrance.') }}
 					</p>
-					<GroupSelect
-						v-model="selectedCreateAppointmentsRoles"
-						:options="availableGroups"
-						:placeholder="t('attendance', 'Select groups …')"
-						:disabled="loading"
-						data-test="select-create-appointments-roles" />
-					<p class="hint-text">
-						{{ n('attendance', '%n group selected', '%n groups selected', selectedCreateAppointmentsRoles.length, { n: selectedCreateAppointmentsRoles.length }) }}
-					</p>
-				</div>
-
-				<div class="subsection">
-					<h4>{{ t('attendance', 'Check-in access') }}</h4>
-					<p class="subsection-hint">
-						{{ t('attendance', 'Groups that can access the check-in interface and execute check-ins') }}
-					</p>
-					<GroupSelect
-						v-model="selectedCheckinRoles"
-						:options="availableGroups"
-						:placeholder="t('attendance', 'Select groups\u00A0…')"
-						:disabled="loading"
-						data-test="select-checkin-roles" />
-					<p class="hint-text">
-						{{ n('attendance', '%n group selected', '%n groups selected', selectedCheckinRoles.length, { n: selectedCheckinRoles.length }) }}
-					</p>
-				</div>
-
-				<div class="subsection">
-					<h4>{{ t('attendance', 'See response & check-in summary') }}</h4>
-					<p class="subsection-hint">
-						{{ t('attendance', 'Groups that can see the response summary and check-in summary') }}
-					</p>
-					<GroupSelect
-						v-model="selectedSeeResponseOverviewRoles"
-						:options="availableGroups"
-						:placeholder="t('attendance', 'Select groups\u00A0…')"
-						:disabled="loading"
-						data-test="select-see-response-overview-roles" />
-					<p class="hint-text">
-						{{ n('attendance', '%n group selected', '%n groups selected', selectedSeeResponseOverviewRoles.length, { n: selectedSeeResponseOverviewRoles.length }) }}
-					</p>
-				</div>
-
-				<div class="subsection">
-					<h4>{{ t('attendance', 'See response counts') }}</h4>
-					<p class="subsection-hint">
-						{{ t('attendance', 'Groups that can see how many people answered yes, no or maybe — without any names. If no group is selected, everyone can see the counts. Groups with the full summary above always see the counts.') }}
-					</p>
-					<GroupSelect
-						v-model="selectedSeeResponseCountsRoles"
-						:options="availableGroups"
-						:placeholder="t('attendance', 'Select groups …')"
-						:disabled="loading"
-						data-test="select-see-response-counts-roles" />
-					<p class="hint-text">
-						{{ n('attendance', '%n group selected', '%n groups selected', selectedSeeResponseCountsRoles.length, { n: selectedSeeResponseCountsRoles.length }) }}
-					</p>
-				</div>
-
-				<div class="subsection">
-					<h4>{{ t('attendance', 'See comments') }}</h4>
-					<p class="subsection-hint">
-						{{ t('attendance', 'Groups that can see comments in the response overview') }}
-					</p>
-					<GroupSelect
-						v-model="selectedSeeCommentsRoles"
-						:options="availableGroups"
-						:placeholder="t('attendance', 'Select groups\u00A0…')"
-						:disabled="loading"
-						data-test="select-see-comments-roles" />
-					<p class="hint-text">
-						{{ n('attendance', '%n group selected', '%n groups selected', selectedSeeCommentsRoles.length, { n: selectedSeeCommentsRoles.length }) }}
-					</p>
-				</div>
-
-				<div class="subsection">
-					<h4>{{ t('attendance', 'Can set responses for other users') }}</h4>
-					<p class="subsection-hint">
-						{{ t('attendance', 'Groups that can record or clear an answer on behalf of another person in the response summary. Not granted automatically to managers — if no group is selected, nobody has this permission.') }}
-					</p>
-					<GroupSelect
-						v-model="selectedRespondForOthersRoles"
-						:options="availableGroups"
-						:placeholder="t('attendance', 'Select groups …')"
-						:disabled="loading"
-						data-test="select-respond-for-others-roles" />
-					<p class="hint-text">
-						{{ n('attendance', '%n group selected', '%n groups selected', selectedRespondForOthersRoles.length, { n: selectedRespondForOthersRoles.length }) }}
-					</p>
-				</div>
-
-				<div class="subsection">
-					<h4>{{ t('attendance', 'Self-check-in') }}</h4>
-					<p class="subsection-hint">
-						{{ t('attendance', 'Groups that can self-check-in via NFC sticker or deep link') }}
-					</p>
-					<GroupSelect
-						v-model="selectedSelfCheckinRoles"
-						:options="availableGroups"
-						:placeholder="t('attendance', 'Select groups …')"
-						:disabled="loading"
-						data-test="select-self-checkin-roles" />
-					<p class="hint-text">
-						{{ n('attendance', '%n group selected', '%n groups selected', selectedSelfCheckinRoles.length, { n: selectedSelfCheckinRoles.length }) }}
-					</p>
-
-					<!-- Wrapper div: scoped attrs don't reach the NcInputField root,
-					     so the spacing lives on an own template element. -->
-					<div class="self-checkin-window-field">
-						<NcInputField
-							v-model.number="selfCheckinWindowMinutes"
-							type="number"
-							:label="t('attendance', 'Check-in window (minutes before start)')"
-							:helperText="t('attendance', 'How many minutes before an appointment starts attendees can check in. The window always closes when the appointment ends.')"
-							data-test="input-self-checkin-window"
-							:inputProps="{ min: 0, max: 1440 }" />
+					<img v-if="qrDataUrl"
+						:src="qrDataUrl"
+						:alt="t('attendance', 'Self-check-in QR code')"
+						class="self-checkin-qr__image"
+						data-test="self-checkin-qr">
+					<div class="self-checkin-qr__actions">
+						<NcButton variant="secondary" @click="downloadQrCode">
+							<template #icon>
+								<Download :size="20" />
+							</template>
+							{{ t('attendance', 'Download QR code') }}
+						</NcButton>
 					</div>
 
-					<div class="self-checkin-qr">
-						<h5>{{ t('attendance', 'Set up self-check-in') }}</h5>
-						<p class="subsection-hint">
-							{{ t('attendance', 'One code works for all appointments — the app matches by time.') }}
-						</p>
-
-						<h6>{{ t('attendance', 'QR code') }}</h6>
-						<p class="subsection-hint">
-							{{ t('attendance', 'Print this QR code and put it up at the entrance.') }}
-						</p>
-						<img v-if="qrDataUrl"
-							:src="qrDataUrl"
-							:alt="t('attendance', 'Self-check-in QR code')"
-							class="self-checkin-qr__image"
-							data-test="self-checkin-qr">
-						<div class="self-checkin-qr__actions">
-							<NcButton variant="secondary" @click="downloadQrCode">
-								<template #icon>
-									<Download :size="20" />
-								</template>
-								{{ t('attendance', 'Download QR code') }}
-							</NcButton>
-						</div>
-
-						<h6>{{ t('attendance', 'NFC tag') }}</h6>
-						<p class="subsection-hint">
-							{{ t('attendance', 'Write the check-in URL to NFC tags and stick them at the entrance.') }}
-						</p>
-						<div class="self-checkin-qr__actions">
-							<NcButton variant="secondary" @click="copySelfCheckinUrl">
-								<template #icon>
-									<ContentCopy :size="20" />
-								</template>
-								{{ t('attendance', 'Copy URL for NFC tags') }}
-							</NcButton>
-						</div>
-						<p class="hint-text">
-							{{ t('attendance', 'NFC tag shopping advice: use NXP NTAG213 tags (or newer) of at least 25 mm, and on-metal tags for metal surfaces. Avoid MIFARE Classic tags — they do not work with iPhones.') }}
-						</p>
-						<p class="hint-text">
-							<a class="self-checkin-qr__app-link" href="#mobile-apps">
-								{{ t('attendance', 'You can also write NFC tags directly with the Attendance mobile app.') }}
-							</a>
-						</p>
+					<h6>{{ t('attendance', 'NFC tag') }}</h6>
+					<p class="subsection-hint">
+						{{ t('attendance', 'Write the check-in URL to NFC tags and stick them at the entrance.') }}
+					</p>
+					<div class="self-checkin-qr__actions">
+						<NcButton variant="secondary" @click="copySelfCheckinUrl">
+							<template #icon>
+								<ContentCopy :size="20" />
+							</template>
+							{{ t('attendance', 'Copy URL for NFC tags') }}
+						</NcButton>
 					</div>
+					<p class="hint-text">
+						{{ t('attendance', 'NFC tag shopping advice: use NXP NTAG213 tags (or newer) of at least 25 mm, and on-metal tags for metal surfaces. Avoid MIFARE Classic tags — they do not work with iPhones.') }}
+					</p>
+					<p class="hint-text">
+						<a class="self-checkin-qr__app-link" href="#mobile-apps" @click.prevent="scrollToSection('mobile-apps')">
+							{{ t('attendance', 'You can also write NFC tags directly with the Attendance mobile app.') }}
+						</a>
+					</p>
 				</div>
 			</NcSettingsSection>
 
-			<NcSettingsSection :name="t('attendance', 'Appointment reminders')"
+			<NcSettingsSection id="reminders"
+				:name="t('attendance', 'Appointment reminders')"
 				:description="reminderSectionDescription">
 				<NcNoteCard v-if="!notificationsAppEnabled" type="warning">
 					<p>{{ t('attendance', 'The Notifications app is not enabled. Please enable it to use appointment reminders.') }}</p>
@@ -368,223 +266,124 @@
 				</template>
 			</NcSettingsSection>
 
-			<div id="calendar-sync">
-				<NcSettingsSection
-					:name="t('attendance', 'Calendar sync')"
-					:description="t('attendance', 'Automatically update attendance appointments when their linked calendar events are modified.')">
+			<NcSettingsSection id="calendar-sync"
+				:name="t('attendance', 'Calendar sync')"
+				:description="t('attendance', 'Automatically update attendance appointments when their linked calendar events are modified.')">
+				<NcCheckboxRadioSwitch
+					v-model="calendarSyncEnabled"
+					type="switch"
+					data-test="switch-calendar-sync-enabled">
+					{{ t('attendance', 'Enable automatic calendar sync') }}
+				</NcCheckboxRadioSwitch>
+				<p class="hint-text">
+					{{ t('attendance', 'When enabled, changes to calendar events will automatically update linked attendance appointments (title, description, date/time).') }}
+				</p>
+			</NcSettingsSection>
+
+			<NcSettingsSection id="org-calendar"
+				:name="t('attendance', 'Organization calendar')"
+				:description="t('attendance', 'Automatically create and update events in a shared calendar for every appointment, so everyone can see them in the Calendar app.')">
+				<NcNoteCard v-if="!calendarAvailable" type="warning">
+					<p>{{ t('attendance', 'The Calendar app is not enabled. Enable it to use the organization calendar.') }}</p>
+				</NcNoteCard>
+
+				<template v-else>
 					<NcCheckboxRadioSwitch
-						v-model="calendarSyncEnabled"
+						v-model="orgCalendarEnabled"
 						type="switch"
-						data-test="switch-calendar-sync-enabled">
-						{{ t('attendance', 'Enable automatic calendar sync') }}
+						data-test="switch-org-calendar-enabled">
+						{{ t('attendance', 'Create calendar events for appointments') }}
 					</NcCheckboxRadioSwitch>
-					<p class="hint-text">
-						{{ t('attendance', 'When enabled, changes to calendar events will automatically update linked attendance appointments (title, description, date/time).') }}
-					</p>
-				</NcSettingsSection>
-			</div>
 
-			<div id="org-calendar">
-				<NcSettingsSection
-					:name="t('attendance', 'Organization calendar')"
-					:description="t('attendance', 'Automatically create and update events in a shared calendar for every appointment, so everyone can see them in the Calendar app.')">
-					<NcNoteCard v-if="!calendarAvailable" type="warning">
-						<p>{{ t('attendance', 'The Calendar app is not enabled. Enable it to use the organization calendar.') }}</p>
-					</NcNoteCard>
+					<div v-if="orgCalendarEnabled" class="subsection">
+						<h4>{{ t('attendance', 'Target calendar') }}</h4>
+						<NcNoteCard v-if="!orgCalendarOptions.length" type="warning">
+							<p>{{ t('attendance', 'No writable calendar found. Create one in the Calendar app first.') }}</p>
+						</NcNoteCard>
+						<NcSelect v-else
+							v-model="selectedOrgCalendar"
+							:options="orgCalendarOptions"
+							label="displayName"
+							:placeholder="t('attendance', 'Select a calendar …')"
+							data-test="select-org-calendar" />
+						<p class="hint-text">
+							{{ t('attendance', 'Share the selected calendar with your groups in the Calendar app so everyone can see the events.') }}
+						</p>
+						<p class="hint-text">
+							{{ t('attendance', 'When you select a calendar, all upcoming appointments are transferred to it. Past appointments are not transferred.') }}
+						</p>
+						<p class="hint-text">
+							{{ t('attendance', 'Events are created for all appointments, regardless of their visibility restrictions. Changing the target calendar does not move events that were already created.') }}
+						</p>
+						<p v-if="orgCalendarUserId" class="hint-text">
+							{{ t('attendance', 'Events are written using the account of {user}.', { user: orgCalendarUserId }) }}
+						</p>
+						<NcButton
+							v-if="selectedOrgCalendar"
+							variant="tertiary"
+							:disabled="syncingOrgCalendar"
+							data-test="button-sync-org-calendar"
+							@click="syncOrgCalendar">
+							<template #icon>
+								<NcLoadingIcon v-if="syncingOrgCalendar" :size="20" />
+								<CalendarSyncIcon v-else :size="20" />
+							</template>
+							{{ t('attendance', 'Sync upcoming appointments now') }}
+						</NcButton>
+						<p class="hint-text">
+							{{ t('attendance', 'Creates or updates the calendar events for all upcoming appointments. This also runs automatically when you enable the feature or change the calendar.') }}
+						</p>
+					</div>
+				</template>
+			</NcSettingsSection>
 
-					<template v-else>
-						<NcCheckboxRadioSwitch
-							v-model="orgCalendarEnabled"
-							type="switch"
-							:disabled="loading"
-							data-test="switch-org-calendar-enabled">
-							{{ t('attendance', 'Create calendar events for appointments') }}
+			<NcSettingsSection id="audit-log"
+				:name="t('attendance', 'Audit log')"
+				:description="t('attendance', 'Records who responded what and when, and surfaces a timeline on every appointment. Also drives the response-change push notifications that managers can opt into in their personal settings.')">
+				<NcCheckboxRadioSwitch v-model="auditLogEnabled"
+					type="switch"
+					data-test="switch-audit-log-enabled">
+					{{ t('attendance', 'Enable audit log') }}
+				</NcCheckboxRadioSwitch>
+				<p class="hint-text">
+					{{ t('attendance', 'Disabling stops new events from being recorded and silences response notifications. Existing entries are kept and reappear once you re-enable.') }}
+				</p>
+
+				<template v-if="auditLogEnabled">
+					<div class="subsection">
+						<h4>{{ t('attendance', 'Who can see the audit log?') }}</h4>
+						<NcCheckboxRadioSwitch v-model="auditLogVisibility"
+							value="managers"
+							name="audit_log_visibility"
+							type="radio"
+							data-test="radio-audit-visibility-managers">
+							{{ t('attendance', 'Only users who can manage appointments') }}
 						</NcCheckboxRadioSwitch>
-
-						<div v-if="orgCalendarEnabled" class="subsection">
-							<h4>{{ t('attendance', 'Target calendar') }}</h4>
-							<NcNoteCard v-if="!orgCalendarOptions.length" type="warning">
-								<p>{{ t('attendance', 'No writable calendar found. Create one in the Calendar app first.') }}</p>
-							</NcNoteCard>
-							<NcSelect v-else
-								v-model="selectedOrgCalendar"
-								:options="orgCalendarOptions"
-								label="displayName"
-								:placeholder="t('attendance', 'Select a calendar …')"
-								:disabled="loading"
-								data-test="select-org-calendar" />
-							<p class="hint-text">
-								{{ t('attendance', 'Share the selected calendar with your groups in the Calendar app so everyone can see the events.') }}
-							</p>
-							<p class="hint-text">
-								{{ t('attendance', 'When you select a calendar, all upcoming appointments are transferred to it. Past appointments are not transferred.') }}
-							</p>
-							<p class="hint-text">
-								{{ t('attendance', 'Events are created for all appointments, regardless of their visibility restrictions. Changing the target calendar does not move events that were already created.') }}
-							</p>
-							<p v-if="orgCalendarUserId" class="hint-text">
-								{{ t('attendance', 'Events are written using the account of {user}.', { user: orgCalendarUserId }) }}
-							</p>
-							<NcButton
-								v-if="selectedOrgCalendar"
-								variant="tertiary"
-								:disabled="syncingOrgCalendar"
-								data-test="button-sync-org-calendar"
-								@click="syncOrgCalendar">
-								<template #icon>
-									<NcLoadingIcon v-if="syncingOrgCalendar" :size="20" />
-									<CalendarSyncIcon v-else :size="20" />
-								</template>
-								{{ t('attendance', 'Sync upcoming appointments now') }}
-							</NcButton>
-							<p class="hint-text">
-								{{ t('attendance', 'Creates or updates the calendar events for all upcoming appointments. This also runs automatically when you enable the feature or change the calendar.') }}
-							</p>
-						</div>
-					</template>
-				</NcSettingsSection>
-			</div>
-
-			<div id="audit-log">
-				<NcSettingsSection :name="t('attendance', 'Audit log')"
-					:description="t('attendance', 'Records who responded what and when, and surfaces a timeline on every appointment. Also drives the response-change push notifications that managers can opt into in their personal settings.')">
-					<NcCheckboxRadioSwitch v-model="auditLogEnabled"
-						type="switch"
-						:disabled="loading"
-						data-test="switch-audit-log-enabled">
-						{{ t('attendance', 'Enable audit log') }}
-					</NcCheckboxRadioSwitch>
-					<p class="hint-text">
-						{{ t('attendance', 'Disabling stops new events from being recorded and silences response notifications. Existing entries are kept and reappear once you re-enable.') }}
-					</p>
-
-					<template v-if="auditLogEnabled">
-						<div class="subsection">
-							<h4>{{ t('attendance', 'Who can see the audit log?') }}</h4>
-							<NcCheckboxRadioSwitch v-model="auditLogVisibility"
-								value="managers"
-								name="audit_log_visibility"
-								type="radio"
-								:disabled="loading"
-								data-test="radio-audit-visibility-managers">
-								{{ t('attendance', 'Only users who can manage appointments') }}
-							</NcCheckboxRadioSwitch>
-							<NcCheckboxRadioSwitch v-model="auditLogVisibility"
-								value="all_with_response_overview"
-								name="audit_log_visibility"
-								type="radio"
-								:disabled="loading"
-								data-test="radio-audit-visibility-overview">
-								{{ t('attendance', 'Everyone who can see the response overview') }}
-							</NcCheckboxRadioSwitch>
-						</div>
-					</template>
-				</NcSettingsSection>
-			</div>
+						<NcCheckboxRadioSwitch v-model="auditLogVisibility"
+							value="all_with_response_overview"
+							name="audit_log_visibility"
+							type="radio"
+							data-test="radio-audit-visibility-overview">
+							{{ t('attendance', 'Everyone who can see the response overview') }}
+						</NcCheckboxRadioSwitch>
+					</div>
+				</template>
+			</NcSettingsSection>
 
 			<!-- TRANSLATORS: Admin settings section title for the scheduling feature: managers give people who answered "yes" a place in the appointment ("schedule someone in"). German: the feature/noun is "Planung", the per-person action is "einplanen" and a scheduled person is "eingeplant" — not "planen"/"geplant". The description and the "Enable scheduling" switch below use the same meaning. -->
-			<NcSettingsSection :name="t('attendance', 'Scheduling')"
+			<NcSettingsSection id="scheduling"
+				:name="t('attendance', 'Scheduling')"
 				:description="t('attendance', 'Let managers mark yes-responders as scheduled for an appointment. When off, no scheduling controls are shown anywhere.')">
 				<NcCheckboxRadioSwitch v-model="bookingEnabled"
 					type="switch"
-					:disabled="loading"
 					data-test="switch-booking-enabled">
 					<!-- TRANSLATORS: Switch label — turns the scheduling feature on (German: "Planung aktivieren"). -->
 					{{ t('attendance', 'Enable scheduling') }}
 				</NcCheckboxRadioSwitch>
 			</NcSettingsSection>
 
-			<div id="mobile-apps">
-				<NcSettingsSection :name="t('attendance', 'Mobile apps')"
-					:description="t('attendance', 'Share these links with your colleagues to install the Attendance mobile app.')">
-					<div class="mobile-app-links">
-						<div v-for="store in mobileAppStores" :key="store.id" class="mobile-app-link">
-							<label class="mobile-app-link__label">
-								<component :is="store.icon" :size="20" />
-								{{ store.label }}
-							</label>
-							<div class="mobile-app-link__row">
-								<code class="mobile-app-link__url" :data-test="`input-${store.id}-store-url`">{{ store.url }}</code>
-								<NcButton variant="secondary"
-									:aria-label="t('attendance', 'Copy URL')"
-									:data-test="`button-copy-${store.id}-url`"
-									@click="copyStoreUrl(store.url)">
-									<template #icon>
-										<ContentCopy :size="20" />
-									</template>
-									{{ t('attendance', 'Copy') }}
-								</NcButton>
-								<NcButton variant="tertiary"
-									:href="store.url"
-									target="_blank"
-									rel="noopener"
-									:data-test="`button-open-${store.id}-url`">
-									<template #icon>
-										<OpenInNew :size="20" />
-									</template>
-									<!-- TRANSLATORS: Verb (imperative) — button that opens the app-store link in a new browser tab. -->
-									{{ t('attendance', 'Open') }}
-								</NcButton>
-							</div>
-						</div>
-					</div>
-
-					<div class="subsection">
-						<h4>{{ t('attendance', 'Mobile App promotion banner') }}</h4>
-						<p class="subsection-hint">
-							{{ t('attendance', 'Show a banner at the top of the web app advertising the mobile apps. Users can dismiss the banner, and users who already have a push device connected will not see it.') }}
-						</p>
-						<NcCheckboxRadioSwitch
-							v-model="mobileAppBannerEnabled"
-							type="switch"
-							:disabled="loading"
-							data-test="switch-mobile-app-banner-enabled">
-							{{ t('attendance', 'Show promotion banner') }}
-						</NcCheckboxRadioSwitch>
-					</div>
-
-					<div class="subsection">
-						<h4>{{ t('attendance', 'Push notifications') }}</h4>
-						<p class="subsection-hint">
-							{{ t('attendance', 'Enable push notifications for the mobile app.') }}
-						</p>
-						<NcCheckboxRadioSwitch
-							v-model="pushEnabled"
-							type="switch"
-							:disabled="loading"
-							data-test="switch-push-enabled">
-							{{ t('attendance', 'Enable push notifications') }}
-						</NcCheckboxRadioSwitch>
-
-						<template v-if="pushEnabled">
-							<div class="push-device-status">
-								<NcNoteCard v-if="pushDeviceCount === 0" type="warning">
-									<p>{{ t('attendance', 'No push device registered for your account. Connect the Attendance mobile app to receive push notifications.') }}</p>
-								</NcNoteCard>
-								<template v-else>
-									<p class="push-device-info">
-										<CellphoneCheck :size="20" />
-										{{ n('attendance', '{count} device registered for push notifications', '{count} devices registered for push notifications', pushDeviceCount, { count: pushDeviceCount }) }}
-									</p>
-									<NcButton
-										variant="secondary"
-										:disabled="sendingTestReminder"
-										class="test-reminder-button"
-										data-test="button-test-push"
-										@click="sendTestReminder">
-										<template #icon>
-											<BellRingIcon :size="20" />
-										</template>
-										{{ t('attendance', 'Send test notification') }}
-									</NcButton>
-								</template>
-							</div>
-						</template>
-					</div>
-				</NcSettingsSection>
-			</div>
-
-			<NcSettingsSection :name="t('attendance', 'Display options')"
+			<NcSettingsSection id="display-options"
+				:name="t('attendance', 'Display options')"
 				:description="t('attendance', 'Choose how appointments are displayed across the app.')">
 				<NcCheckboxRadioSwitch
 					v-model="displayOrder"
@@ -610,7 +409,95 @@
 				</NcCheckboxRadioSwitch>
 			</NcSettingsSection>
 
-			<NcSettingsSection :name="t('attendance', 'Guest invitation')"
+			<NcSettingsSection id="mobile-apps"
+				:name="t('attendance', 'Mobile apps')"
+				:description="t('attendance', 'Share these links with your colleagues to install the Attendance mobile app.')">
+				<div class="mobile-app-links">
+					<div v-for="store in mobileAppStores" :key="store.id" class="mobile-app-link">
+						<label class="mobile-app-link__label">
+							<component :is="store.icon" :size="20" />
+							{{ store.label }}
+						</label>
+						<div class="mobile-app-link__row">
+							<code class="mobile-app-link__url" :data-test="`input-${store.id}-store-url`">{{ store.url }}</code>
+							<NcButton variant="secondary"
+								:aria-label="t('attendance', 'Copy URL')"
+								:data-test="`button-copy-${store.id}-url`"
+								@click="copyStoreUrl(store.url)">
+								<template #icon>
+									<ContentCopy :size="20" />
+								</template>
+								{{ t('attendance', 'Copy') }}
+							</NcButton>
+							<NcButton variant="tertiary"
+								:href="store.url"
+								target="_blank"
+								rel="noopener"
+								:data-test="`button-open-${store.id}-url`">
+								<template #icon>
+									<OpenInNew :size="20" />
+								</template>
+								<!-- TRANSLATORS: Verb (imperative) — button that opens the app-store link in a new browser tab. -->
+								{{ t('attendance', 'Open') }}
+							</NcButton>
+						</div>
+					</div>
+				</div>
+
+				<div class="subsection">
+					<h4>{{ t('attendance', 'Mobile App promotion banner') }}</h4>
+					<p class="subsection-hint">
+						{{ t('attendance', 'Show a banner at the top of the web app advertising the mobile apps. Users can dismiss the banner, and users who already have a push device connected will not see it.') }}
+					</p>
+					<NcCheckboxRadioSwitch
+						v-model="mobileAppBannerEnabled"
+						type="switch"
+						data-test="switch-mobile-app-banner-enabled">
+						{{ t('attendance', 'Show promotion banner') }}
+					</NcCheckboxRadioSwitch>
+				</div>
+
+				<div class="subsection">
+					<h4>{{ t('attendance', 'Push notifications') }}</h4>
+					<p class="subsection-hint">
+						{{ t('attendance', 'Enable push notifications for the mobile app.') }}
+					</p>
+					<NcCheckboxRadioSwitch
+						v-model="pushEnabled"
+						type="switch"
+						data-test="switch-push-enabled">
+						{{ t('attendance', 'Enable push notifications') }}
+					</NcCheckboxRadioSwitch>
+
+					<template v-if="pushEnabled">
+						<div class="push-device-status">
+							<NcNoteCard v-if="pushDeviceCount === 0" type="warning">
+								<p>{{ t('attendance', 'No push device registered for your account. Connect the Attendance mobile app to receive push notifications.') }}</p>
+							</NcNoteCard>
+							<template v-else>
+								<p class="push-device-info">
+									<CellphoneCheck :size="20" />
+									{{ n('attendance', '{count} device registered for push notifications', '{count} devices registered for push notifications', pushDeviceCount, { count: pushDeviceCount }) }}
+								</p>
+								<NcButton
+									variant="secondary"
+									:disabled="sendingTestReminder"
+									class="test-reminder-button"
+									data-test="button-test-push"
+									@click="sendTestReminder">
+									<template #icon>
+										<BellRingIcon :size="20" />
+									</template>
+									{{ t('attendance', 'Send test notification') }}
+								</NcButton>
+							</template>
+						</div>
+					</template>
+				</div>
+			</NcSettingsSection>
+
+			<NcSettingsSection id="guests"
+				:name="t('attendance', 'Guest invitation')"
 				:description="t('attendance', 'Invite people without a Nextcloud account by integrating with the Nextcloud Guests app.')"
 				data-test="section-guests-warning">
 				<template v-if="guestsHintVariant === 'install'">
@@ -677,19 +564,6 @@
 					</div>
 				</template>
 			</NcSettingsSection>
-
-			<NcSettingsSection>
-				<NcButton
-					variant="primary"
-					:disabled="loading"
-					data-test="button-save-settings"
-					@click="saveSettings">
-					<template #icon>
-						<NcLoadingIcon v-if="loading" />
-					</template>
-					{{ t('attendance', 'Save') }}
-				</NcButton>
-			</NcSettingsSection>
 		</template>
 	</div>
 </template>
@@ -708,7 +582,7 @@ import {
 	NcSettingsSection,
 } from '@nextcloud/vue'
 import QRCode from 'qrcode'
-import { computed, nextTick, onMounted, ref } from 'vue'
+import { computed, nextTick, onMounted, ref, watch } from 'vue'
 import AccountStar from 'vue-material-design-icons/AccountStar.vue'
 import AppleIcon from 'vue-material-design-icons/Apple.vue'
 import BellRingIcon from 'vue-material-design-icons/BellRing.vue'
@@ -718,6 +592,7 @@ import ContentCopy from 'vue-material-design-icons/ContentCopy.vue'
 import Download from 'vue-material-design-icons/Download.vue'
 import GoogleIcon from 'vue-material-design-icons/Google.vue'
 import OpenInNew from 'vue-material-design-icons/OpenInNew.vue'
+import PermissionRow from '../components/admin/PermissionRow.vue'
 import GroupSelect from '../components/common/GroupSelect.vue'
 import { copyToClipboard } from '../utils/clipboard.js'
 import { formatDate, formatDateTimeMedium } from '../utils/datetime.js'
@@ -728,6 +603,89 @@ const mobileAppStores = [
 	{ id: 'google', icon: GoogleIcon, url: GOOGLE_STORE_URL, label: t('attendance', 'Google Play (Android)') },
 ]
 
+const navSections = [
+	{ id: 'permissions', label: t('attendance', 'Permissions') },
+	{ id: 'response-summary', label: t('attendance', 'Response summary') },
+	{ id: 'self-checkin', label: t('attendance', 'Self-check-in') },
+	{ id: 'reminders', label: t('attendance', 'Appointment reminders') },
+	{ id: 'calendar-sync', label: t('attendance', 'Calendar sync') },
+	{ id: 'org-calendar', label: t('attendance', 'Organization calendar') },
+	{ id: 'audit-log', label: t('attendance', 'Audit log') },
+	{ id: 'scheduling', label: t('attendance', 'Scheduling') },
+	{ id: 'display-options', label: t('attendance', 'Display options') },
+	{ id: 'mobile-apps', label: t('attendance', 'Mobile apps') },
+	{ id: 'guests', label: t('attendance', 'Guest invitation') },
+]
+
+const permissionGroups = [
+	{
+		key: 'appointments',
+		label: t('attendance', 'Appointments'),
+		rows: [
+			{
+				name: 'manage_appointments',
+				title: t('attendance', 'Manage appointments'),
+				hint: t('attendance', 'Create, edit and delete any appointment and manage its responses.'),
+				warningWhenAll: t('attendance', 'Every user can create, edit and delete all appointments.'),
+			},
+			{
+				name: 'create_appointments',
+				title: t('attendance', 'Create own appointments'),
+				hint: t('attendance', 'Create appointments and manage them as organizer.'),
+				implication: t('attendance', 'Users who can manage appointments can always create appointments.'),
+			},
+		],
+	},
+	{
+		key: 'responses',
+		label: t('attendance', 'Responses'),
+		rows: [
+			{
+				name: 'see_response_overview',
+				title: t('attendance', 'See response & check-in summary'),
+				hint: t('attendance', 'See the full response and check-in summary, including names.'),
+				implication: t('attendance', 'Organizers always see the summary of their own appointments.'),
+			},
+			{
+				name: 'see_response_counts',
+				title: t('attendance', 'See response counts'),
+				hint: t('attendance', 'See how many people answered yes, no or maybe — without any names.'),
+				implication: t('attendance', 'Users who see the full summary always see the counts.'),
+			},
+			{
+				name: 'see_comments',
+				title: t('attendance', 'See comments'),
+				hint: t('attendance', 'See comments in the response overview.'),
+			},
+			{
+				name: 'respond_for_others',
+				title: t('attendance', 'Set responses for other users'),
+				hint: t('attendance', 'Record or clear an answer on behalf of another person.'),
+				implication: t('attendance', 'Not granted automatically to users who can manage appointments.'),
+			},
+		],
+	},
+	{
+		key: 'checkin',
+		label: t('attendance', 'Check-in'),
+		rows: [
+			{
+				name: 'checkin',
+				title: t('attendance', 'Check-in access'),
+				hint: t('attendance', 'Access the check-in interface and check in attendees.'),
+			},
+			{
+				name: 'self_checkin',
+				title: t('attendance', 'Self-check-in'),
+				hint: t('attendance', 'Check in themselves via QR code, NFC tag or deep link.'),
+				implication: t('attendance', 'Set up QR codes and NFC tags in the Self-check-in section.'),
+			},
+		],
+	},
+]
+
+const PERMISSION_NAMES = permissionGroups.flatMap((group) => group.rows.map((row) => row.name))
+
 // State
 const availableGroups = ref([])
 const selectedGroups = ref([])
@@ -735,14 +693,7 @@ const selectedTeams = ref([])
 const teamSearchResults = ref([])
 const isSearchingTeams = ref(false)
 const teamsAvailable = ref(false)
-const selectedManageAppointmentsRoles = ref([])
-const selectedCreateAppointmentsRoles = ref([])
-const selectedCheckinRoles = ref([])
-const selectedSeeResponseOverviewRoles = ref([])
-const selectedSeeResponseCountsRoles = ref([])
-const selectedSeeCommentsRoles = ref([])
-const selectedRespondForOthersRoles = ref([])
-const selectedSelfCheckinRoles = ref([])
+const permissions = ref(Object.fromEntries(PERMISSION_NAMES.map((name) => [name, { mode: 'all', groups: [] }])))
 const selfCheckinWindowMinutes = ref(30)
 const qrDataUrl = ref(null)
 const selfCheckinUrl = window.location.origin + generateUrl('/apps/attendance/self-checkin')
@@ -766,7 +717,6 @@ const mobileAppBannerEnabled = ref(true)
 const bookingEnabled = ref(false)
 const displayOrder = ref('name_first')
 const pushDeviceCount = ref(0)
-const loading = ref(false)
 const loadingData = ref(true)
 const sendingTestReminder = ref(false)
 const syncingOrgCalendar = ref(false)
@@ -848,9 +798,113 @@ const reminderPreviewDates = computed(() => {
 	return dates
 })
 
+// Auto-save
+// Every mutation posts a partial payload; the backend leaves omitted settings
+// untouched. Saves are debounced per key so rapid edits collapse into one.
+let suppressSaves = true
+const saveTimers = {}
+
+function queueSave(key, payloadFactory, delay = 0) {
+	if (suppressSaves) return
+	clearTimeout(saveTimers[key])
+	saveTimers[key] = setTimeout(async () => {
+		delete saveTimers[key]
+		const payload = payloadFactory()
+		if (!payload) return
+		try {
+			await axios.post(generateUrl('/apps/attendance/api/admin/settings'), payload)
+			showSuccess(window.t('attendance', 'Settings saved'))
+		} catch (error) {
+			console.error('Error saving settings:', error)
+			showError(window.t('attendance', 'Failed to save settings'))
+		}
+	}, delay)
+}
+
+function autoSave(source, key, payloadFactory, delay = 0) {
+	watch(source, () => queueSave(key, payloadFactory, delay), { deep: true })
+}
+
+const SELECT_DEBOUNCE = 800
+
+autoSave(
+	selectedGroups,
+	'whitelistedGroups',
+	() => ({ whitelistedGroups: selectedGroups.value.map((g) => g.id) }),
+	SELECT_DEBOUNCE,
+)
+autoSave(
+	selectedTeams,
+	'whitelistedTeams',
+	() => ({ whitelistedTeams: selectedTeams.value.map((team) => team.id) }),
+	SELECT_DEBOUNCE,
+)
+// Per permission, not the whole map: the backend leaves omitted permissions
+// untouched, so concurrent admins and stale local state cannot overwrite
+// settings the user never edited.
+function onPermissionChange(name, value) {
+	permissions.value[name] = value
+	queueSave(`permission:${name}`, () => ({
+		permissions: {
+			[name]: {
+				mode: permissions.value[name].mode,
+				groups: permissions.value[name].groups.map((g) => g.id),
+			},
+		},
+	}), SELECT_DEBOUNCE)
+}
+autoSave(selfCheckinWindowMinutes, 'selfCheckinWindowMinutes', () => {
+	if (!Number.isFinite(selfCheckinWindowMinutes.value)) return null
+	return { selfCheckinWindowMinutes: selfCheckinWindowMinutes.value }
+}, SELECT_DEBOUNCE)
+autoSave([remindersEnabled, reminderDays, reminderFrequency, reminderTarget], 'reminders', () => {
+	const reminders = {
+		enabled: remindersEnabled.value,
+		reminderTarget: reminderTarget.value,
+	}
+	if (Number.isFinite(reminderDays.value)) reminders.reminderDays = reminderDays.value
+	if (Number.isFinite(reminderFrequency.value)) reminders.reminderFrequency = reminderFrequency.value
+	return { reminders }
+}, SELECT_DEBOUNCE)
+autoSave(
+	calendarSyncEnabled,
+	'calendarSync',
+	() => ({ calendarSync: { enabled: calendarSyncEnabled.value } }),
+)
+// Debounced although these are discrete clicks: saving triggers the calendar
+// backfill server-side, so enable + calendar pick should collapse into one run.
+autoSave([orgCalendarEnabled, selectedOrgCalendar], 'orgCalendar', () => ({
+	orgCalendar: {
+		enabled: orgCalendarEnabled.value,
+		...(selectedOrgCalendar.value?.uri ? { calendarUri: selectedOrgCalendar.value.uri } : {}),
+	},
+}), SELECT_DEBOUNCE)
+autoSave(
+	[auditLogEnabled, auditLogVisibility],
+	'audit',
+	() => ({ audit: { enabled: auditLogEnabled.value, visibility: auditLogVisibility.value } }),
+)
+autoSave(displayOrder, 'displayOrder', () => ({ displayOrder: displayOrder.value }))
+autoSave(pushEnabled, 'pushEnabled', () => ({ pushEnabled: pushEnabled.value }))
+autoSave(
+	mobileAppBannerEnabled,
+	'mobileAppBannerEnabled',
+	() => ({ mobileAppBannerEnabled: mobileAppBannerEnabled.value }),
+)
+autoSave(bookingEnabled, 'bookingEnabled', () => ({ bookingEnabled: bookingEnabled.value }))
+
 // Methods
+function scrollToSection(id) {
+	const element = document.getElementById(id)
+	if (element) {
+		element.scrollIntoView({ behavior: 'smooth' })
+		window.history.replaceState(null, '', `#${id}`)
+	}
+}
+
 async function loadSettings() {
 	loadingData.value = true
+	suppressSaves = true
 
 	try {
 		const [settingsRes, capabilitiesRes] = await Promise.all([
@@ -862,10 +916,13 @@ async function loadSettings() {
 		const caps = capabilitiesRes.data
 
 		availableGroups.value = groups
-		// Convert selected IDs to selected group objects for NcSelect, preserving database order
-		selectedGroups.value = config.whitelistedGroups
-			.map((id) => groups.find((group) => group.id === id))
+		// Convert stored IDs to group objects for NcSelect, preserving database order
+		const groupsById = new Map(groups.map((group) => [group.id, group]))
+		const toGroupObjects = (ids) => (ids || [])
+			.map((id) => groupsById.get(id))
 			.filter((group) => group !== undefined)
+
+		selectedGroups.value = toGroupObjects(config.whitelistedGroups)
 
 		// Load teams settings
 		teamsAvailable.value = caps.teamsAvailable || false
@@ -875,32 +932,16 @@ async function loadSettings() {
 			teamSearchResults.value = [...config.whitelistedTeams]
 		}
 
-		// Load permission settings, preserving database order
+		// Load permission settings
 		if (config.permissions) {
-			selectedManageAppointmentsRoles.value = config.permissions.manage_appointments
-				.map((id) => groups.find((group) => group.id === id))
-				.filter((group) => group !== undefined)
-			selectedCheckinRoles.value = config.permissions.checkin
-				.map((id) => groups.find((group) => group.id === id))
-				.filter((group) => group !== undefined)
-			selectedSeeResponseOverviewRoles.value = (config.permissions.see_response_overview || [])
-				.map((id) => groups.find((group) => group.id === id))
-				.filter((group) => group !== undefined)
-			selectedSeeResponseCountsRoles.value = (config.permissions.see_response_counts || [])
-				.map((id) => groups.find((group) => group.id === id))
-				.filter((group) => group !== undefined)
-			selectedSeeCommentsRoles.value = (config.permissions.see_comments || [])
-				.map((id) => groups.find((group) => group.id === id))
-				.filter((group) => group !== undefined)
-			selectedSelfCheckinRoles.value = (config.permissions.self_checkin || [])
-				.map((id) => groups.find((group) => group.id === id))
-				.filter((group) => group !== undefined)
-			selectedRespondForOthersRoles.value = (config.permissions.respond_for_others || [])
-				.map((id) => groups.find((group) => group.id === id))
-				.filter((group) => group !== undefined)
-			selectedCreateAppointmentsRoles.value = (config.permissions.create_appointments || [])
-				.map((id) => groups.find((group) => group.id === id))
-				.filter((group) => group !== undefined)
+			for (const name of PERMISSION_NAMES) {
+				const setting = config.permissions[name]
+				if (!setting) continue
+				permissions.value[name] = {
+					mode: setting.mode,
+					groups: toGroupObjects(setting.groups),
+				}
+			}
 		}
 
 		selfCheckinWindowMinutes.value = config.selfCheckinWindowMinutes ?? 30
@@ -958,6 +999,9 @@ async function loadSettings() {
 		showError(window.t('attendance', 'Failed to load settings'))
 	} finally {
 		loadingData.value = false
+		// Let the watchers flush the load mutations before arming auto-save
+		await nextTick()
+		suppressSaves = false
 	}
 }
 
@@ -987,59 +1031,6 @@ async function searchTeams(query) {
 		console.error('Error searching teams:', error)
 	} finally {
 		isSearchingTeams.value = false
-	}
-}
-
-async function saveSettings() {
-	loading.value = true
-
-	try {
-		await axios.post(
-			generateUrl('/apps/attendance/api/admin/settings'),
-			{
-				whitelistedGroups: selectedGroups.value.map((g) => g.id),
-				whitelistedTeams: selectedTeams.value.map((t) => t.id),
-				permissions: {
-					PERMISSION_MANAGE_APPOINTMENTS: selectedManageAppointmentsRoles.value.map((g) => g.id),
-					PERMISSION_CHECKIN: selectedCheckinRoles.value.map((g) => g.id),
-					PERMISSION_SEE_RESPONSE_OVERVIEW: selectedSeeResponseOverviewRoles.value.map((g) => g.id),
-					PERMISSION_SEE_RESPONSE_COUNTS: selectedSeeResponseCountsRoles.value.map((g) => g.id),
-					PERMISSION_SEE_COMMENTS: selectedSeeCommentsRoles.value.map((g) => g.id),
-					PERMISSION_SELF_CHECKIN: selectedSelfCheckinRoles.value.map((g) => g.id),
-					PERMISSION_CREATE_APPOINTMENTS: selectedCreateAppointmentsRoles.value.map((g) => g.id),
-					PERMISSION_RESPOND_FOR_OTHERS: selectedRespondForOthersRoles.value.map((g) => g.id),
-				},
-				reminders: {
-					enabled: remindersEnabled.value,
-					reminderDays: reminderDays.value,
-					reminderFrequency: reminderFrequency.value,
-					reminderTarget: reminderTarget.value,
-				},
-				calendarSync: {
-					enabled: calendarSyncEnabled.value,
-				},
-				orgCalendar: {
-					enabled: orgCalendarEnabled.value,
-					...(selectedOrgCalendar.value?.uri ? { calendarUri: selectedOrgCalendar.value.uri } : {}),
-				},
-				audit: {
-					enabled: auditLogEnabled.value,
-					visibility: auditLogVisibility.value,
-				},
-				displayOrder: displayOrder.value,
-				pushEnabled: pushEnabled.value,
-				mobileAppBannerEnabled: mobileAppBannerEnabled.value,
-				bookingEnabled: bookingEnabled.value,
-				selfCheckinWindowMinutes: selfCheckinWindowMinutes.value,
-			},
-		)
-
-		showSuccess(window.t('attendance', 'Settings saved'))
-	} catch (error) {
-		console.error('Error saving settings:', error)
-		showError(window.t('attendance', 'Failed to save settings'))
-	} finally {
-		loading.value = false
 	}
 }
 
@@ -1118,10 +1109,7 @@ onMounted(async () => {
 	// Handle hash navigation after content is loaded
 	await nextTick()
 	if (window.location.hash) {
-		const element = document.querySelector(window.location.hash)
-		if (element) {
-			element.scrollIntoView({ behavior: 'smooth' })
-		}
+		scrollToSection(window.location.hash.slice(1))
 	}
 })
 </script>
@@ -1130,6 +1118,28 @@ onMounted(async () => {
 #attendance-admin-settings {
 	padding: 20px;
 	max-width: 900px;
+}
+
+.anchor-nav {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 8px;
+	margin-top: 12px;
+}
+
+.anchor-nav__link {
+	padding: 6px 14px;
+	border-radius: var(--border-radius-pill);
+	background-color: var(--color-background-dark);
+	color: var(--color-main-text);
+	font-size: 13px;
+	text-decoration: none;
+	white-space: nowrap;
+}
+
+.anchor-nav__link:hover,
+.anchor-nav__link:focus {
+	background-color: var(--color-primary-element-light);
 }
 
 .loading-section {
@@ -1145,6 +1155,22 @@ onMounted(async () => {
 	margin-top: 8px;
 	color: var(--color-text-maxcontrast);
 	font-size: 13px;
+}
+
+.permission-group {
+	margin-bottom: 32px;
+}
+
+.permission-group:last-child {
+	margin-bottom: 0;
+}
+
+.permission-group__title {
+	margin: 0 0 4px 0;
+	padding-bottom: 6px;
+	border-bottom: 1px solid var(--color-border-dark);
+	font-size: 16px;
+	font-weight: 700;
 }
 
 .guests-warning-actions {
@@ -1217,17 +1243,12 @@ onMounted(async () => {
 .self-checkin-window-field {
 	max-width: 400px;
 	/* The floating label sits above the input border, so it needs extra
-	   room to not collide with the group hint text above. */
-	margin-top: 24px;
+	   room to not collide with the section description above. */
+	margin-top: 12px;
 }
 
 .self-checkin-qr {
 	margin-top: 20px;
-
-	h5 {
-		font-weight: 600;
-		margin-bottom: 4px;
-	}
 
 	h6 {
 		font-weight: 600;

--- a/tests/e2e/28-create-permission.spec.js
+++ b/tests/e2e/28-create-permission.spec.js
@@ -28,8 +28,8 @@ test.describe('Attendance App - Create appointment permission (sequential)', () 
 			whitelistedTeams: [],
 			permissions: {
 				...PERMISSIVE_PERMISSIONS,
-				manage_appointments: ['admin'],
-				create_appointments: ['creators'],
+				manage_appointments: { mode: 'groups', groups: ['admin'] },
+				create_appointments: { mode: 'groups', groups: ['creators'] },
 			},
 			reminders: { enabled: false },
 		})

--- a/tests/e2e/29-organizer-visibility.spec.js
+++ b/tests/e2e/29-organizer-visibility.spec.js
@@ -34,10 +34,10 @@ test.describe('Attendance App - Organizer response visibility (sequential)', () 
 			whitelistedTeams: [],
 			permissions: {
 				...PERMISSIVE_PERMISSIONS,
-				manage_appointments: ['admin'],
-				see_response_overview: ['admin'],
-				see_response_counts: ['admin'],
-				see_comments: ['admin'],
+				manage_appointments: { mode: 'groups', groups: ['admin'] },
+				see_response_overview: { mode: 'groups', groups: ['admin'] },
+				see_response_counts: { mode: 'groups', groups: ['admin'] },
+				see_comments: { mode: 'groups', groups: ['admin'] },
 			},
 			reminders: { enabled: false },
 		})

--- a/tests/e2e/4-admin-settings.spec.js
+++ b/tests/e2e/4-admin-settings.spec.js
@@ -1,4 +1,4 @@
-import { test, expect, resetAdminSettings, deleteAllAppointments } from './fixtures/nextcloud.js'
+import { deleteAllAppointments, expect, resetAdminSettings, restrictPermissionToGroup, test, waitForSettingsSave } from './fixtures/nextcloud.js'
 
 /**
  * Admin Settings E2E Tests
@@ -7,6 +7,10 @@ import { test, expect, resetAdminSettings, deleteAllAppointments } from './fixtu
  * 1. Configuring permissions to restrict features to admin group only
  * 2. Verifying regular users (test/test) cannot access restricted features
  * 3. Verifying admin users retain access to all features
+ *
+ * The settings page auto-saves: every change posts a partial payload to the
+ * admin settings endpoint, so the tests wait for that POST instead of
+ * clicking a save button.
  *
  * Tests cover:
  * - Manage Appointments permission (create/edit/delete buttons)
@@ -31,24 +35,7 @@ test.describe('Attendance App - Admin Settings', () => {
 			await page.goto('/settings/admin/attendance')
 			await page.waitForLoadState('networkidle')
 
-			// Find and configure "Manage Appointments" permission to admin only
-			const managePermissionSelect = page.locator('[data-test="select-manage-appointments-roles"]')
-			await expect(managePermissionSelect).toBeVisible()
-
-			// Click on the combobox to open dropdown
-			await managePermissionSelect.getByRole('combobox').click()
-			const adminOption = page.getByRole('option', { name: 'admin' })
-			await adminOption.waitFor({ state: 'visible' })
-
-			// Select admin option from dropdown
-			await adminOption.click()
-
-			// Save settings
-			const saveButton = page.locator('[data-test="button-save-settings"]')
-			await saveButton.click()
-
-			// Verify success message or settings saved
-			await page.waitForLoadState('networkidle')
+			await restrictPermissionToGroup(page, 'manage_appointments', 'admin')
 
 			// Now login as regular test user
 			await loginAsUser('test', 'test')
@@ -99,17 +86,7 @@ test.describe('Attendance App - Admin Settings', () => {
 			await page.goto('/settings/admin/attendance')
 			await page.waitForLoadState('networkidle')
 
-			const checkinPermissionSelect = page.locator('[data-test="select-checkin-roles"]')
-			await expect(checkinPermissionSelect).toBeVisible()
-
-			await checkinPermissionSelect.getByRole('combobox').click()
-			const adminOption = page.getByRole('option', { name: 'admin' })
-			await adminOption.waitFor({ state: 'visible' })
-
-			await adminOption.click()
-
-			const saveButton = page.locator('[data-test="button-save-settings"]')
-			await saveButton.click()
+			await restrictPermissionToGroup(page, 'checkin', 'admin')
 
 			// Login as test user
 			await loginAsUser('test', 'test')
@@ -149,17 +126,7 @@ test.describe('Attendance App - Admin Settings', () => {
 			await page.goto('/settings/admin/attendance')
 			await page.waitForLoadState('networkidle')
 
-			const responseOverviewSelect = page.locator('[data-test="select-see-response-overview-roles"]')
-			await expect(responseOverviewSelect).toBeVisible()
-
-			await responseOverviewSelect.getByRole('combobox').click()
-			const adminOption = page.getByRole('option', { name: 'admin' })
-			await adminOption.waitFor({ state: 'visible' })
-
-			await adminOption.click()
-
-			const saveButton = page.locator('[data-test="button-save-settings"]')
-			await saveButton.click()
+			await restrictPermissionToGroup(page, 'see_response_overview', 'admin')
 
 			// Create appointment as admin
 			await attendanceApp()
@@ -218,17 +185,7 @@ test.describe('Attendance App - Admin Settings', () => {
 			await page.goto('/settings/admin/attendance')
 			await page.waitForLoadState('networkidle')
 
-			const seeCommentsSelect = page.locator('[data-test="select-see-comments-roles"]')
-			await expect(seeCommentsSelect).toBeVisible()
-
-			await seeCommentsSelect.getByRole('combobox').click()
-			const adminOption = page.getByRole('option', { name: 'admin' })
-			await adminOption.waitFor({ state: 'visible' })
-
-			await adminOption.click()
-
-			const saveButton = page.locator('[data-test="button-save-settings"]')
-			await saveButton.click()
+			await restrictPermissionToGroup(page, 'see_comments', 'admin')
 
 			// Navigate to app and verify settings applied
 			await attendanceApp()
@@ -249,17 +206,7 @@ test.describe('Attendance App - Admin Settings', () => {
 			await page.goto('/settings/admin/attendance')
 			await page.waitForLoadState('networkidle')
 
-			const countsSelect = page.locator('[data-test="select-see-response-counts-roles"]')
-			await expect(countsSelect).toBeVisible()
-
-			await countsSelect.getByRole('combobox').click()
-			const adminOption = page.getByRole('option', { name: 'admin' })
-			await adminOption.waitFor({ state: 'visible' })
-			await adminOption.click()
-
-			const saveButton = page.locator('[data-test="button-save-settings"]')
-			await saveButton.click()
-			await page.waitForLoadState('networkidle')
+			await restrictPermissionToGroup(page, 'see_response_counts', 'admin')
 
 			// Test user now sees no bar at all
 			await loginAsUser('test', 'test')
@@ -272,6 +219,29 @@ test.describe('Attendance App - Admin Settings', () => {
 			await attendanceApp()
 			await page.waitForLoadState('networkidle')
 			await expect(page.locator('[data-test="response-bar"]').first()).toBeVisible()
+		})
+
+		test('should deny a permission to everyone via the nobody mode', async ({ page, loginAsUser, attendanceApp }) => {
+			// Login as admin and set check-in access to nobody
+			await loginAsUser('admin', 'admin')
+			await page.goto('/settings/admin/attendance')
+			await page.waitForLoadState('networkidle')
+
+			const row = page.locator('[data-test="permission-checkin"]')
+			await expect(row).toBeVisible()
+			const saved = waitForSettingsSave(page)
+			await row.getByText('Nobody', { exact: true }).click()
+			await saved
+
+			// Even the admin loses the check-in entry point now
+			await attendanceApp()
+			await page.waitForLoadState('networkidle')
+
+			const actionsButton = page.getByRole('button', { name: 'Actions' }).first()
+			await actionsButton.click()
+			await page.waitForLoadState('networkidle')
+			await expect(page.locator('[data-test="action-start-checkin"]')).not.toBeVisible()
+			await page.keyboard.press('Escape')
 		})
 	})
 
@@ -290,15 +260,10 @@ test.describe('Attendance App - Admin Settings', () => {
 			const adminOption = page.getByRole('option', { name: 'admin' })
 			await adminOption.waitFor({ state: 'visible' })
 
-			// Select 'admin' group
+			// Select 'admin' group and wait for the auto-save
+			const saved = waitForSettingsSave(page)
 			await adminOption.click()
-
-			// Save settings
-			const saveButton = page.locator('[data-test="button-save-settings"]')
-			await saveButton.click()
-
-			// Verify settings were saved (could check for success message)
-			await page.waitForLoadState('networkidle')
+			await saved
 		})
 	})
 
@@ -326,15 +291,13 @@ test.describe('Attendance App - Admin Settings', () => {
 			await expect(reminderDaysInput).toBeVisible()
 			await reminderDaysInput.fill('3')
 
-			// Configure reminder frequency using spinbutton role
+			// Configure reminder frequency using spinbutton role; the two edits
+			// collapse into one debounced auto-save
 			const reminderFrequencyInput = page.getByRole('spinbutton', { name: 'Reminder frequency (days)' })
 			await expect(reminderFrequencyInput).toBeVisible()
+			const saved = waitForSettingsSave(page)
 			await reminderFrequencyInput.fill('2')
-
-			// Save settings
-			const saveButton = page.locator('[data-test="button-save-settings"]')
-			await saveButton.click()
-			await page.waitForLoadState('networkidle')
+			await saved
 
 			// Verify settings persisted by reloading page
 			await page.reload()
@@ -390,13 +353,16 @@ test.describe('Attendance App - Admin Settings', () => {
 			await page.goto('/settings/admin/attendance')
 			await page.waitForLoadState('networkidle')
 
-			// Test all permission select fields
+			// Permission selects only render in "Specific groups" mode
+			const permissionNames = ['manage_appointments', 'checkin', 'see_response_overview', 'see_comments']
+			for (const permission of permissionNames) {
+				const row = page.locator(`[data-test="permission-${permission}"]`)
+				await row.getByText('Specific groups', { exact: true }).click()
+			}
+
 			const selectFields = [
 				'select-whitelisted-groups',
-				'select-manage-appointments-roles',
-				'select-checkin-roles',
-				'select-see-response-overview-roles',
-				'select-see-comments-roles',
+				...permissionNames.map((permission) => `permission-${permission}-groups`),
 			]
 
 			for (const fieldTestId of selectFields) {
@@ -426,8 +392,11 @@ test.describe('Attendance App - Admin Settings', () => {
 			await page.goto('/settings/admin/attendance')
 			await page.waitForLoadState('networkidle')
 
-			// Find the manage appointments permission selector
-			const manageSelect = page.locator('[data-test="select-manage-appointments-roles"]')
+			// Switch the manage row to specific groups to reveal the select
+			const row = page.locator('[data-test="permission-manage_appointments"]')
+			await row.getByText('Specific groups', { exact: true }).click()
+
+			const manageSelect = page.locator('[data-test="permission-manage_appointments-groups"]')
 			await expect(manageSelect).toBeVisible()
 
 			// Select admin group
@@ -446,6 +415,7 @@ test.describe('Attendance App - Admin Settings', () => {
 			const hasTestGroup = await testOption.isVisible().catch(() => false)
 
 			if (hasTestGroup) {
+				const saved = waitForSettingsSave(page)
 				await testOption.click()
 
 				// Verify both tags are visible
@@ -453,16 +423,14 @@ test.describe('Attendance App - Admin Settings', () => {
 				const testTag = manageSelect.locator('.vs__selected').filter({ hasText: 'test' })
 				await expect(testTag).toBeVisible()
 
-				// Save and reload to verify persistence
-				const saveButton = page.locator('[data-test="button-save-settings"]')
-				await saveButton.click()
-				await page.waitForLoadState('networkidle')
+				// Wait for the auto-save, then reload to verify persistence
+				await saved
 
 				await page.reload()
 				await page.waitForLoadState('networkidle')
 
 				// Verify both groups are still selected after reload
-				const reloadedSelect = page.locator('[data-test="select-manage-appointments-roles"]')
+				const reloadedSelect = page.locator('[data-test="permission-manage_appointments-groups"]')
 				const reloadedAdminTag = reloadedSelect.locator('.vs__selected').filter({ hasText: 'admin' })
 				const reloadedTestTag = reloadedSelect.locator('.vs__selected').filter({ hasText: 'test' })
 				await expect(reloadedAdminTag).toBeVisible()
@@ -476,8 +444,11 @@ test.describe('Attendance App - Admin Settings', () => {
 			await page.goto('/settings/admin/attendance')
 			await page.waitForLoadState('networkidle')
 
-			// Find the checkin roles selector
-			const checkinSelect = page.locator('[data-test="select-checkin-roles"]')
+			// Switch the check-in row to specific groups to reveal the select
+			const row = page.locator('[data-test="permission-checkin"]')
+			await row.getByText('Specific groups', { exact: true }).click()
+
+			const checkinSelect = page.locator('[data-test="permission-checkin-groups"]')
 			await expect(checkinSelect).toBeVisible()
 
 			// Select admin group first
@@ -512,27 +483,23 @@ test.describe('Attendance App - Admin Settings', () => {
 	})
 
 	test.describe('Settings Persistence', () => {
-		test('should persist all settings across page reloads', async ({ page, loginAsUser }) => {
+		test('should persist the selected mode across page reloads', async ({ page, loginAsUser }) => {
 			// Login as admin
 			await loginAsUser('admin', 'admin')
 			await page.goto('/settings/admin/attendance')
 			await page.waitForLoadState('networkidle')
 
-			// Configure multiple settings
-			const managePermissionSelect = page.locator('[data-test="select-manage-appointments-roles"]')
-			await expect(managePermissionSelect).toBeVisible()
-
-			// Save settings
-			const saveButton = page.locator('[data-test="button-save-settings"]')
-			await saveButton.click()
-			await page.waitForLoadState('networkidle')
+			await restrictPermissionToGroup(page, 'manage_appointments', 'admin')
 
 			// Reload page
 			await page.reload()
 			await page.waitForLoadState('networkidle')
 
-			// Verify settings are still there
+			// The row comes back in "Specific groups" mode with the select visible
+			const managePermissionSelect = page.locator('[data-test="permission-manage_appointments-groups"]')
 			await expect(managePermissionSelect).toBeVisible()
+			const adminTag = managePermissionSelect.locator('.vs__selected').filter({ hasText: 'admin' })
+			await expect(adminTag).toBeVisible()
 		})
 	})
 })

--- a/tests/e2e/5-visibility-users.spec.js
+++ b/tests/e2e/5-visibility-users.spec.js
@@ -1,4 +1,4 @@
-import { test, expect, login, resetAdminSettings, deleteAllAppointments } from './fixtures/nextcloud.js'
+import { deleteAllAppointments, expect, login, resetAdminSettings, restrictPermissionToGroup, test } from './fixtures/nextcloud.js'
 
 // Helper function to create an appointment with visibility settings
 async function createAppointmentWithVisibility(page, { name, description, daysFromNow = 2, durationHours = 1, visibleUsers = [] }) {
@@ -79,16 +79,9 @@ test.describe('Attendance App - User Visibility Filtering', () => {
 		await page.goto('/settings/admin/attendance')
 		await page.waitForLoadState('networkidle')
 
-		// Configure manage_appointments permission to admin only
-		const managePermissionSelect = page.locator('[data-test="select-manage-appointments-roles"]')
-		await managePermissionSelect.getByRole('combobox').click()
-		const adminOption = page.getByRole('option', { name: 'admin' })
-		await adminOption.waitFor({ state: 'visible' })
-		await adminOption.click()
-
-		// Save settings
-		await page.locator('[data-test="button-save-settings"]').click()
-		await page.waitForLoadState('networkidle')
+		// Configure manage_appointments permission to admin only; the page
+		// auto-saves, so the helper waits for the settings POST
+		await restrictPermissionToGroup(page, 'manage_appointments', 'admin')
 
 		await page.close()
 	})
@@ -105,9 +98,9 @@ test.describe('Attendance App - User Visibility Filtering', () => {
 			description: 'This appointment should only be visible to test1',
 			daysFromNow: 2,
 			durationHours: 1,
-			visibleUsers: ['test1']
+			visibleUsers: ['test1'],
 		})
-		
+
 		// Verify appointment appears for admin (creator can always see)
 		await expect(page.getByText('Private Meeting - Test1 Only').first()).toBeVisible()
 	})
@@ -118,9 +111,9 @@ test.describe('Attendance App - User Visibility Filtering', () => {
 			description: 'Everyone can see this appointment',
 			daysFromNow: 3,
 			durationHours: 1,
-			visibleUsers: [] // Empty = visible to all
+			visibleUsers: [], // Empty = visible to all
 		})
-		
+
 		// Verify appointment appears
 		await expect(page.getByText('Public Team Meeting').first()).toBeVisible()
 	})
@@ -131,9 +124,9 @@ test.describe('Attendance App - User Visibility Filtering', () => {
 			description: 'Only test1 and test2 can see this',
 			daysFromNow: 4,
 			durationHours: 1,
-			visibleUsers: ['test1', 'test2']
+			visibleUsers: ['test1', 'test2'],
 		})
-		
+
 		// Verify appointment appears
 		await expect(page.getByText('Selective Access Meeting').first()).toBeVisible()
 	})
@@ -143,7 +136,7 @@ test.describe('Attendance App - User Visibility Filtering', () => {
 		await loginAsUser('test1', 'test1')
 		await attendanceApp()
 		await page.waitForLoadState('networkidle')
-		
+
 		// Should see: "Private Meeting - Test1 Only", "Public Team Meeting", "Selective Access Meeting"
 		await expect(page.getByText('Private Meeting - Test1 Only').first()).toBeVisible()
 		await expect(page.getByText('Public Team Meeting').first()).toBeVisible()
@@ -152,23 +145,23 @@ test.describe('Attendance App - User Visibility Filtering', () => {
 
 	test('unauthorized user should not see restricted appointments', async ({ page, loginAsUser, attendanceApp, browser, baseURL }) => {
 		// Create an appointment that's NOT visible to test3
-		
+
 		// First, as admin, create an appointment visible only to test1
 		await loginAsUser('admin', 'admin')
 		await attendanceApp()
 		await page.waitForLoadState('networkidle')
-		
+
 		await createAppointmentWithVisibility(page, {
 			name: 'Test1 Only Meeting',
 			description: 'Only test1 can see this',
 			daysFromNow: 5,
 			durationHours: 1,
-			visibleUsers: ['test1']
+			visibleUsers: ['test1'],
 		})
-		
+
 		// Verify admin sees it (managers see all)
 		await expect(page.getByText('Test1 Only Meeting').first()).toBeVisible()
-		
+
 		// Now login as regular test user and verify they DON'T see it
 		// (test user doesn't have manage_appointments permission after beforeAll setup)
 		await loginAsUser('test', 'test')

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -243,16 +243,16 @@ All interactive elements in the app have `data-test` attributes for reliable tes
 - `button-bulk-confirm` - Confirm bulk action
 
 ### Admin Settings
+
+The page auto-saves; there is no save button. Wait for the POST to
+`/api/admin/settings` after a change instead.
+
 - `admin-settings` - Admin settings container
 - `select-whitelisted-groups` - Whitelisted groups selector
-- `select-manage-appointments-roles` - Manage appointments permission selector
-- `select-checkin-roles` - Check-in permission selector
-- `select-see-response-overview-roles` - See response overview permission selector
-- `select-see-comments-roles` - See comments permission selector
+- `permission-<name>` - Permission row (e.g. `permission-manage_appointments`) with `permission-<name>-mode-all|groups|nobody` radios and a `permission-<name>-groups` group selector (visible in "Specific groups" mode)
 - `switch-reminders-enabled` - Enable reminders switch
 - `input-reminder-days` - Reminder days input
 - `input-reminder-frequency` - Reminder frequency input
-- `button-save-settings` - Save settings button
 
 ### Widget (Dashboard)
 - `widget-container` - Widget container

--- a/tests/e2e/fixtures/nextcloud.js
+++ b/tests/e2e/fixtures/nextcloud.js
@@ -283,11 +283,9 @@ export async function respondToAppointmentViaAPI(request, appointmentId, {
  * Cancel an appointment via the REST API (event will not take place)
  */
 export async function cancelAppointmentViaAPI(request, id, { username = 'admin', password = 'admin' } = {}) {
-	const resp = await resilientJson(() =>
-		request.post(`${API_BASE}/apps/attendance/api/appointments/${id}/cancel`, {
-			headers: authHeaders(username, password),
-		}),
-	)
+	const resp = await resilientJson(() => request.post(`${API_BASE}/apps/attendance/api/appointments/${id}/cancel`, {
+		headers: authHeaders(username, password),
+	}))
 	return resp.json()
 }
 
@@ -302,12 +300,10 @@ export async function updateAppointmentViaAPI(request, id, {
 	username = 'admin',
 	password = 'admin',
 } = {}) {
-	const resp = await resilientJson(() =>
-		request.put(`${API_BASE}/apps/attendance/api/appointments/${id}`, {
-			headers: authHeaders(username, password),
-			data: { name, description, startDatetime, endDatetime },
-		}),
-	)
+	const resp = await resilientJson(() => request.put(`${API_BASE}/apps/attendance/api/appointments/${id}`, {
+		headers: authHeaders(username, password),
+		data: { name, description, startDatetime, endDatetime },
+	}))
 	return resp.json()
 }
 
@@ -365,31 +361,31 @@ export async function saveAdminSettings(request, settings = {}) {
  * Returns { status, body }.
  */
 export async function syncOrgCalendarViaAPI(request) {
-	const resp = await resilientJson(() =>
-		request.post(`${API_BASE}/apps/attendance/api/admin/org-calendar/sync`, {
-			headers: authHeaders('admin', 'admin'),
-		}),
-	)
+	const resp = await resilientJson(() => request.post(`${API_BASE}/apps/attendance/api/admin/org-calendar/sync`, {
+		headers: authHeaders('admin', 'admin'),
+	}))
 	return { status: resp.status(), body: await resp.json() }
 }
 
 /**
- * Every permission key at its permissive default. Specs that restrict
- * permissions should spread this and override only the keys they are
- * actually about.
+ * Every permission key at the default of a fresh install: open to all users,
+ * except the additive ones (create own / respond for others), which grant
+ * nobody. Specs that restrict permissions should spread this and override
+ * only the keys they are actually about.
  */
 export const PERMISSIVE_PERMISSIONS = Object.freeze({
-	manage_appointments: [],
-	checkin: [],
-	see_response_overview: [],
-	see_response_counts: [],
-	see_comments: [],
-	create_appointments: [],
-	respond_for_others: [],
+	manage_appointments: { mode: 'all', groups: [] },
+	checkin: { mode: 'all', groups: [] },
+	see_response_overview: { mode: 'all', groups: [] },
+	see_response_counts: { mode: 'all', groups: [] },
+	see_comments: { mode: 'all', groups: [] },
+	self_checkin: { mode: 'all', groups: [] },
+	create_appointments: { mode: 'nobody', groups: [] },
+	respond_for_others: { mode: 'nobody', groups: [] },
 })
 
 /**
- * Reset admin settings to permissive defaults
+ * Reset admin settings to the defaults of a fresh install
  */
 export async function resetAdminSettings(request) {
 	return saveAdminSettings(request, {
@@ -620,6 +616,36 @@ export function waitForRespond(page) {
 	return page.waitForResponse((response) => /\/appointments\/\d+\/respond$/.test(new URL(response.url()).pathname)
 		&& response.request().method() === 'POST'
 		&& response.ok())
+}
+
+/**
+ * Wait for the admin settings auto-save POST. The settings page has no save
+ * button — arm this before the change and await it after.
+ */
+export function waitForSettingsSave(page) {
+	return page.waitForResponse((response) => response.url().includes('/api/admin/settings')
+		&& response.request().method() === 'POST'
+		&& response.ok())
+}
+
+/**
+ * On the admin settings page: switch a permission row to "Specific groups"
+ * and pick a group. Resolves once the auto-save POST went through.
+ */
+export async function restrictPermissionToGroup(page, permission, groupName) {
+	const row = page.locator(`[data-test="permission-${permission}"]`)
+	await expect(row).toBeVisible()
+	await row.getByText('Specific groups', { exact: true }).click()
+
+	const select = page.locator(`[data-test="permission-${permission}-groups"]`)
+	await expect(select).toBeVisible()
+	await select.getByRole('combobox').click()
+	const option = page.getByRole('option', { name: groupName })
+	await option.waitFor({ state: 'visible' })
+
+	const saved = waitForSettingsSave(page)
+	await option.click()
+	await saved
 }
 
 /**

--- a/tests/unit/Service/PermissionServiceTest.php
+++ b/tests/unit/Service/PermissionServiceTest.php
@@ -6,6 +6,7 @@ namespace OCA\Attendance\Tests\Unit\Service;
 
 use OCA\Attendance\Service\GuestService;
 use OCA\Attendance\Service\PermissionService;
+use OCP\IAppConfig;
 use OCP\IConfig;
 use OCP\IGroup;
 use OCP\IGroupManager;
@@ -18,6 +19,9 @@ use PHPUnit\Framework\TestCase;
 class PermissionServiceTest extends TestCase {
 	/** @var IConfig|MockObject */
 	private $config;
+
+	/** @var IAppConfig|MockObject */
+	private $appConfig;
 
 	/** @var IGroupManager|MockObject */
 	private $groupManager;
@@ -35,6 +39,7 @@ class PermissionServiceTest extends TestCase {
 
 	protected function setUp(): void {
 		$this->config = $this->createMock(IConfig::class);
+		$this->appConfig = $this->createMock(IAppConfig::class);
 		$this->groupManager = $this->createMock(IGroupManager::class);
 		$this->userSession = $this->createMock(IUserSession::class);
 		$this->userManager = $this->createMock(IUserManager::class);
@@ -42,6 +47,7 @@ class PermissionServiceTest extends TestCase {
 
 		$this->service = new PermissionService(
 			$this->config,
+			$this->appConfig,
 			$this->groupManager,
 			$this->userSession,
 			$this->userManager,
@@ -49,11 +55,31 @@ class PermissionServiceTest extends TestCase {
 		);
 	}
 
+	/**
+	 * Stub app config values by key: group lists live on IConfig, the
+	 * `*_mode` keys on IAppConfig. Unknown keys return their default, so
+	 * unset mode keys exercise the legacy fallback exactly like an
+	 * un-migrated install.
+	 */
+	private function configValues(array $values): void {
+		$this->config->method('getAppValue')
+			->willReturnCallback(
+				fn (string $app, string $key, string $default = '') => $values[$key] ?? $default,
+			);
+		$this->appConfig->method('getValueString')
+			->willReturnCallback(
+				fn (string $app, string $key, string $default = '') => $values[$key] ?? $default,
+			);
+	}
+
+	private function userInGroups(string $userId, array $groups): void {
+		$user = $this->createMock(IUser::class);
+		$this->userManager->method('get')->with($userId)->willReturn($user);
+		$this->groupManager->method('getUserGroupIds')->with($user)->willReturn($groups);
+	}
+
 	public function testGetRolesForPermission(): void {
-		$this->config->expects($this->once())
-			->method('getAppValue')
-			->with('attendance', 'permission_manage_appointments', '[]')
-			->willReturn('["admin","managers"]');
+		$this->configValues(['permission_manage_appointments' => '["admin","managers"]']);
 
 		$roles = $this->service->getRolesForPermission(PermissionService::PERMISSION_MANAGE_APPOINTMENTS);
 
@@ -61,10 +87,7 @@ class PermissionServiceTest extends TestCase {
 	}
 
 	public function testGetRolesForPermissionEmpty(): void {
-		$this->config->expects($this->once())
-			->method('getAppValue')
-			->with('attendance', 'permission_checkin', '[]')
-			->willReturn('[]');
+		$this->configValues([]);
 
 		$roles = $this->service->getRolesForPermission(PermissionService::PERMISSION_CHECKIN);
 
@@ -82,11 +105,85 @@ class PermissionServiceTest extends TestCase {
 		);
 	}
 
+	// --- modes ---
+
+	public function testModeAllGrantsWithoutGroupLookup(): void {
+		$this->configValues([
+			'permission_manage_appointments_mode' => 'all',
+			'permission_manage_appointments' => '["managers"]',
+		]);
+		$this->userManager->expects($this->never())->method('get');
+
+		$this->assertTrue($this->service->hasPermission('testuser', PermissionService::PERMISSION_MANAGE_APPOINTMENTS));
+	}
+
+	public function testModeNobodyDeniesEvenGroupMembers(): void {
+		$this->configValues([
+			'permission_checkin_mode' => 'nobody',
+			'permission_checkin' => '["staff"]',
+		]);
+		$this->userManager->expects($this->never())->method('get');
+
+		$this->assertFalse($this->service->hasPermission('testuser', PermissionService::PERMISSION_CHECKIN));
+	}
+
+	public function testModeGroupsWithEmptyListDeniesEveryone(): void {
+		$this->configValues(['permission_checkin_mode' => 'groups']);
+
+		$this->assertFalse($this->service->hasPermission('testuser', PermissionService::PERMISSION_CHECKIN));
+	}
+
+	public function testGetModeForPermissionExplicit(): void {
+		$this->configValues(['permission_checkin_mode' => 'nobody']);
+
+		$this->assertSame('nobody', $this->service->getModeForPermission(PermissionService::PERMISSION_CHECKIN));
+	}
+
+	public function testGetModeForPermissionLegacyFallbacks(): void {
+		$this->configValues(['permission_checkin' => '["staff"]']);
+
+		// Non-empty list → groups; empty + open → all; empty + additive → nobody
+		$this->assertSame('groups', $this->service->getModeForPermission(PermissionService::PERMISSION_CHECKIN));
+		$this->assertSame('all', $this->service->getModeForPermission(PermissionService::PERMISSION_MANAGE_APPOINTMENTS));
+		$this->assertSame('nobody', $this->service->getModeForPermission(PermissionService::PERMISSION_CREATE_APPOINTMENTS));
+		$this->assertSame('nobody', $this->service->getModeForPermission(PermissionService::PERMISSION_RESPOND_FOR_OTHERS));
+	}
+
+	public function testGetModeForPermissionInvalidStoredValueFallsBack(): void {
+		$this->configValues(['permission_checkin_mode' => 'bogus']);
+
+		$this->assertSame('all', $this->service->getModeForPermission(PermissionService::PERMISSION_CHECKIN));
+	}
+
+	public function testSetPermissionWritesModeAndGroups(): void {
+		$written = [];
+		$this->config->method('setAppValue')
+			->willReturnCallback(function (string $app, string $key, string $value) use (&$written): void {
+				$written[$key] = $value;
+			});
+		$this->appConfig->method('setValueString')
+			->willReturnCallback(function (string $app, string $key, string $value) use (&$written): bool {
+				$written[$key] = $value;
+				return true;
+			});
+
+		$this->service->setPermission(PermissionService::PERMISSION_CHECKIN, 'groups', ['staff']);
+
+		$this->assertSame('groups', $written['permission_checkin_mode']);
+		$this->assertSame('["staff"]', $written['permission_checkin']);
+	}
+
+	public function testSetPermissionRejectsInvalidMode(): void {
+		$this->expectException(\InvalidArgumentException::class);
+
+		$this->service->setPermission(PermissionService::PERMISSION_CHECKIN, 'everyone', []);
+	}
+
+	// --- legacy behavior via fallback (un-migrated installs) ---
+
 	public function testHasPermissionWhenNoRolesConfigured(): void {
-		// When no roles are configured, all users should have permission
-		$this->config->expects($this->once())
-			->method('getAppValue')
-			->willReturn('[]');
+		// When nothing is configured, all users should have permission
+		$this->configValues([]);
 
 		$result = $this->service->hasPermission('testuser', PermissionService::PERMISSION_MANAGE_APPOINTMENTS);
 
@@ -94,20 +191,8 @@ class PermissionServiceTest extends TestCase {
 	}
 
 	public function testHasPermissionWhenUserInRole(): void {
-		$this->config->expects($this->once())
-			->method('getAppValue')
-			->willReturn('["managers"]');
-
-		$user = $this->createMock(IUser::class);
-		$this->userManager->expects($this->once())
-			->method('get')
-			->with('testuser')
-			->willReturn($user);
-
-		$this->groupManager->expects($this->once())
-			->method('getUserGroupIds')
-			->with($user)
-			->willReturn(['managers', 'employees']);
+		$this->configValues(['permission_manage_appointments' => '["managers"]']);
+		$this->userInGroups('testuser', ['managers', 'employees']);
 
 		$result = $this->service->hasPermission('testuser', PermissionService::PERMISSION_MANAGE_APPOINTMENTS);
 
@@ -115,20 +200,8 @@ class PermissionServiceTest extends TestCase {
 	}
 
 	public function testHasPermissionWhenUserNotInRole(): void {
-		$this->config->expects($this->once())
-			->method('getAppValue')
-			->willReturn('["managers"]');
-
-		$user = $this->createMock(IUser::class);
-		$this->userManager->expects($this->once())
-			->method('get')
-			->with('testuser')
-			->willReturn($user);
-
-		$this->groupManager->expects($this->once())
-			->method('getUserGroupIds')
-			->with($user)
-			->willReturn(['employees']);
+		$this->configValues(['permission_manage_appointments' => '["managers"]']);
+		$this->userInGroups('testuser', ['employees']);
 
 		$result = $this->service->hasPermission('testuser', PermissionService::PERMISSION_MANAGE_APPOINTMENTS);
 
@@ -136,10 +209,7 @@ class PermissionServiceTest extends TestCase {
 	}
 
 	public function testHasPermissionWhenUserDoesNotExist(): void {
-		$this->config->expects($this->once())
-			->method('getAppValue')
-			->willReturn('["managers"]');
-
+		$this->configValues(['permission_manage_appointments' => '["managers"]']);
 		$this->userManager->expects($this->once())
 			->method('get')
 			->with('nonexistent')
@@ -160,9 +230,7 @@ class PermissionServiceTest extends TestCase {
 			->method('getUser')
 			->willReturn($user);
 
-		$this->config->expects($this->once())
-			->method('getAppValue')
-			->willReturn('[]');
+		$this->configValues([]);
 
 		$result = $this->service->currentUserHasPermission(PermissionService::PERMISSION_MANAGE_APPOINTMENTS);
 
@@ -204,9 +272,7 @@ class PermissionServiceTest extends TestCase {
 	}
 
 	public function testCanManageAppointments(): void {
-		$this->config->expects($this->once())
-			->method('getAppValue')
-			->willReturn('[]');
+		$this->configValues([]);
 
 		$result = $this->service->canManageAppointments('testuser');
 
@@ -214,9 +280,7 @@ class PermissionServiceTest extends TestCase {
 	}
 
 	public function testCanCheckin(): void {
-		$this->config->expects($this->once())
-			->method('getAppValue')
-			->willReturn('[]');
+		$this->configValues([]);
 
 		$result = $this->service->canCheckin('testuser');
 
@@ -224,9 +288,7 @@ class PermissionServiceTest extends TestCase {
 	}
 
 	public function testCanSeeResponseOverview(): void {
-		$this->config->expects($this->once())
-			->method('getAppValue')
-			->willReturn('[]');
+		$this->configValues([]);
 
 		$result = $this->service->canSeeResponseOverview('testuser');
 
@@ -234,7 +296,7 @@ class PermissionServiceTest extends TestCase {
 	}
 
 	public function testCanSeeResponseCountsOpenWhenUnconfigured(): void {
-		$this->config->method('getAppValue')->willReturn('[]');
+		$this->configValues([]);
 
 		$this->assertTrue($this->service->canSeeResponseCounts('testuser'));
 	}
@@ -242,37 +304,37 @@ class PermissionServiceTest extends TestCase {
 	public function testCanSeeResponseCountsFallsBackToOverviewPermission(): void {
 		// Counts restricted to "counters", overview open to everyone — the
 		// overview implies the counts, so the user still passes.
-		$this->config->method('getAppValue')
-			->willReturnMap([
-				['attendance', 'permission_see_response_counts', '[]', '["counters"]'],
-				['attendance', 'permission_see_response_overview', '[]', '[]'],
-			]);
-
-		$user = $this->createMock(IUser::class);
-		$this->userManager->method('get')->with('testuser')->willReturn($user);
-		$this->groupManager->method('getUserGroupIds')->with($user)->willReturn(['employees']);
+		$this->configValues(['permission_see_response_counts' => '["counters"]']);
+		$this->userInGroups('testuser', ['employees']);
 
 		$this->assertTrue($this->service->canSeeResponseCounts('testuser'));
 	}
 
 	public function testCanSeeResponseCountsDeniedWhenBothRestricted(): void {
-		$this->config->method('getAppValue')
-			->willReturnMap([
-				['attendance', 'permission_see_response_counts', '[]', '["counters"]'],
-				['attendance', 'permission_see_response_overview', '[]', '["managers"]'],
-			]);
-
-		$user = $this->createMock(IUser::class);
-		$this->userManager->method('get')->with('testuser')->willReturn($user);
-		$this->groupManager->method('getUserGroupIds')->with($user)->willReturn(['employees']);
+		$this->configValues([
+			'permission_see_response_counts' => '["counters"]',
+			'permission_see_response_overview' => '["managers"]',
+		]);
+		$this->userInGroups('testuser', ['employees']);
 
 		$this->assertFalse($this->service->canSeeResponseCounts('testuser'));
 	}
 
+	public function testCanSeeResponseCountsNobodyStillImpliedByOverview(): void {
+		// Explicit "nobody" on the counts keeps the structural implication:
+		// whoever sees the full summary necessarily sees the numbers in it.
+		$this->configValues([
+			'permission_see_response_counts_mode' => 'nobody',
+			'permission_see_response_overview_mode' => 'groups',
+			'permission_see_response_overview' => '["managers"]',
+		]);
+		$this->userInGroups('testuser', ['managers']);
+
+		$this->assertTrue($this->service->canSeeResponseCounts('testuser'));
+	}
+
 	public function testCanSeeComments(): void {
-		$this->config->expects($this->once())
-			->method('getAppValue')
-			->willReturn('[]');
+		$this->configValues([]);
 
 		$result = $this->service->canSeeComments('testuser');
 
@@ -280,33 +342,25 @@ class PermissionServiceTest extends TestCase {
 	}
 
 	public function testGetAllPermissionSettings(): void {
-		$this->config->expects($this->exactly(8))
-			->method('getAppValue')
-			->willReturnMap([
-				['attendance', 'permission_manage_appointments', '[]', '["admin"]'],
-				['attendance', 'permission_checkin', '[]', '["admin","staff"]'],
-				['attendance', 'permission_see_response_overview', '[]', '["admin"]'],
-				['attendance', 'permission_see_response_counts', '[]', '["everyone"]'],
-				['attendance', 'permission_see_comments', '[]', '["admin","managers"]'],
-				['attendance', 'permission_self_checkin', '[]', '["users"]'],
-				['attendance', 'permission_create_appointments', '[]', '["members"]'],
-				['attendance', 'permission_respond_for_others', '[]', '["staff"]']
-			]);
+		$this->configValues([
+			'permission_manage_appointments_mode' => 'groups',
+			'permission_manage_appointments' => '["admin"]',
+			'permission_checkin_mode' => 'all',
+			'permission_checkin' => '[]',
+			'permission_see_response_overview' => '["admin"]',
+			'permission_respond_for_others_mode' => 'nobody',
+		]);
 
 		$result = $this->service->getAllPermissionSettings();
 
-		$expected = [
-			PermissionService::PERMISSION_MANAGE_APPOINTMENTS => ['admin'],
-			PermissionService::PERMISSION_CHECKIN => ['admin', 'staff'],
-			PermissionService::PERMISSION_SEE_RESPONSE_OVERVIEW => ['admin'],
-			PermissionService::PERMISSION_SEE_RESPONSE_COUNTS => ['everyone'],
-			PermissionService::PERMISSION_SEE_COMMENTS => ['admin', 'managers'],
-			PermissionService::PERMISSION_SELF_CHECKIN => ['users'],
-			PermissionService::PERMISSION_CREATE_APPOINTMENTS => ['members'],
-			PermissionService::PERMISSION_RESPOND_FOR_OTHERS => ['staff']
-		];
-
-		$this->assertEquals($expected, $result);
+		$this->assertSame(PermissionService::ALL_PERMISSIONS, array_keys($result));
+		$this->assertEquals(['mode' => 'groups', 'groups' => ['admin']], $result[PermissionService::PERMISSION_MANAGE_APPOINTMENTS]);
+		$this->assertEquals(['mode' => 'all', 'groups' => []], $result[PermissionService::PERMISSION_CHECKIN]);
+		// No stored mode → legacy fallback derives it from the group list
+		$this->assertEquals(['mode' => 'groups', 'groups' => ['admin']], $result[PermissionService::PERMISSION_SEE_RESPONSE_OVERVIEW]);
+		$this->assertEquals(['mode' => 'all', 'groups' => []], $result[PermissionService::PERMISSION_SEE_COMMENTS]);
+		$this->assertEquals(['mode' => 'nobody', 'groups' => []], $result[PermissionService::PERMISSION_CREATE_APPOINTMENTS]);
+		$this->assertEquals(['mode' => 'nobody', 'groups' => []], $result[PermissionService::PERMISSION_RESPOND_FOR_OTHERS]);
 	}
 
 	public function testGuestUserIsBlockedFromManageAppointments(): void {
@@ -338,10 +392,8 @@ class PermissionServiceTest extends TestCase {
 
 	public function testGuestUserCanStillSelfCheckin(): void {
 		// SELF_CHECKIN is not in the guest hard-block list, so the regular
-		// group lookup runs. With no roles configured, the user gets access.
-		$this->config->expects($this->once())
-			->method('getAppValue')
-			->willReturn('[]');
+		// mode lookup runs. Unconfigured → all users, including guests.
+		$this->configValues([]);
 
 		$this->assertTrue(
 			$this->service->hasPermission('guestuser', PermissionService::PERMISSION_SELF_CHECKIN),
@@ -354,9 +406,7 @@ class PermissionServiceTest extends TestCase {
 			->with('regularuser')
 			->willReturn(false);
 
-		$this->config->expects($this->once())
-			->method('getAppValue')
-			->willReturn('[]');
+		$this->configValues([]);
 
 		$this->assertTrue(
 			$this->service->hasPermission('regularuser', PermissionService::PERMISSION_MANAGE_APPOINTMENTS),
@@ -378,29 +428,97 @@ class PermissionServiceTest extends TestCase {
 		);
 	}
 
-	public function testSetAllPermissionSettings(): void {
-		$permissions = [
-			'PERMISSION_MANAGE_APPOINTMENTS' => ['admin'],
-			'PERMISSION_CHECKIN' => ['admin', 'staff']
-		];
-
-		$callCount = 0;
-		$this->config->expects($this->exactly(2))
-			->method('setAppValue')
-			->willReturnCallback(function ($app, $key, $value) use (&$callCount) {
-				$callCount++;
-				if ($callCount === 1) {
-					$this->assertEquals('attendance', $app);
-					$this->assertEquals('permission_manage_appointments', $key);
-					$this->assertEquals('["admin"]', $value);
-				} elseif ($callCount === 2) {
-					$this->assertEquals('attendance', $app);
-					$this->assertEquals('permission_checkin', $key);
-					$this->assertEquals('["admin","staff"]', $value);
-				}
+	public function testSetAllPermissionSettingsExplicitShape(): void {
+		$written = [];
+		$this->config->method('setAppValue')
+			->willReturnCallback(function (string $app, string $key, string $value) use (&$written): void {
+				$written[$key] = $value;
+			});
+		$this->appConfig->method('setValueString')
+			->willReturnCallback(function (string $app, string $key, string $value) use (&$written): bool {
+				$written[$key] = $value;
+				return true;
 			});
 
-		$this->service->setAllPermissionSettings($permissions);
+		$this->service->setAllPermissionSettings([
+			'manage_appointments' => ['mode' => 'groups', 'groups' => ['admin']],
+			'checkin' => ['mode' => 'nobody', 'groups' => []],
+			'see_comments' => ['mode' => 'all', 'groups' => []],
+		]);
+
+		$this->assertSame('groups', $written['permission_manage_appointments_mode']);
+		$this->assertSame('["admin"]', $written['permission_manage_appointments']);
+		$this->assertSame('nobody', $written['permission_checkin_mode']);
+		$this->assertSame('[]', $written['permission_checkin']);
+		$this->assertSame('all', $written['permission_see_comments_mode']);
+	}
+
+	public function testSetAllPermissionSettingsLegacyListShape(): void {
+		$written = [];
+		$this->config->method('setAppValue')
+			->willReturnCallback(function (string $app, string $key, string $value) use (&$written): void {
+				$written[$key] = $value;
+			});
+		$this->appConfig->method('setValueString')
+			->willReturnCallback(function (string $app, string $key, string $value) use (&$written): bool {
+				$written[$key] = $value;
+				return true;
+			});
+
+		$this->service->setAllPermissionSettings([
+			'PERMISSION_MANAGE_APPOINTMENTS' => ['admin'],
+			'checkin' => [],
+			'respond_for_others' => [],
+		]);
+
+		// Bare lists carry the legacy semantics: non-empty → groups,
+		// empty + open → all, empty + additive → nobody.
+		$this->assertSame('groups', $written['permission_manage_appointments_mode']);
+		$this->assertSame('["admin"]', $written['permission_manage_appointments']);
+		$this->assertSame('all', $written['permission_checkin_mode']);
+		$this->assertSame('nobody', $written['permission_respond_for_others_mode']);
+	}
+
+	public function testSetAllPermissionSettingsIgnoresUnknownPermission(): void {
+		$this->config->expects($this->never())->method('setAppValue');
+		$this->appConfig->expects($this->never())->method('setValueString');
+
+		$this->service->setAllPermissionSettings([
+			'made_up_permission' => ['mode' => 'all', 'groups' => []],
+		]);
+	}
+
+	// --- getUsersWith ---
+
+	public function testGetUsersWithNobodyReturnsEmpty(): void {
+		$this->configValues(['permission_checkin_mode' => 'nobody']);
+		$this->userManager->expects($this->never())->method('search');
+
+		$this->assertSame([], $this->service->getUsersWith(PermissionService::PERMISSION_CHECKIN));
+	}
+
+	public function testGetUsersWithAllWalksEveryUser(): void {
+		$this->configValues(['permission_checkin_mode' => 'all']);
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('alice');
+		$this->userManager->expects($this->once())->method('search')->with('')->willReturn([$user]);
+
+		$this->assertSame(['alice'], $this->service->getUsersWith(PermissionService::PERMISSION_CHECKIN));
+	}
+
+	public function testGetUsersWithGroupsCollectsMembers(): void {
+		$this->configValues([
+			'permission_checkin_mode' => 'groups',
+			'permission_checkin' => '["staff"]',
+		]);
+		$member = $this->createMock(IUser::class);
+		$member->method('getUID')->willReturn('bob');
+		$group = $this->createMock(IGroup::class);
+		$group->method('getUsers')->willReturn([$member]);
+		$this->groupManager->method('get')->with('staff')->willReturn($group);
+		$this->userManager->expects($this->never())->method('search');
+
+		$this->assertSame(['bob'], $this->service->getUsersWith(PermissionService::PERMISSION_CHECKIN));
 	}
 
 	private function makeAppointment(?array $organizers): \OCA\Attendance\Db\Appointment {
@@ -409,64 +527,54 @@ class PermissionServiceTest extends TestCase {
 		return $appointment;
 	}
 
-	// --- create_appointments: empty config must mean "nobody additional" ---
+	// --- create_appointments: unconfigured must mean "nobody additional" ---
 
 	public function testCreateAppointmentsEmptyConfigDeniesNonManagers(): void {
 		$this->guestService->method('isGuestUser')->willReturn(false);
-		// Both manage_appointments and create_appointments configured non-empty
-		// resp. empty: user is in neither group.
-		$this->config->method('getAppValue')
-			->willReturnMap([
-				['attendance', 'permission_manage_appointments', '[]', '["admins"]'],
-				['attendance', 'permission_create_appointments', '[]', '[]'],
-			]);
-		$user = $this->createMock(IUser::class);
-		$this->userManager->method('get')->willReturn($user);
-		$this->groupManager->method('getUserGroupIds')->willReturn(['members']);
+		// manage_appointments configured non-empty, create_appointments
+		// unconfigured: user is in neither group.
+		$this->configValues(['permission_manage_appointments' => '["admins"]']);
+		$this->userInGroups('regularuser', ['members']);
 
 		$this->assertFalse($this->service->canCreateAppointments('regularuser'));
 	}
 
 	public function testCreateAppointmentsGrantedViaCreateGroup(): void {
 		$this->guestService->method('isGuestUser')->willReturn(false);
-		$this->config->method('getAppValue')
-			->willReturnMap([
-				['attendance', 'permission_manage_appointments', '[]', '["admins"]'],
-				['attendance', 'permission_create_appointments', '[]', '["members"]'],
-			]);
-		$user = $this->createMock(IUser::class);
-		$this->userManager->method('get')->willReturn($user);
-		$this->groupManager->method('getUserGroupIds')->willReturn(['members']);
+		$this->configValues([
+			'permission_manage_appointments' => '["admins"]',
+			'permission_create_appointments' => '["members"]',
+		]);
+		$this->userInGroups('regularuser', ['members']);
 
 		$this->assertTrue($this->service->canCreateAppointments('regularuser'));
 	}
 
 	public function testCreateAppointmentsImpliedByManagePermission(): void {
 		$this->guestService->method('isGuestUser')->willReturn(false);
-		// manage_appointments unconfigured → empty = everyone manages = everyone creates
-		$this->config->method('getAppValue')->willReturn('[]');
+		// manage_appointments unconfigured → everyone manages = everyone creates
+		$this->configValues([]);
 
 		$this->assertTrue($this->service->canCreateAppointments('regularuser'));
 	}
 
 	public function testCreateAppointmentsBlockedForGuests(): void {
 		$this->guestService->method('isGuestUser')->with('guestuser')->willReturn(true);
-		$this->config->method('getAppValue')
-			->willReturnMap([
-				['attendance', 'permission_manage_appointments', '[]', '["admins"]'],
-				['attendance', 'permission_create_appointments', '[]', '["guest_app"]'],
-			]);
+		$this->configValues([
+			'permission_manage_appointments' => '["admins"]',
+			'permission_create_appointments' => '["guest_app"]',
+		]);
 
 		$this->assertFalse($this->service->canCreateAppointments('guestuser'));
 	}
 
-	// --- respond_for_others: empty config must mean "nobody", not even managers ---
+	// --- respond_for_others: unconfigured must mean "nobody", not even managers ---
 
 	public function testRespondForOthersEmptyConfigDeniesEveryone(): void {
 		$this->guestService->method('isGuestUser')->willReturn(false);
 		// Unconfigured: manage_appointments would default to "everyone", but
-		// respond_for_others is closed-when-unconfigured — nobody gets it.
-		$this->config->method('getAppValue')->willReturn('[]');
+		// respond_for_others defaults to nobody.
+		$this->configValues([]);
 
 		$this->assertFalse($this->service->canRespondForOthers('regularuser'));
 	}
@@ -475,14 +583,11 @@ class PermissionServiceTest extends TestCase {
 		$this->guestService->method('isGuestUser')->willReturn(false);
 		// User is a manager, but respond_for_others is granted to a group
 		// they are not in — manage rights must not bleed through.
-		$this->config->method('getAppValue')
-			->willReturnMap([
-				['attendance', 'permission_manage_appointments', '[]', '["managers"]'],
-				['attendance', 'permission_respond_for_others', '[]', '["office"]'],
-			]);
-		$user = $this->createMock(IUser::class);
-		$this->userManager->method('get')->willReturn($user);
-		$this->groupManager->method('getUserGroupIds')->willReturn(['managers']);
+		$this->configValues([
+			'permission_manage_appointments' => '["managers"]',
+			'permission_respond_for_others' => '["office"]',
+		]);
+		$this->userInGroups('manageruser', ['managers']);
 
 		$this->assertTrue($this->service->canManageAppointments('manageruser'));
 		$this->assertFalse($this->service->canRespondForOthers('manageruser'));
@@ -490,13 +595,8 @@ class PermissionServiceTest extends TestCase {
 
 	public function testRespondForOthersGrantedViaConfiguredGroup(): void {
 		$this->guestService->method('isGuestUser')->willReturn(false);
-		$this->config->method('getAppValue')
-			->willReturnMap([
-				['attendance', 'permission_respond_for_others', '[]', '["office"]'],
-			]);
-		$user = $this->createMock(IUser::class);
-		$this->userManager->method('get')->willReturn($user);
-		$this->groupManager->method('getUserGroupIds')->willReturn(['office']);
+		$this->configValues(['permission_respond_for_others' => '["office"]']);
+		$this->userInGroups('officeuser', ['office']);
 
 		$this->assertTrue($this->service->canRespondForOthers('officeuser'));
 	}
@@ -542,10 +642,7 @@ class PermissionServiceTest extends TestCase {
 
 	public function testCanManageAppointmentTrueForOrganizerWithoutGlobalPermission(): void {
 		$this->guestService->method('isGuestUser')->willReturn(false);
-		$this->config->method('getAppValue')
-			->willReturnMap([
-				['attendance', 'permission_manage_appointments', '[]', '["admins"]'],
-			]);
+		$this->configValues(['permission_manage_appointments' => '["admins"]']);
 		$user = $this->createMock(IUser::class);
 		$this->userManager->method('get')->willReturn($user);
 		$this->groupManager->method('getUserGroupIds')->willReturn(['members']);
@@ -557,10 +654,7 @@ class PermissionServiceTest extends TestCase {
 
 	public function testCanSeeResponseOverviewForOrganizer(): void {
 		$this->guestService->method('isGuestUser')->willReturn(false);
-		$this->config->method('getAppValue')
-			->willReturnMap([
-				['attendance', 'permission_see_response_overview', '[]', '["admins"]'],
-			]);
+		$this->configValues(['permission_see_response_overview' => '["admins"]']);
 		$user = $this->createMock(IUser::class);
 		$this->userManager->method('get')->willReturn($user);
 		$this->groupManager->method('getUserGroupIds')->willReturn(['members']);


### PR DESCRIPTION
## Summary
Refactor the admin settings permissions interface to use explicit access modes (`all`, `groups`, `nobody`) instead of implicitly deriving them from group list configuration. This makes permission semantics clearer and enables better UX with dedicated UI controls for each mode.

## Key Changes

### Frontend
- **New `PermissionRow` component** (`src/components/admin/PermissionRow.vue`): Replaces repetitive permission subsections with a reusable component that displays three radio buttons for access modes and a group selector when "Specific groups" is chosen
- **Reorganized admin settings layout**: Moved permissions section to the top with a navigation anchor menu; restructured self-check-in settings into a dedicated section; improved visual hierarchy with consistent section IDs for deep linking
- **Auto-save UI**: Removed explicit save button; settings now post individually as they change (already implemented in backend)
- **Updated e2e tests**: Added `restrictPermissionToGroup()` helper and `waitForSettingsSave()` to handle auto-saving behavior; simplified test code by reusing the helper

### Backend
- **Enhanced `PermissionService`**: 
  - Added `IAppConfig` dependency for storing explicit mode values (`permission_<name>_mode`)
  - New methods: `getModeForPermission()`, `setPermission()` with mode validation
  - Per-request caching for roles and modes to avoid repeated JSON decoding in list endpoints
  - Legacy fallback logic: derives mode from existing group list configuration for un-migrated installs
  - Constants for modes (`MODE_ALL`, `MODE_GROUPS`, `MODE_NOBODY`) and all permission names
- **Migration `Version000018Date20260803120000`**: Backfills explicit modes for all permissions based on current configuration, ensuring effective access does not change during upgrade
- **Updated `AdminController`**: Modified `saveSettings()` to accept partial permission payloads with both mode and groups; updated docblock to reflect new structure
- **Updated `ConfigService`**: Removed deprecated `getPermissionRoles()` method (now in `PermissionService`)

### API & Documentation
- **OpenAPI schema updates**: Changed `PermissionSettings` structure from `additionalProperties: array<string>` to `additionalProperties: PermissionSetting` where `PermissionSetting` has `mode` and `groups` properties
- **Response definitions**: Updated `AttendancePermissionSettings` type to reflect new structure

## Implementation Details

- **Backward compatibility**: The migration and legacy fallback ensure existing installs continue to work without manual intervention. Un-migrated installs derive modes on-the-fly from group lists.
- **Caching strategy**: `rolesCache` and `modeCache` prevent repeated JSON decoding and mode lookups during request processing (important for list endpoints that check permissions per item).
- **Mode semantics**:
  - `all`: Everyone has access (no group lookup needed)
  - `groups`: Only users in selected groups have access
  - `nobody`: Nobody has access (no group lookup needed)
- **Default policies**: Additive permissions (`create_appointments`, `respond_for_others`) default to `nobody` when unconfigured; others default to `all`
- **UI improvements**: Radio buttons make the three-state choice explicit; group selector only appears when "Specific groups" is selected; warning notes clarify implications (e.g., "currently nobody is granted this" when no groups selected)

## Testing
- Unit tests updated to use new `configValues()` helper and `userInGroups()` helper for cleaner test setup
- New test cases for mode handling, legacy fallback, and mode validation
- E2E tests simplified with `restrictPermissionToGroup()` helper that handles the auto-save flow

https://claude.ai/code/session_01XTqmhSSkwFgHqkkiGoTumT