### PR TITLE
Answer four open translator questions, and stop losing them in the first place

### DIFF
--- a/.claude/skills/transifex/SKILL.md
+++ b/.claude/skills/transifex/SKILL.md
@@ -41,6 +41,15 @@ forever, see Step 5). Drop `--new` only when the user explicitly wants
 to revisit older threads; drop `--open` to see everything including
 settled threads.
 
+One class of thread ignores the watermark: an **open issue somebody else
+raised** stays listed (`"outstanding": true`) until `mark-answered`
+records it by string id in `answered_threads`. Without that, a batch of
+our own issue reports pushes the watermark past questions nobody has
+answered yet — that is exactly how tlend's question from 3 August and
+fbausch_t's from the 4th went missing until 6 August. A later comment on
+a signed-off thread lifts it back above its recorded date, so follow-up
+questions resurface on their own.
+
 Reading the output, keep in mind:
 
 - Entries with `"type": "issue"` carry an open/resolved **status**; plain
@@ -199,12 +208,19 @@ python3 .claude/skills/transifex/scripts/tx_feedback.py mark-answered
 
 This writes the newest comment date seen on the resource (including our
 own just-posted replies — the API is the source of truth, not the local
-clock) into `answered_up_to` in `state.json`. The next `list --new` run
-then only surfaces threads with newer activity, so nothing gets answered
-twice. Commit `state.json` together with the session's code changes so
-the watermark survives across worktrees and machines.
+clock) into `answered_up_to` in `state.json`, and signs off every thread
+holding somebody else's open issue in `answered_threads`. The next
+`list --new` run then only surfaces threads with newer activity, so
+nothing gets answered twice. Commit `state.json` together with the
+session's code changes so the watermark survives across worktrees and
+machines.
 
 Skip this step if replies are still pending (e.g. the user postponed a
 draft) — an advanced watermark would hide those threads from the next
 run. If that happens anyway, `mark-answered --date <ISO>` can move the
-watermark back explicitly.
+watermark back explicitly; it also releases every `answered_threads`
+entry recorded after that date, so winding back really does bring the
+threads back.
+
+Verify with a final `list --open --new` — it should come back empty. If
+a thread is still listed, the reply for it did not go out.

--- a/.claude/skills/transifex/scripts/tx_feedback.py
+++ b/.claude/skills/transifex/scripts/tx_feedback.py
@@ -14,6 +14,11 @@ Commands:
   list --new                 Only threads with activity newer than the
                              answered_up_to watermark in state.json (kept
                              next to the skill). Combine with --open.
+                             A thread carrying an open issue somebody else
+                             raised ignores the watermark and stays listed
+                             until mark-answered signs it off by name —
+                             our own issue reports would otherwise push the
+                             watermark past unanswered questions.
   find TEXT                  Search the resource's source strings by key or
                              source text (case-insensitive substring) and
                              print their string ids.
@@ -26,7 +31,11 @@ Commands:
                              an existing thread, pass --language (l:de_DE).
   mark-answered              Record the newest comment date seen on the
                              resource as the answered_up_to watermark in
-                             state.json (or pass --date ISO explicitly).
+                             state.json, and sign off every thread holding
+                             an open issue of someone else's in
+                             answered_threads (or pass --date ISO
+                             explicitly, which also releases threads signed
+                             off after that point).
                              Run after all replies for a session are posted.
   resolve COMMENT_ID         Mark an issue comment as resolved. NOTE: needs
                              project-maintainer rights; translator-level
@@ -146,9 +155,16 @@ def full_string_id(string_id):
     return f'{RESOURCE}:s:{string_id.removeprefix("s:")}'
 
 
+def has_foreign_open_issue(comments, me):
+    return any(c['type'] == 'issue' and c['status'] == 'open'
+               and c['author'] != f'u:{me}' for c in comments)
+
+
 def cmd_list(args):
     threads = fetch_threads()
