### PR TITLE
fix: creator without manage permission stays organizer, category icon in filter chips

### DIFF
--- a/lib/Service/AppointmentService.php
+++ b/lib/Service/AppointmentService.php
@@ -135,9 +135,15 @@ class AppointmentService {
 		$appointment->setResponseDeadline($deadlineFormatted);
 		// The creator freely chooses the initial organizer list; when the client
 		// sends nothing, the creator becomes the sole organizer.
+		$requestedOrganizers = $organizers ?? [$createdBy];
+		// Without manage permission, being an organizer is the creator's only
+		// handle on the appointment — a copy would carry only foreign organizers.
+		if (!$this->permissionService->canManageAppointments($createdBy)) {
+			$requestedOrganizers[] = $createdBy;
+		}
 		$this->applyOrganizerChange(
 			$appointment,
-			$this->normalizeOrganizers($organizers ?? [$createdBy]),
+			$this->normalizeOrganizers($requestedOrganizers),
 			$createdBy,
 			true,
 		);

--- a/src/views/AllAppointments.vue
+++ b/src/views/AllAppointments.vue
@@ -174,11 +174,12 @@
 				<NcChip
 					v-for="category in selectedCategoryChips"
 					:key="category.id"
-					:text="t('attendance', 'Category: {category}', { category: category.name })"
 					@close="toggleCategoryFilter(category.id)">
-					<template #icon>
+					<span class="filter-bar__category-chip">
+						<span v-if="categoryChipLabel.before">{{ categoryChipLabel.before }}</span>
 						<component :is="categoryIconComponent(category.icon)" :size="16" />
-					</template>
+						<span>{{ category.name }}{{ categoryChipLabel.after }}</span>
+					</span>
 				</NcChip>
 			</div>
 		</div>
@@ -232,6 +233,7 @@
 
 <script setup>
 import axios from '@nextcloud/axios'
+import { translate as t } from '@nextcloud/l10n'
 import { generateUrl } from '@nextcloud/router'
 import { NcButton, NcChip, NcPopover } from '@nextcloud/vue'
 import { create as createConfetti } from 'canvas-confetti'
@@ -439,6 +441,14 @@ const availableCategories = computed(() => {
 const selectedCategoryChips = computed(() => selectedCategoryIds.value
 	.map((id) => categories.find((category) => category.id === id))
 	.filter(Boolean))
+
+// Split the label at its placeholder so the icon sits next to the category
+// name instead of at the chip's leading edge — one msgid, translators keep
+// the ordering.
+const categoryChipLabel = computed(() => {
+	const [before = '', after = ''] = t('attendance', 'Category: {category}').split('{category}')
+	return { before: before.trim(), after: after.trim() }
+})
 
 function toggleCategoryFilter(categoryId) {
 	selectedCategoryIds.value = selectedCategoryIds.value.includes(categoryId)
@@ -849,6 +859,12 @@ onMounted(async () => {
 		flex-wrap: wrap;
 		align-items: center;
 		gap: 6px;
+	}
+
+	&__category-chip {
+		display: inline-flex;
+		align-items: center;
+		gap: 4px;
 	}
 
 	&__active-label {

--- a/src/views/AllAppointments.vue
+++ b/src/views/AllAppointments.vue
@@ -178,7 +178,8 @@
 					<span class="filter-bar__category-chip">
 						<span v-if="categoryChipLabel.before">{{ categoryChipLabel.before }}</span>
 						<component :is="categoryIconComponent(category.icon)" :size="16" />
-						<span>{{ category.name }}{{ categoryChipLabel.after }}</span>
+						<span>{{ category.name }}</span>
+						<span v-if="categoryChipLabel.after">{{ categoryChipLabel.after }}</span>
 					</span>
 				</NcChip>
 			</div>
@@ -442,9 +443,8 @@ const selectedCategoryChips = computed(() => selectedCategoryIds.value
 	.map((id) => categories.find((category) => category.id === id))
 	.filter(Boolean))
 
-// Split the label at its placeholder so the icon sits next to the category
-// name instead of at the chip's leading edge — one msgid, translators keep
-// the ordering.
+// Deliberately unsubstituted: splitting the translated label at its own
+// placeholder puts the icon next to the name, in the translator's order.
 const categoryChipLabel = computed(() => {
 	const [before = '', after = ''] = t('attendance', 'Category: {category}').split('{category}')
 	return { before: before.trim(), after: after.trim() }

--- a/src/views/AppointmentForm.vue
+++ b/src/views/AppointmentForm.vue
@@ -626,7 +626,7 @@ const deadlineRelativeValue = computed(() => {
 
 const deadlineRelativeOffsetMs = computed(() => deadlineRelativeValue.value * UNIT_MS[deadlineRelativeUnit.value])
 
-const { capabilities, loadPermissions } = usePermissions()
+const { permissions, capabilities, loadPermissions } = usePermissions()
 
 const visibilityItems = ref([])
 const searchResults = ref([])
@@ -885,17 +885,23 @@ watch(organizerItems, (selected) => {
 	formData.organizers = selected.map((item) => item.value)
 })
 
-// Prefill the current user as organizer for new appointments — matches the
-// server default and makes the delegation visible in the form.
-function prefillCurrentUserAsOrganizer() {
+function currentUserOrganizerItem() {
 	const currentUser = window.OC?.getCurrentUser?.()
-	if (!currentUser?.uid) return
-	organizerItems.value = [{
+	if (!currentUser?.uid) return null
+	return {
 		id: `user:${currentUser.uid}`,
 		value: currentUser.uid,
 		label: currentUser.displayName || currentUser.uid,
 		type: 'user',
-	}]
+	}
+}
+
+// Prefill the current user as organizer for new appointments — matches the
+// server default and makes the delegation visible in the form.
+function prefillCurrentUserAsOrganizer() {
+	const item = currentUserOrganizerItem()
+	if (!item) return
+	organizerItems.value = [item]
 }
 
 /**
@@ -1050,6 +1056,17 @@ async function loadAppointment() {
 			label: o.label,
 			type: 'user',
 		}))
+		// Without manage permission, organizer is the copier's only handle on
+		// the new appointment; the server enforces this too, show it up front.
+		const self = currentUserOrganizerItem()
+		if (
+			props.mode === 'copy'
+			&& !permissions.canManageAppointments
+			&& self
+			&& !organizerList.some((o) => o.value === self.value)
+		) {
+			organizerList.push(self)
+		}
 		organizerItems.value = organizerList
 		organizerSearchResults.value = [...organizerList]
 		if (props.mode === 'edit') {

--- a/tests/unit/Service/AppointmentServiceTest.php
+++ b/tests/unit/Service/AppointmentServiceTest.php
@@ -1165,6 +1165,7 @@ class AppointmentServiceTest extends TestCase {
 	}
 
 	public function testCreateAppointmentFiltersUnknownUsersAndGuestsFromOrganizers(): void {
+		$this->permissionService->method('canManageAppointments')->willReturn(true);
 		$this->userManager->method('get')
 			->willReturnCallback(function (string $uid) {
 				return $uid === 'ghost' ? null : $this->createMock(\OCP\IUser::class);
@@ -1183,6 +1184,40 @@ class AppointmentServiceTest extends TestCase {
 		);
 
 		$this->assertEquals(['alice', 'bob'], $result->getOrganizersList());
+	}
+
+	public function testCreateAppointmentAddsNonManagerCreatorToOrganizers(): void {
+		$this->permissionService->method('canManageAppointments')->willReturn(false);
+		$this->expectKnownUsers(['alice', 'bob']);
+		$this->appointmentMapper->method('insert')->willReturnCallback(function (Appointment $a) {
+			$a->setId(1);
+			return $a;
+		});
+
+		$result = $this->service->createAppointment(
+			'Meeting', '', '2024-01-15T10:00:00Z', '2024-01-15T11:00:00Z', 'bob',
+			[], [], [], false, null, null, null, null, null,
+			['alice'],
+		);
+
+		$this->assertEquals(['alice', 'bob'], $result->getOrganizersList());
+	}
+
+	public function testCreateAppointmentLeavesManagerCreatorOutOfOrganizers(): void {
+		$this->permissionService->method('canManageAppointments')->willReturn(true);
+		$this->expectKnownUsers(['alice', 'admin']);
+		$this->appointmentMapper->method('insert')->willReturnCallback(function (Appointment $a) {
+			$a->setId(1);
+			return $a;
+		});
+
+		$result = $this->service->createAppointment(
+			'Meeting', '', '2024-01-15T10:00:00Z', '2024-01-15T11:00:00Z', 'admin',
+			[], [], [], false, null, null, null, null, null,
+			['alice'],
+		);
+
+		$this->assertEquals(['alice'], $result->getOrganizersList());
 	}
 
 	private function setUpOrganizerUpdate(array $currentOrganizers, bool $actorIsManager): Appointment {


### PR DESCRIPTION
## Problem

Die Kopieren-Aktion hängt an `canCreateAppointments` (`AppointmentActionsMenu.vue:79`), ist also auch für Nutzer sichtbar, die nur das `create_appointments`-Recht haben. Der Kopier-Modus übernimmt die Organisatoren-Liste 1:1 aus dem Quelltermin, und `createAppointment()` setzte den Ersteller nur dann als Organisator, wenn der Client gar keine Liste schickte.

`createdBy` verleiht für sich genommen keine Rechte — Bearbeiten und Löschen hängen an `manage_appointments` **oder** einem Eintrag in der Organisatoren-Liste (`PermissionService::isOrganizer`). Ein reiner „create"-Nutzer konnte damit einen fremden Termin kopieren und den neuen Termin danach weder ändern noch löschen.

## Änderung

- `AppointmentService::createAppointment`: Wer beim Anlegen keine Manage-Berechtigung hat, bleibt immer in der Organisatoren-Liste. Die Prüfung sitzt in der Methode, durch die alle Clients und auch der Bulk-Endpunkt laufen, greift also auch für ältere Versionen der Mobile-App. Manager sind ausgenommen — sie dürfen weiterhin Termine für andere anlegen, ohne selbst einzurücken.
- `AppointmentForm.vue`: Im Kopier-Modus wird der aktuelle Nutzer sichtbar in die Organisatoren-Auswahl gesetzt, wenn ihm die Manage-Berechtigung fehlt. Der Server erzwingt das ohnehin, aber so sieht man vor dem Speichern, was passiert.
- Zwei neue Unit-Tests für beide Zweige der neuen Bedingung. Ein bestehender Organizer-Test pinnt jetzt explizit `canManageAppointments = true`, da sein Ersteller sonst die neue Regel mitnehmen würde.

Keine API- oder Schema-Änderung, keine neue Capability: Das Verhalten wird nur enger, alte Clients bleiben kompatibel. Der passende Client-seitige Prefill für die Flutter-App liegt in luflow/attendance-flutter#73.

## Zweiter Commit: Kategorie-Icon in den aktiven Filter-Chips

`NcChip` rendert den `#icon`-Slot ganz am Anfang, also stand das Icon vor dem Label: „🎵 Kategorie: Probe". Damit sah es aus, als gehörte es zum Filtertyp statt zur Kategorie. Der Chip rendert das Label jetzt selbst und teilt es an seinem eigenen Platzhalter, sodass das Icon direkt vor dem Namen steht: „Kategorie: 🎵 Probe".

Die msgid `Category: {category}` bleibt unverändert und vollständig — der Split passiert auf dem bereits übersetzten String, eine Sprache, die den Platzhalter vorzieht, funktioniert also weiter. Kein neuer String, kein Transifex-Umlauf.

## Bewusst offengelassen

`bulkCreate` prüft `canManageAppointments()` jetzt pro Termin statt einmal pro Request. Ein Durchreichen als Parameter würde die Garantie aufweichen (ein Aufrufer könnte falsch übergeben), und die darunterliegenden `userManager->get()`/`getUserGroupIds()`-Aufrufe cached Nextcloud bereits pro Request. Ein Ergebnis-Cache in `PermissionService::hasPermission` wäre die saubere Lösung, gehört aber in eine eigene Änderung.

## Test

- `npx eslint`, `npx stylelint`, `npm run build` — grün
- `php -l` auf den geänderten Dateien — grün
- **Nicht gelaufen:** PHPUnit, Psalm und php-cs-fixer — `composer install` war in dieser Umgebung nicht möglich, die Gates laufen also erstmals in CI.