### PR TITLE
docs: correct the supported Nextcloud range in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The mobile app is free for the first 30 days per Nextcloud instance, then one ye
 
 ### Organising appointments
 - **Recurring appointments:** daily, weekly or monthly series created in one go; edit or delete this one, this and following, or all of them
-- **Calendar import:** pull events out of Nextcloud Calendar, with optional automatic sync (Nextcloud 32+)
+- **Calendar import:** pull events out of Nextcloud Calendar, with optional automatic sync
 - **Closing and deadlines:** close an inquiry by hand, on a deadline, or automatically once it starts
 - **Cancel and reactivate:** cancelling is a state of its own, separate from closing
 - **Scheduling:** mark the yes-repliers you actually need and notify exactly those people on closing (instance-wide opt-in, off by default)
@@ -50,11 +50,11 @@ The mobile app is free for the first 30 days per Nextcloud instance, then one ye
 - **Response summary groups:** choose which groups and Teams appear as sections (this also scopes the check-in list)
 - **Reminder settings:** days before the appointment and repeat frequency
 - **Self-check-in settings:** which groups may self-check-in, how wide the check-in window is, plus the instance QR code and the NFC URL
-- **Calendar sync:** keep imported appointments in step with the source event (Nextcloud 32+)
+- **Calendar sync:** keep imported appointments in step with the source event
 
 ## Requirements
 
-- Nextcloud 31 to 34 (32 or newer for calendar sync)
+- Nextcloud 32 to 34
 - PHP 8.1 or newer
 - The Notifications app enabled, for reminders and notifications
 


### PR DESCRIPTION
## What

The README's Requirements section said **"Nextcloud 31 to 34 (32 or newer for calendar sync)"**. It now says **"Nextcloud 32 to 34"**.

The two calendar feature bullets lose their `(Nextcloud 32+)` markers for the same reason — with the floor at 32, every supported version can do calendar sync, so the qualifier is noise.

## Why

`appinfo/info.xml` is the authoritative declaration and has said `min-version="32"` since a9fe5fe ("chore: require Nextcloud 32, drop NC 31 fallbacks"), which also removed the NC 31 fallbacks from the code — so the app does not run on 31 at all. `CHANGELOG.md` records the same under 1.43.0 ("Requires Nextcloud 32 or later"), and the website already says "Nextcloud 32 bis 34" / "32 to 34".

The README was simply never pulled along when the floor moved.

## For the reviewer

- **README-only, no code touched.** I grepped `docs/`, `CHANGELOG.md`, `appinfo/` and the rest of the repo for other NC 31 claims — there are none. The remaining `31` hits are unrelated: app version `1.31.0` in the changelog, SVG transform values, a composer-lock entry.
- **Changelog history left alone** — the NC 32/33/34 entries are historically accurate.
- **Deliberately not touched:** `appinfo/info.xml:25` and `:71` carry the same now-redundant `(Nextcloud 32+)` / `(ab Nextcloud 32)` qualifier in the app store description (EN and DE). Redundant but not wrong, and it is published store text in two languages — happy to follow up if you want it aligned.
- `./scripts/check.sh` was not run: no gate in it covers Markdown, and nothing outside README.md changed.