-    watermark = read_state().get('answered_up_to', '') if args.new else ''
+    state = read_state()
+    watermark = state.get('answered_up_to', '') if args.new else ''
+    answered_threads = state.get('answered_threads', {})
     if args.new and not watermark:
         print('state.json has no answered_up_to watermark yet — listing '
               'everything. Run mark-answered after replying.',
@@ -161,15 +177,22 @@ def cmd_list(args):
             comments and comments[-1]['author'] != f'u:{args.me}')
         if args.open and not needs_attention:
             continue
+        # Our own issue reports push the watermark past questions other
+        # people asked and nobody answered — that is how two of them were
+        # missed for days. An open issue someone else raised therefore
+        # survives the watermark until mark-answered records it by name.
+        outstanding = (has_foreign_open_issue(comments, args.me)
+                       and comments[-1]['date'] > answered_threads.get(sid, ''))
         # Watermark dates come from the same API field as the comment
         # dates, so plain string comparison of the ISO timestamps works.
-        if watermark and comments[-1]['date'] <= watermark:
+        if watermark and not outstanding and comments[-1]['date'] <= watermark:
             continue
         out.append({
             'string_id': sid,
             'string': fetch_string(sid),
             'has_open_issue': has_open_issue,
             'needs_attention': needs_attention,
+            'outstanding': outstanding,
             'comments': comments,
         })
     out.sort(key=lambda t: t['comments'][-1]['date'], reverse=True)
@@ -239,13 +262,14 @@ def cmd_reply(args):
 
 
 def cmd_mark_answered(args):
+    threads = {} if args.date else fetch_threads()
     if args.date:
         newest = args.date
     else:
         # Take the newest comment date from the API itself instead of the
         # local clock — clocks may drift, the API is the source of truth.
         newest = max(
-            (c['date'] for comments in fetch_threads().values()
+            (c['date'] for comments in threads.values()
              for c in comments), default='')
         if not newest:
             sys.exit('No comments found on the resource; pass --date '
@@ -257,9 +281,23 @@ def cmd_mark_answered(args):
                  f'({previous} -> {newest}); pass an explicit --date '
                  f'if that is really intended.')
     state['answered_up_to'] = newest
+    answered_threads = state.setdefault('answered_threads', {})
+    if args.date:
+        # Winding the watermark back has to release the threads recorded
+        # after that point too, or they stay hidden regardless.
+        for sid in [s for s, d in answered_threads.items() if d > newest]:
+            del answered_threads[sid]
+    else:
+        # Threads carrying someone else's open issue ignore the watermark,
+        # so each one has to be signed off individually. Recording the
+        # newest comment lets a follow-up question resurface the thread.
+        for sid, comments in threads.items():
+            if has_foreign_open_issue(comments, args.me):
+                answered_threads[sid] = comments[-1]['date']
     write_state(state)
     print(json.dumps({'ok': True, 'answered_up_to': newest,
-                      'previous': previous or None}))
+                      'previous': previous or None,
+                      'answered_threads': len(answered_threads)}))
 
 
 def cmd_resolve(args):
@@ -300,6 +338,9 @@ def main():
     p_mark.add_argument('--date',
                         help='explicit ISO timestamp instead of the newest '
                              'comment date from the API')
+    p_mark.add_argument('--me', default='magdeflow',
+                        help='username treated as "us" when deciding which '
+                             'open issues are someone else\'s')
     p_mark.set_defaults(func=cmd_mark_answered)
 
     p_find = sub.add_parser('find', help='search source strings by text/key')

--- a/.claude/skills/transifex/state.json
+++ b/.claude/skills/transifex/state.json
@@ -1,3 +1,9 @@
 {
- "answered_up_to": "2026-08-05T20:25:58Z"
+ "answered_up_to": "2026-08-06T11:06:27Z",
+ "answered_threads": {
+  "o:nextcloud:p:nextcloud:r:attendance:s:6aabb6e378e0a65a53d64c4a760cc553": "2026-08-06T11:06:27Z",
+  "o:nextcloud:p:nextcloud:r:attendance:s:baf548090dd0d14c45abb3024ea21678": "2026-08-06T11:06:06Z",
+  "o:nextcloud:p:nextcloud:r:attendance:s:5ec1635a3b31697266c44dee96c74a90": "2026-08-06T11:05:55Z",
+  "o:nextcloud:p:nextcloud:r:attendance:s:46d58e2a39a8294566af822ac7da7ab3": "2026-07-31T21:57:06Z"
+ }
 }

