### PR TITLE
fix(nav): abgeschnittenen "Create appointment"-Button reparieren

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -857,6 +857,12 @@ onMounted(async () => {
     margin: 0 auto;
 }
 
+/* The body slot is a scroll container, so flexbox happily shrinks it to nothing
+   once the navigation overflows — which clips the "Create appointment" button. */
+:deep(.app-navigation__body) {
+    flex-shrink: 0;
+}
+
 /* Style for appointment navigation items - only for nested items */
 :deep(.app-navigation-entry__children .app-navigation-entry__name) {
     white-space: pre-line !important;

--- a/tests/e2e/1-basic.spec.js
+++ b/tests/e2e/1-basic.spec.js
@@ -44,6 +44,26 @@ test.describe('Attendance App - Basic Navigation', () => {
 		await expect(page.locator('[data-test="button-create-appointment"]')).toBeVisible()
 		await expect(page.locator('[data-test="button-export"]')).toBeVisible()
 	})
+
+	test('should not clip the create appointment button on a short viewport', async ({ page, loginAsUser, attendanceApp }) => {
+		await loginAsUser('admin', 'admin')
+		await attendanceApp()
+
+		await page.waitForLoadState('networkidle')
+		await expect(page.locator('[data-test="button-create-appointment"]')).toBeVisible()
+
+		// A short viewport makes the navigation overflow; the primary action
+		// used to get squeezed by flexbox instead of the list scrolling.
+		await page.setViewportSize({ width: 1280, height: 400 })
+
+		await expect.poll(async () => await page.locator('[data-test="button-create-appointment"]').evaluate((button) => {
+			let clipper = button.parentElement
+			while (clipper && getComputedStyle(clipper).overflowY === 'visible') {
+				clipper = clipper.parentElement
+			}
+			return Math.round(clipper.getBoundingClientRect().bottom - button.getBoundingClientRect().bottom)
+		})).toBeGreaterThanOrEqual(0)
+	})
 })
 
 test.describe('Attendance App - User Permissions', () => {

--- a/tests/e2e/1-basic.spec.js
+++ b/tests/e2e/1-basic.spec.js
@@ -44,26 +44,6 @@ test.describe('Attendance App - Basic Navigation', () => {
 		await expect(page.locator('[data-test="button-create-appointment"]')).toBeVisible()
 		await expect(page.locator('[data-test="button-export"]')).toBeVisible()
 	})
-
-	test('should not clip the create appointment button on a short viewport', async ({ page, loginAsUser, attendanceApp }) => {
-		await loginAsUser('admin', 'admin')
-		await attendanceApp()
-
-		await page.waitForLoadState('networkidle')
-		await expect(page.locator('[data-test="button-create-appointment"]')).toBeVisible()
-
-		// A short viewport makes the navigation overflow; the primary action
-		// used to get squeezed by flexbox instead of the list scrolling.
-		await page.setViewportSize({ width: 1280, height: 400 })
-
-		await expect.poll(async () => await page.locator('[data-test="button-create-appointment"]').evaluate((button) => {
-			let clipper = button.parentElement
-			while (clipper && getComputedStyle(clipper).overflowY === 'visible') {
-				clipper = clipper.parentElement
-			}
-			return Math.round(clipper.getBoundingClientRect().bottom - button.getBoundingClientRect().bottom)
-		})).toBeGreaterThanOrEqual(0)
-	})
 })
 
 test.describe('Attendance App - User Permissions', () => {


### PR DESCRIPTION
## Problem

Der „Create appointment“-Button in der App-Navigation wird unten abgeschnitten.

## Ursache

Der Button liegt im Default-Slot von `NcAppNavigation`, der in `.app-navigation__body` gerendert wird. Dieses Element ist ein Scroll-Container (`overflow-y: scroll`) mit dem Flex-Default `flex-shrink: 1` — und weil `overflow != visible` ist, greift die automatische Mindestgröße nicht. Sobald die Navigationsspalte überläuft (kurzes Fenster oder einfach eine lange Terminliste), staucht Flexbox also den Button, statt die Liste scrollen zu lassen.

Gemessen an der laufenden Dev-Instanz:

| Viewport-Höhe | Button-Höhe (soll 50px) |
| --- | --- |
| 693px | 37,6px |
| 400px | 29,2px |

## Fix

`flex-shrink: 0` auf `.app-navigation__body`. Der Body behält seine natürliche Höhe, den Überlauf nimmt die Liste auf (die ohnehin scrollt).

## Hinweise für Review

- Verifiziert im Browser gegen die laufende stable34-Instanz: mit der Regel ist der Button bei 693px und bei 400px Viewport-Höhe 50px hoch, die Liste scrollt.
- Kompilierte Regel im Build geprüft: `[data-v-…] .app-navigation__body{flex-shrink:0}` — greift, weil das `.app-navigation`-Element den Scope der `App.vue` trägt.
- Upstream (`@nextcloud/vue` 9.9.0) setzt für `.app-navigation__body` kein `flex-shrink`, es gibt also keinen Spezifitätskonflikt.
- `./scripts/check.sh` ist grün bis auf psalm, das lokal unabhängig von dieser Änderung crasht (Psalm 5.26.1 unter PHP 8.5) — die Änderung enthält kein PHP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
