### PR TITLE
chore(screenshots): add --reopen-running to the demo seeder

### DIFF
--- a/.claude/skills/screenshots/SKILL.md
+++ b/.claude/skills/screenshots/SKILL.md
@@ -51,6 +51,11 @@ It is **non-destructive** — it only deletes and re-inserts IDs 101-199, a
 reserved range. Existing appointments survive. Re-running is safe and
 idempotent.
 
+The Flutter repo's `scripts/capture_screenshots.sh` calls **this same file**
+by path (`$ATTENDANCE_SERVER_REPO/.claude/skills/screenshots/scripts/seed_demo_data.py`)
+so the phone screenshots show the same choir. Moving or renaming it breaks
+that repo — adjust both sides together.
+
 Times are computed relative to the instance clock, so re-running months later
 still yields sensible data. Rehearsals land on Tuesdays, concerts on Saturdays,
 and one appointment is **running right now** (started 90 min ago) — that is what
@@ -69,11 +74,12 @@ appointment (ID 104) will flip to "Closed" between seeding and shooting.
 Re-open it immediately before each shot that needs it live:
 
 ```bash
-CFG=$(docker exec master-stable34-1 php -r 'require "/var/www/html/config/config.php"; echo $CONFIG["dbuser"],"|",$CONFIG["dbpassword"],"|",$CONFIG["dbname"];')
-DBU=${CFG%%|*}; REST=${CFG#*|}; DBP=${REST%%|*}; DBN=${REST##*|}
-docker exec -i master-database-mysql-1 mysql -u"$DBU" -p"$DBP" "$DBN" \
-  -e "UPDATE oc_att_appointments SET closed_at=NULL WHERE id=104;"
+python3 .claude/skills/screenshots/scripts/seed_demo_data.py --reopen-running
 ```
+
+That touches nothing but `closed_at` of whatever seeded appointment is running
+at this moment, so it is safe to fire repeatedly — the Flutter capture script
+runs it on a 20-second loop for the length of its build.
 
 A closed first card also changes the list geometry (no response buttons, no
 deadline line → shorter card), so re-measure the cut after re-opening.

--- a/.claude/skills/screenshots/scripts/seed_demo_data.py
+++ b/.claude/skills/screenshots/scripts/seed_demo_data.py
@@ -455,6 +455,18 @@ def db_config(container: str) -> dict:
         sys.exit(f"could not read DB credentials from config.php:\n{out}")
 
 
+def mysql(container: str, cfg: dict, sql: list[str]) -> None:
+    cmd = ["docker", "exec", "-i", container, "mysql",
+           f"-u{cfg['dbuser']}", f"-p{cfg['dbpassword']}", cfg["dbname"]]
+    res = subprocess.run(cmd, input="\n".join(sql), capture_output=True, text=True)
+    err = "\n".join(l for l in res.stderr.splitlines()
+                    if "Using a password" not in l).strip()
+    if res.returncode != 0:
+        sys.exit(f"seeding failed:\n{err}")
+    if err:
+        print(err)
+
+
 def instance_now(container: str) -> dt.datetime:
     """UTC clock of the instance — appointment times must line up with it."""
     out = run(["docker", "exec", container, "date", "-u", "+%Y-%m-%d %H:%M:%S"])
@@ -792,6 +804,11 @@ def main() -> None:
                    help="also seed one appointment per designed card state "
                         "(open/maybe/no, closed + scheduled, closed + not "
                         "scheduled, cancelled, unanswered with deadline)")
+    p.add_argument("--reopen-running", action="store_true",
+                   help="re-open the seeded appointment that is running right "
+                        "now (autoCloseExpired() closes it minutes after "
+                        "seeding) and exit, changing nothing else. Cheap "
+                        "enough to call in a loop while shooting.")
     p.add_argument("--lang", choices=["en", "de"], default="en",
                    help="language of the seeded data AND the admin UI. "
                         "'en' for the app store set (the store cannot take "
@@ -803,6 +820,16 @@ def main() -> None:
     names = docker_names()
     nc = args.nc_container or autodetect(names, ["stable", "nextcloud-1"], "Nextcloud")
     db = args.db_container or autodetect(names, ["database", "mysql", "mariadb"], "database")
+
+    if args.reopen_running:
+        now = instance_now(nc)
+        stamp = f"{now:%Y-%m-%d %H:%M:%S}"
+        mysql(db, db_config(nc), [
+            f"UPDATE oc_att_appointments SET closed_at = NULL "
+            f"WHERE id BETWEEN {ID_BASE} AND {ID_MAX} AND closed_at IS NOT NULL "
+            f"AND start_datetime <= '{stamp}' AND end_datetime >= '{stamp}';"
+        ])
+        return
 
     users = set(json.loads(occ(nc, "user:list", "--output=json")).keys())
     now = instance_now(nc)
@@ -820,16 +847,7 @@ def main() -> None:
     if not args.no_config:
         apply_config(nc, users, args.lang)
 
-    cfg = db_config(nc)
-    cmd = ["docker", "exec", "-i", db, "mysql",
-           f"-u{cfg['dbuser']}", f"-p{cfg['dbpassword']}", cfg["dbname"]]
-    res = subprocess.run(cmd, input="\n".join(sql), capture_output=True, text=True)
-    err = "\n".join(l for l in res.stderr.splitlines()
-                    if "Using a password" not in l).strip()
-    if res.returncode != 0:
-        sys.exit(f"seeding failed:\n{err}")
-    if err:
-        print(err)
+    mysql(db, db_config(nc), sql)
 
     print(f"seeded {len(CATEGORIES)} categories and {len(appts)} appointments "
           f"(IDs {ID_BASE}-{appts[-1]['id']}):")


### PR DESCRIPTION
The Flutter app's capture script now drives this seeder instead of shipping its own copy, and two things came out of that.

## `--reopen-running`

`autoCloseExpired()` closes any appointment whose start time has passed, so the "running right now" appointment (ID 104) — the one the check-in and live-banner shots depend on — flips to *Closed* a few minutes after seeding. Until now the fix was a hand-pasted `docker exec … mysql -e "UPDATE …"` block in the skill, which only helped if you happened to run it in the right minute.

The new flag re-opens whatever seeded appointment is running at that moment and exits, touching nothing else. It is cheap enough to call repeatedly, which is what the Flutter capture script does: a 20-second watchdog for the length of its Xcode build, so the appointment is still live when the app finally loads.

The SQL execution in `main()` moved into a small `mysql()` helper so the new path and the full seed share it.

## Skill notes

- The manual SQL snippet in the "Auto-close trap" section is replaced by the flag.
- `seed_demo_data.py` is now referenced by path from `attendance-flutter/scripts/capture_screenshots.sh`, so moving or renaming it breaks that repo. Noted next to the script's description.

Paired with the Flutter PR that wires the capture pipeline to this seeder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)