--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -219,6 +219,7 @@ class Notifier implements INotifier {
 		switch ($notification->getSubject()) {
 			case 'response_changed':
 				$subject = $onBehalfOf !== ''
+					// TRANSLATORS: %1$s changes the answer on behalf of person %2$s; %3$s and %4$s are the old and the new answer (yes/no/maybe) and %5$s the appointment title.
 					? $l->t('%1$s changed the response of %2$s from %3$s to %4$s on "%5$s"', [
 						$actorLabel,
 						$onBehalfOf,
@@ -235,6 +236,7 @@ class Notifier implements INotifier {
 				break;
 			case 'response_rescinded':
 				$subject = $onBehalfOf !== ''
+					// TRANSLATORS: %1$s deletes the answer that person %2$s had given; %3$s is the appointment title.
 					? $l->t('%1$s removed the response of %2$s on "%3$s"', [
 						$actorLabel,
 						$onBehalfOf,

--- a/src/App.vue
+++ b/src/App.vue
@@ -352,6 +352,7 @@ t('attendance', 'No results match the active filters.')
 t('attendance', 'No connection')
 t('attendance', 'The server cannot be reached. Check your internet connection and try again.')
 t('attendance', 'No connection — showing saved data')
+// TRANSLATORS: Offline banner in the mobile app, telling when the cached data was fetched. {time} is a combined date and time of day, formatted in the user's locale (e.g. "6/8/2026 14:32").
 t('attendance', 'Last updated {time}')
 
 t('attendance', 'Subscribe')
@@ -370,6 +371,7 @@ t('attendance', 'Privacy Policy')
 t('attendance', 'By connecting, you agree to our [Terms of Service](terms) and acknowledge our [Privacy Policy](privacy).')
 t('attendance', 'Current plan')
 t('attendance', 'Expired')
+// TRANSLATORS: Call-to-action button opening the subscription screen; "plans" are the paid subscription tiers, not schedules or agendas.
 t('attendance', 'See plans')
 t('attendance', 'No subscription plans available at this time.')
 t('attendance', 'No previous purchases found.')
@@ -395,6 +397,7 @@ t('attendance', 'After this date, the inquiry is automatically closed and no fur
 // Transifex extracts them and the community can translate them centrally; the
 // translations are synced back into the app's own l10n files. Keep the English
 // source identical to the `.tr()` keys used in the attendance-flutter repo.
+// TRANSLATORS: Headline of the mobile app's subscription screen, above a switch between the personal and the group plans. "license" is the paid subscription, "group" the organization sharing one.
 t('attendance', 'A license for you, or for your whole group')
 t('attendance', 'A personal license works on every Nextcloud account you sign in with.')
 t('attendance', 'A personal license covers just you, so nobody else has to agree to it.')
@@ -476,6 +479,7 @@ t('attendance', 'Questions?')
 t('attendance', 'Rather book directly?')
 t('attendance', 'Scan NFC tag')
 t('attendance', 'Scan again')
+// TRANSLATORS: Call-to-action button opening the subscription screen on the group tiers; "plans" are the paid subscription tiers, not schedules or agendas.
 t('attendance', 'See group plans')
 t('attendance', 'Search by name …')
 t('attendance', 'Select the appointment you want to check into:')
@@ -531,8 +535,11 @@ t('attendance', 'You only see the bar where you are allowed to see responses —
 t('attendance', 'Your 14 extra days are yours either way — this just helps me make the app worth keeping.')
 t('attendance', 'Your fair price')
 t('attendance', 'Your free trial has ended')
+// TRANSLATORS: Nudge in the mobile app when the group outgrew its subscription tier. "plan" is the paid tier, "the next plan up" the larger one.
 t('attendance', 'Your group has grown past this plan. The next plan up covers everyone.')
+// TRANSLATORS: Same nudge with numbers — {count} is how many members the group has now, {limit} how many the current subscription tier covers.
 t('attendance', 'Your group has grown past your plan ({count} of {limit} members). The next plan up covers everyone.')
+// TRANSLATORS: Nudge shortly before the tier's limit is reached — {count} is how many members the group has now, {limit} how many the subscription tier covers.
 t('attendance', 'Your group is close to your plan limit ({count} of {limit} members).')
 t('attendance', 'You can decide this on your own')
 t('attendance', 'Your message')

--- a/src/components/appointment/RecurrenceSelector.vue
+++ b/src/components/appointment/RecurrenceSelector.vue
@@ -229,11 +229,19 @@ const weekdays = [
 	{ value: 'SU', label: t('attendance', 'Sun') },
 ]
 
+// Ordinal position of a weekday within a month, filled into "On the {ordinal}
+// {weekday} of each month" — one hint per line, the extractor binds only to the
+// t() directly below it.
 const ordinalLabels = [
+	// TRANSLATORS: Ordinal number in "On the 1st Monday of each month" — a position in a sequence, not a date like the first of May.
 	t('attendance', '1st'),
+	// TRANSLATORS: Ordinal number in "On the 2nd Monday of each month" — a position in a sequence, not a date.
 	t('attendance', '2nd'),
+	// TRANSLATORS: Ordinal number in "On the 3rd Monday of each month" — a position in a sequence, not a date.
 	t('attendance', '3rd'),
+	// TRANSLATORS: Ordinal number in "On the 4th Monday of each month" — a position in a sequence, not a date.
 	t('attendance', '4th'),
+	// TRANSLATORS: Ordinal number in "On the 5th Monday of each month" — a position in a sequence, not a date.
 	t('attendance', '5th'),
 ]
 

--- a/src/views/AdminSettings.vue
+++ b/src/views/AdminSettings.vue
@@ -127,9 +127,9 @@
 						<CategoryIconPicker v-model="newCategory.icon" data-test="input-new-category-icon" />
 						<NcInputField
 							v-model="newCategory.name"
-							:label="t('attendance', 'New category name')"
+							:label="newCategoryNameLabel"
 							:labelOutside="true"
-							:aria-label="t('attendance', 'New category name')"
+							:aria-label="newCategoryNameLabel"
 							:placeholder="t('attendance', 'e.g. Rehearsal')"
 							class="category-add__name-field"
 							data-test="input-new-category"
@@ -743,6 +743,8 @@ const editingCategoryId = ref(null)
 const editingCategory = reactive({ name: '', icon: DEFAULT_CATEGORY_ICON })
 // TRANSLATORS: Label of the input field holding a category's name — "name" is what the field expects, not part of a compound noun.
 const categoryNameLabel = t('attendance', 'Category name')
+// TRANSLATORS: Label of the empty input field for creating a category — the name the new category is about to get, not the name of an existing one.
+const newCategoryNameLabel = t('attendance', 'New category name')
 const savingCategoryEdit = ref(false)
 const categoryToDelete = ref(null)
 

--- a/src/views/AllAppointments.vue
+++ b/src/views/AllAppointments.vue
@@ -80,6 +80,7 @@
 							<template #icon>
 								<MapMarkerIcon :size="20" />
 							</template>
+							<!-- TRANSLATORS: Filter button in the appointment list, filtering by the venue an appointment takes place at — not a file or storage path. -->
 							{{ t('attendance', 'Location') }}
 						</NcButton>
 					</template>

--- a/src/views/AppointmentForm.vue
+++ b/src/views/AppointmentForm.vue
@@ -126,7 +126,7 @@
 					minHeight="150px" />
 
 				<div v-if="locationsAvailable" class="form-field">
-					<!-- TRANSLATORS: The venue an appointment takes place at (room, church, address) — not a file or storage path. Also written to the LOCATION field of calendar events. -->
+					<!-- TRANSLATORS: The venue an appointment takes place at — not a file or storage path. Free text, so it can be a room, a street address or just a city. Also written to the LOCATION field of calendar events. -->
 					<label for="appointment-location">{{ t('attendance', 'Location') }}</label>
 					<NcSelect
 						id="appointment-location"


### PR DESCRIPTION
Four questions from translators were sitting unanswered on Transifex, two of
them since 3 and 4 August. This answers all four, persists the answers as
`TRANSLATORS` hints so every language gets them, and fixes the watermark bug
that made two of them disappear.

## Replies posted

| String | Asked by | Answer |
|---|---|---|
| `Location` | tlend | Free text — a room, a street address or just a city; all three are valid |
| `New category name` | tlend | The name a category is *about to get*, not an existing one (tlend guessed the opposite) |
| `Last updated {time}` | fbausch_t | A date **and** a time of day, locale-formatted |
| `A license for you, …` | tlend | Headline of the mobile subscription screen (described, since images cannot be attached) |

Two needed the `--language l:de_DE` fallback — their threads hang only off
`l:et_EE` / `l:pt_BR`, where the token has no team membership. Known, documented
in the skill. The issues themselves stay open; resolving needs maintainer rights
on the shared nextcloud project.

## TRANSLATORS hints (`f10f625`)

Beyond the four answers, the gaps found while checking them:

- the `Location` **filter button** had no hint at all — only the form label did
- `See plans` / `See group plans` and the three plan-limit nudges never said
  that "plan" means a *paid tier*, which invites "schedule"/"agenda" in other
  languages (the German translation had already drifted to "Siehe Pläne")
- the two `Notifier` strings taking a person as `%2$s` had no placeholder note,
  while their web counterparts in `auditFormat.js` did
- `1st`–`5th` never got the hint that CaféTango's answered question earned back
  in February — answered on Transifex, never persisted in code

`New category name` moves into a constant: the extractor binds a hint only to
the `t()` on the line directly below it, which an attribute binding never is.

All 15 hints verified against a locally generated `.pot` before committing;
`translationfiles/` deleted afterwards.

## Watermark fix (`6e22c7a`)

`mark-answered` set the watermark to the newest comment on the whole resource —
**our own issue reports included**. Nine de_DE reports on 4 and 5 August pushed
it past tlend's question from the 3rd and fbausch_t's from the 4th, which then
dropped out of `list --new` entirely. They only surfaced because this session
listed without the filter.

A thread carrying an open issue **somebody else** raised now survives the
watermark and stays listed until `mark-answered` signs it off by string id in
`answered_threads`; a later comment lifts it back above its recorded date, so
follow-ups resurface on their own.

Worth knowing for review: the obvious fix — "show threads whose last word isn't
ours" — was tried first and **fails on exactly the case that motivated it**. On
`A license for you, …` the last comment *is* ours: our unrelated whitespace
issue, posted a day after tlend's question and never answering it. Hence the
narrower "someone else's open issue" criterion plus an explicit sign-off. A
blanket "always show foreign open issues" was rejected too, because reporters
often never resolve them — `Organized by {names}` has been answered since 31
July and is still open.

Our own open issues, which we have no rights to resolve, keep relying on the
watermark alone, so reporting a batch of them does not flood the next run.

## Verification

- `./scripts/check.sh` — all gates pass (eslint, stylelint, php-cs-fixer, psalm,
  272 PHPUnit tests, vite build, OpenAPI spec check)
- `list --open --new`: 2 threads before the fix → 5 after (the four plus the
  straggler `Organized by {names}`) → 0 after `mark-answered`
- No source strings changed, so no paired Flutter PR is needed — comments and
  hints only

🤖 Generated with [Claude Code](https://claude.com/claude-code)
