### PR TITLE
fix(ui): stop the loading label from landing on top of the spinner

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -17,6 +17,9 @@ export default [
 			'vue/first-attribute-linebreak': 'off',
 			// Single-word view names that predate the rule.
 			'vue/multi-word-component-names': ['error', { ignores: ['Widget', 'Checkin'] }],
+			// Nextcloud core paints a centred spinner behind anything carrying
+			// these classes, so own content ends up sitting on top of it.
+			'vue/no-restricted-class': ['error', 'loading', 'loading-small'],
 		},
 	},
 ]

--- a/src/App.vue
+++ b/src/App.vue
@@ -236,9 +236,7 @@
 				@clearSearch="searchQuery = ''" />
 
 			<!-- Loading state while routing is determined -->
-			<div v-else class="loading-state">
-				<div class="loading-spinner" />
-			</div>
+			<LoadingState v-else :text="t('attendance', 'Loading …')" />
 		</NcAppContent>
 
 		<!-- iCal Feed Modal -->
@@ -286,6 +284,7 @@ import HelpCircle from 'vue-material-design-icons/HelpCircle.vue'
 import LockIcon from 'vue-material-design-icons/Lock.vue'
 import PlusIcon from 'vue-material-design-icons/Plus.vue'
 import ProgressQuestion from 'vue-material-design-icons/ProgressQuestion.vue'
+import LoadingState from './components/common/LoadingState.vue'
 import MobileAppBanner from './components/common/MobileAppBanner.vue'
 import ExportDialog from './components/ExportDialog.vue'
 import IcalFeedModal from './components/IcalFeedModal.vue'
@@ -856,31 +855,6 @@ onMounted(async () => {
 </script>
 
 <style scoped>
-.loading-state {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    height: 200px;
-}
-
-.loading-spinner {
-    width: 32px;
-    height: 32px;
-    border: 3px solid var(--color-loading-light);
-    border-top: 3px solid var(--color-loading-dark);
-    border-radius: 50%;
-    animation: spin 1s linear infinite;
-}
-
-@keyframes spin {
-    0% {
-        transform: rotate(0deg);
-    }
-    100% {
-        transform: rotate(360deg);
-    }
-}
-
 .mobile-banner-container {
     padding: 20px 20px 0;
     max-width: 1200px;

--- a/src/components/IcalFeedModal.vue
+++ b/src/components/IcalFeedModal.vue
@@ -7,9 +7,7 @@
 				{{ t('attendance', 'Subscribe to your appointments in external calendar apps like Google Calendar, Apple Calendar, or Thunderbird.') }}
 			</p>
 
-			<div v-if="loading" class="loading-container">
-				<NcLoadingIcon :size="32" />
-			</div>
+			<LoadingState v-if="loading" />
 
 			<template v-else>
 				<div class="feed-url-section">
@@ -90,12 +88,13 @@
 </template>
 
 <script setup>
-import { NcButton, NcDialog, NcLoadingIcon, NcNoteCard } from '@nextcloud/vue'
+import { NcButton, NcDialog, NcNoteCard } from '@nextcloud/vue'
 import { ref, watch } from 'vue'
 import AppleIcon from 'vue-material-design-icons/Apple.vue'
 import ContentCopy from 'vue-material-design-icons/ContentCopy.vue'
 import GoogleIcon from 'vue-material-design-icons/Google.vue'
 import Refresh from 'vue-material-design-icons/Refresh.vue'
+import LoadingState from './common/LoadingState.vue'
 import { useIcalFeed } from '../composables/useIcalFeed.js'
 import { formatDateTime } from '../utils/datetime.js'
 
@@ -141,12 +140,6 @@ async function handleRegenerate() {
 .description {
 	margin: 0 0 20px 0;
 	color: var(--color-text-maxcontrast);
-}
-
-.loading-container {
-	display: flex;
-	justify-content: center;
-	padding: 40px;
 }
 
 .feed-url-section {

--- a/src/components/appointment/AuditTimeline.vue
+++ b/src/components/appointment/AuditTimeline.vue
@@ -4,10 +4,10 @@
 			{{ t('attendance', 'Activity history') }}
 		</h4>
 
-		<div v-if="loading" class="audit-timeline__state">
-			<NcLoadingIcon :size="20" />
-			<span>{{ t('attendance', 'Loading …') }}</span>
-		</div>
+		<LoadingState v-if="loading"
+			inline
+			:size="20"
+			:text="t('attendance', 'Loading …')" />
 
 		<NcEmptyContent v-else-if="error"
 			:name="t('attendance', 'Failed to load activity')"
@@ -63,7 +63,7 @@
 
 <script setup>
 import { translate as t } from '@nextcloud/l10n'
-import { NcButton, NcEmptyContent, NcLoadingIcon } from '@nextcloud/vue'
+import { NcButton, NcEmptyContent } from '@nextcloud/vue'
 import { computed, onMounted } from 'vue'
 import AccountCheck from 'vue-material-design-icons/AccountCheck.vue'
 import AccountSync from 'vue-material-design-icons/AccountSync.vue'
@@ -82,6 +82,7 @@ import LockOpenVariantOutline from 'vue-material-design-icons/LockOpenVariantOut
 import LockOutline from 'vue-material-design-icons/LockOutline.vue'
 import SwapHorizontal from 'vue-material-design-icons/SwapHorizontal.vue'
 import UndoVariant from 'vue-material-design-icons/UndoVariant.vue'
+import LoadingState from '../common/LoadingState.vue'
 import { useAuditLog } from '../../composables/useAuditLog.js'
 import { usePermissions } from '../../composables/usePermissions.js'
 import { formatAuditEvent, formatSource } from '../../utils/auditFormat.js'
@@ -154,13 +155,6 @@ onMounted(() => {
 	margin: 0 0 12px;
 	font-size: 1rem;
 	font-weight: 600;
-}
-
-.audit-timeline__state {
-	display: flex;
-	align-items: center;
-	gap: 8px;
-	color: var(--color-text-maxcontrast);
 }
 
 .audit-timeline__list {

--- a/src/components/calendar/CalendarEventPicker.vue
+++ b/src/components/calendar/CalendarEventPicker.vue
@@ -9,10 +9,7 @@
 
 			<!-- Calendar Selection Step -->
 			<template v-if="!selectedCalendar">
-				<div v-if="loadingCalendars" class="loading-container">
-					<NcLoadingIcon :size="32" />
-					<span class="loading-text">{{ t('attendance', 'Loading calendars …') }}</span>
-				</div>
+				<LoadingState v-if="loadingCalendars" :text="t('attendance', 'Loading calendars …')" />
 
 				<template v-else-if="calendars.length > 0">
 					<label class="section-label">{{ t('attendance', 'Select calendar') }}</label>
@@ -72,10 +69,7 @@
 						@update:modelValue="onToDateChange" />
 				</div>
 
-				<div v-if="loadingEvents" class="loading-container">
-					<NcLoadingIcon :size="32" />
-					<span class="loading-text">{{ t('attendance', 'Loading events …') }}</span>
-				</div>
+				<LoadingState v-if="loadingEvents" :text="t('attendance', 'Loading events …')" />
 
 				<template v-else-if="events.length > 0">
 					<div class="event-list-header">
@@ -135,11 +129,12 @@
 
 <script setup>
 import { translatePlural as n, translate as t } from '@nextcloud/l10n'
-import { NcButton, NcCheckboxRadioSwitch, NcDateTimePickerNative, NcDialog, NcLoadingIcon, NcTextField } from '@nextcloud/vue'
+import { NcButton, NcCheckboxRadioSwitch, NcDateTimePickerNative, NcDialog, NcTextField } from '@nextcloud/vue'
 import { computed, ref, watch } from 'vue'
 import ArrowLeft from 'vue-material-design-icons/ArrowLeft.vue'
 import CalendarBlankOutline from 'vue-material-design-icons/CalendarBlankOutline.vue'
 import ChevronRight from 'vue-material-design-icons/ChevronRight.vue'
+import LoadingState from '../common/LoadingState.vue'
 import { useCalendarEvents } from '../../composables/useCalendarEvents.js'
 import { formatDateRange } from '../../utils/datetime.js'
 
@@ -337,19 +332,6 @@ function importSelected() {
 
 .description {
 	margin: 0 0 20px 0;
-	color: var(--color-text-maxcontrast);
-}
-
-.loading-container {
-	display: flex;
-	flex-direction: column;
-	align-items: center;
-	justify-content: center;
-	padding: 40px;
-	gap: 12px;
-}
-
-.loading-text {
 	color: var(--color-text-maxcontrast);
 }
 

--- a/src/components/common/LoadingState.vue
+++ b/src/components/common/LoadingState.vue
@@ -1,0 +1,53 @@
+<template>
+	<div class="loading-state" :class="{ 'loading-state--inline': inline }">
+		<NcLoadingIcon :size="size" />
+		<p v-if="text" class="loading-state__text">
+			{{ text }}
+		</p>
+	</div>
+</template>
+
+<script setup>
+import { NcLoadingIcon } from '@nextcloud/vue'
+
+defineProps({
+	// Label shown next to the spinner; omit for a spinner-only state
+	text: {
+		type: String,
+		default: '',
+	},
+	size: {
+		type: Number,
+		default: 32,
+	},
+	// Compact single-row variant for states inside a panel or list
+	inline: {
+		type: Boolean,
+		default: false,
+	},
+})
+</script>
+
+<style scoped>
+.loading-state {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	gap: 12px;
+	padding: 40px 0;
+	color: var(--color-text-maxcontrast);
+}
+
+.loading-state--inline {
+	flex-direction: row;
+	justify-content: flex-start;
+	gap: 8px;
+	padding: 0;
+}
+
+.loading-state__text {
+	margin: 0;
+	text-align: center;
+}
+</style>

--- a/src/components/onboarding/OnboardingWizard.vue
+++ b/src/components/onboarding/OnboardingWizard.vue
@@ -13,10 +13,7 @@
 				<NcProgressBar :value="progressPercent" size="medium" />
 			</div>
 
-			<div v-if="loading" class="onboarding__loading">
-				<NcLoadingIcon :size="32" />
-				<p>{{ t('attendance', 'Loading settings …') }}</p>
-			</div>
+			<LoadingState v-if="loading" :text="t('attendance', 'Loading settings …')" />
 
 			<div v-else class="onboarding__body">
 				<p v-if="currentStep.lead" class="onboarding__lead">
@@ -252,6 +249,7 @@ import TagIcon from 'vue-material-design-icons/TagOutline.vue'
 import WifiOffIcon from 'vue-material-design-icons/WifiOff.vue'
 import PermissionRow from '../admin/PermissionRow.vue'
 import GroupSelect from '../common/GroupSelect.vue'
+import LoadingState from '../common/LoadingState.vue'
 import { toGroupObjects } from '../../utils/groups.js'
 import { MOBILE_APP_STORES } from '../../utils/mobileApp.js'
 import { AUDIT_VISIBILITIES, emptyPermissionState, PERMISSION_ROWS, permissionPayload, REMINDER_TARGETS } from '../../utils/permissions.js'
@@ -530,14 +528,6 @@ watch(() => props.open, (open) => {
 	font-weight: 600;
 	font-size: 17px;
 	margin-bottom: 4px;
-}
-
-.onboarding__loading {
-	display: flex;
-	flex-direction: column;
-	align-items: center;
-	gap: 12px;
-	padding: 40px 0;
 }
 
 .onboarding__body {

--- a/src/views/AdminSettings.vue
+++ b/src/views/AdminSettings.vue
@@ -13,10 +13,7 @@
 			</nav>
 		</NcSettingsSection>
 
-		<div v-if="loadingData" class="loading-section">
-			<NcLoadingIcon :size="32" />
-			<p>{{ t('attendance', 'Loading settings …') }}</p>
-		</div>
+		<LoadingState v-if="loadingData" :text="t('attendance', 'Loading settings …')" />
 
 		<template v-else>
 			<NcSettingsSection id="setup-wizard"
@@ -85,9 +82,7 @@
 				:name="t('attendance', 'Categories')"
 				:description="t('attendance', 'Define categories appointments can be classified under. Each one gets an icon, shown wherever the category appears.')"
 				data-test="section-categories">
-				<div v-if="categoriesLoading" class="loading-section">
-					<NcLoadingIcon :size="24" />
-				</div>
+				<LoadingState v-if="categoriesLoading" :size="24" />
 				<template v-else>
 					<ul v-if="categories.length > 0" class="category-list">
 						<li v-for="category in categories" :key="category.id" class="category-list__item">
@@ -700,6 +695,7 @@ import CategoryIconPicker from '../components/admin/CategoryIconPicker.vue'
 import PermissionRow from '../components/admin/PermissionRow.vue'
 import SectionLink from '../components/admin/SectionLink.vue'
 import GroupSelect from '../components/common/GroupSelect.vue'
+import LoadingState from '../components/common/LoadingState.vue'
 import { categoryIconComponent, DEFAULT_CATEGORY_ICON } from '../utils/categoryIcons.js'
 import { copyToClipboard } from '../utils/clipboard.js'
 import { formatDate, formatDateTimeMedium } from '../utils/datetime.js'
@@ -1303,15 +1299,6 @@ onMounted(async () => {
 .anchor-nav__link:hover,
 .anchor-nav__link:focus {
 	background-color: var(--color-primary-element-light);
-}
-
-.loading-section {
-	display: flex;
-	flex-direction: column;
-	align-items: center;
-	gap: 12px;
-	padding: 40px;
-	color: var(--color-text-maxcontrast);
 }
 
 .hint-text {

--- a/src/views/AllAppointments.vue
+++ b/src/views/AllAppointments.vue
@@ -188,9 +188,7 @@
 
 		<!-- Appointments List -->
 		<div class="appointments-list">
-			<div v-if="loading" class="loading">
-				{{ t('attendance', 'Loading\u00A0…') }}
-			</div>
+			<LoadingState v-if="loading" :text="t('attendance', 'Loading\u00A0…')" />
 			<NcEmptyContent v-else-if="visibleAppointments.length === 0 && !showUnanswered"
 				:name="emptyState.name"
 				:description="emptyState.description"
@@ -276,6 +274,7 @@ import RocketLaunchIcon from 'vue-material-design-icons/RocketLaunch.vue'
 import TagIcon from 'vue-material-design-icons/TagOutline.vue'
 import AppointmentListCard from '../components/appointment/AppointmentListCard.vue'
 import DeleteAppointmentDialog from '../components/appointment/DeleteAppointmentDialog.vue'
+import LoadingState from '../components/common/LoadingState.vue'
 import SingleAppointmentExportDialog from '../components/SingleAppointmentExportDialog.vue'
 import { useAppointmentResponse } from '../composables/useAppointmentResponse.js'
 import { useCategories } from '../composables/useCategories.js'
@@ -841,12 +840,6 @@ onMounted(async () => {
 .appointments-list {
 	max-width: 800px;
 	margin: 0 auto;
-
-	.loading {
-		text-align: center;
-		padding: 40px;
-		color: var(--color-text-lighter);
-	}
 }
 
 .unanswered-banner-container {

--- a/src/views/AppointmentDetail.vue
+++ b/src/views/AppointmentDetail.vue
@@ -8,9 +8,7 @@
 			<span>{{ n('attendance', '%n appointment awaiting your response', '%n appointments awaiting your response', unansweredCount) }}</span>
 			<span class="banner-action">{{ t('attendance', 'View all') }} →</span>
 		</div>
-		<div v-if="loading" class="loading-state" data-test="loading-state">
-			{{ t('attendance', 'Loading\u00A0…') }}
-		</div>
+		<LoadingState v-if="loading" :text="t('attendance', 'Loading\u00A0…')" data-test="loading-state" />
 		<div v-else-if="error" class="error-state" data-test="error-state">
 			<p>{{ error }}</p>
 			<NcButton data-test="button-back" @click="goBack">
@@ -59,6 +57,7 @@ import ProgressQuestion from 'vue-material-design-icons/ProgressQuestion.vue'
 import AppointmentCard from '../components/appointment/AppointmentCard.vue'
 import AuditTimeline from '../components/appointment/AuditTimeline.vue'
 import DeleteAppointmentDialog from '../components/appointment/DeleteAppointmentDialog.vue'
+import LoadingState from '../components/common/LoadingState.vue'
 import SingleAppointmentExportDialog from '../components/SingleAppointmentExportDialog.vue'
 import { useAppointmentResponse } from '../composables/useAppointmentResponse.js'
 import { usePermissions } from '../composables/usePermissions.js'
@@ -275,12 +274,6 @@ watch(() => props.appointmentId, async (newId, oldId) => {
 	font-weight: normal;
 	white-space: nowrap;
 	opacity: 0.85;
-}
-
-.loading-state {
-	text-align: center;
-	padding: 40px;
-	color: var(--color-text-lighter);
 }
 
 .error-state {

--- a/src/views/AppointmentForm.vue
+++ b/src/views/AppointmentForm.vue
@@ -27,14 +27,10 @@
 			</h2>
 		</div>
 
-		<div v-if="loading || bulkImporting" class="loading-state">
-			<NcLoadingIcon v-if="bulkImporting" :size="32" />
-			{{
-				bulkImporting
-					? t("attendance", "Importing appointments\u00A0…")
-					: t("attendance", "Loading\u00A0…")
-			}}
-		</div>
+		<LoadingState v-if="loading || bulkImporting"
+			:text="bulkImporting
+				? t('attendance', 'Importing appointments\u00A0…')
+				: t('attendance', 'Loading\u00A0…')" />
 
 		<form
 			v-else
@@ -542,6 +538,7 @@ import RepeatIcon from 'vue-material-design-icons/Repeat.vue'
 import RecurrenceSelector from '../components/appointment/RecurrenceSelector.vue'
 import SeriesActionDialog from '../components/appointment/SeriesActionDialog.vue'
 import CalendarEventPicker from '../components/calendar/CalendarEventPicker.vue'
+import LoadingState from '../components/common/LoadingState.vue'
 import MarkdownEditor from '../components/common/MarkdownEditor.vue'
 import { useCategories } from '../composables/useCategories.js'
 import { usePermissions } from '../composables/usePermissions.js'
@@ -1653,12 +1650,6 @@ onBeforeUnmount(() => {
     h2 {
         margin: 0;
     }
-}
-
-.loading-state {
-    text-align: center;
-    padding: 40px;
-    color: var(--color-text-lighter);
 }
 
 .appointment-form {

--- a/src/views/Checkin.vue
+++ b/src/views/Checkin.vue
@@ -2,10 +2,7 @@
 	<div class="checkin-view" data-test="checkin-view">
 		<CheckinHeader @back="goBack" />
 
-		<div v-if="loading" class="loading-container">
-			<NcLoadingIcon />
-			<p>{{ t('attendance', 'Loading appointment data\u00A0…') }}</p>
-		</div>
+		<LoadingState v-if="loading" :text="t('attendance', 'Loading appointment data\u00A0…')" />
 
 		<div v-else-if="error" class="error-container">
 			<NcEmptyContent :title="t('attendance', 'Error loading appointment')">
@@ -160,7 +157,7 @@
 <script setup>
 import axios from '@nextcloud/axios'
 import { generateUrl } from '@nextcloud/router'
-import { NcButton, NcDialog, NcEmptyContent, NcLoadingIcon, NcNoteCard, NcRadioGroup, NcRadioGroupButton } from '@nextcloud/vue'
+import { NcButton, NcDialog, NcEmptyContent, NcNoteCard, NcRadioGroup, NcRadioGroupButton } from '@nextcloud/vue'
 import { computed, onMounted, reactive, ref } from 'vue'
 import AccountSearchIcon from 'vue-material-design-icons/AccountSearch.vue'
 import AlertIcon from 'vue-material-design-icons/Alert.vue'
@@ -172,6 +169,7 @@ import CheckinControls from '../components/checkin/CheckinControls.vue'
 import CheckinHeader from '../components/checkin/CheckinHeader.vue'
 import CheckinStatus from '../components/checkin/CheckinStatus.vue'
 import CheckinUserItem from '../components/checkin/CheckinUserItem.vue'
+import LoadingState from '../components/common/LoadingState.vue'
 import { usePermissions } from '../composables/usePermissions.js'
 import { formatDateRange } from '../utils/datetime.js'
 
@@ -402,7 +400,6 @@ onMounted(async () => {
 	margin: 0 auto;
 }
 
-.loading-container,
 .error-container {
 	display: flex;
 	flex-direction: column;

--- a/src/views/PersonalSettings.vue
+++ b/src/views/PersonalSettings.vue
@@ -2,9 +2,7 @@
 	<div id="attendance-personal-settings">
 		<NcSettingsSection :name="t('attendance', 'Calendar subscription')"
 			:description="t('attendance', 'Subscribe to your appointments in external calendar apps like Google Calendar, Apple Calendar, or Thunderbird.')">
-			<div v-if="icalLoading" class="loading-section">
-				<NcLoadingIcon :size="32" />
-			</div>
+			<LoadingState v-if="icalLoading" />
 
 			<template v-else>
 				<div class="quick-subscribe-section">
@@ -80,10 +78,7 @@
 
 		<NcSettingsSection :name="t('attendance', 'Calendar reminders')"
 			:description="t('attendance', 'Configure reminders for appointments you accepted or tentatively accepted in your calendar subscription (iCal feed). You can select multiple reminder times.')">
-			<div v-if="settingsLoading" class="loading-section">
-				<NcLoadingIcon :size="32" />
-				<p>{{ t('attendance', 'Loading settings\u00A0\u2026') }}</p>
-			</div>
+			<LoadingState v-if="settingsLoading" :text="t('attendance', 'Loading settings\u00A0\u2026')" />
 
 			<div v-else>
 				<div class="setting-row">
@@ -125,7 +120,6 @@ import {
 	NcButton,
 	NcCheckboxRadioSwitch,
 	NcDialog,
-	NcLoadingIcon,
 	NcNoteCard,
 	NcSelect,
 	NcSettingsSection,
@@ -135,6 +129,7 @@ import AppleIcon from 'vue-material-design-icons/Apple.vue'
 import ContentCopy from 'vue-material-design-icons/ContentCopy.vue'
 import GoogleIcon from 'vue-material-design-icons/Google.vue'
 import Refresh from 'vue-material-design-icons/Refresh.vue'
+import LoadingState from '../components/common/LoadingState.vue'
 import { useIcalFeed } from '../composables/useIcalFeed.js'
 import { formatDateTime } from '../utils/datetime.js'
 
@@ -214,13 +209,6 @@ onMounted(() => {
 </script>
 
 <style scoped>
-.loading-section {
-	display: flex;
-	align-items: center;
-	gap: 12px;
-	padding: 20px 0;
-}
-
 .feed-url-section {
 	margin-bottom: 16px;
 }


### PR DESCRIPTION
## The bug

The appointment list marked its loading state with `class="loading"`:

```html
<div v-if="loading" class="loading">{{ t('attendance', 'Loading …') }}</div>
```

`loading` is not a free class name. Nextcloud core (`core/css/icons.scss`) claims it alongside `icon-loading`:

```scss
.loading, .loading-small, .icon-loading, … {
	position: relative;
	&:after {
		content: ''; height: 28px; width: 28px; margin: -16px 0 0 -16px;
		position: absolute; top: 50%; inset-inline-start: 50%;
		border-radius: 100%; animation: rotate .8s infinite linear;
		border: 2px solid var(--color-loading-light);
		border-top-color: var(--color-loading-dark);
	}
}
```

That paints an absolutely positioned spinner in the centre of the element — and the div also centred its own text there. So the word "Lade …" / "Loading …" sat directly on top of the animation, which is what showed up on every appointment list (upcoming, past, unanswered, all).

## The fix

Everything now goes through one `LoadingState` component: `NcLoadingIcon` above the label, centred, or an inline row for the compact activity-history state. It replaces eleven ad-hoc loading blocks that had each drifted apart — `App.vue` had a hand-rolled CSS spinner with its own `@keyframes spin` and no label, `AllAppointments` and `AppointmentDetail` had a label and no spinner, `AppointmentForm` only showed a spinner while bulk-importing.

To keep the collision from coming back, `vue/no-restricted-class` now rejects `loading` and `loading-small` in templates (verified: re-adding the class fails eslint).

## Verification

`./scripts/check.sh` — all gates green (eslint, stylelint, php-cs-fixer, psalm, phpunit, vite build, openapi).

Rendered the component in Chromium against core's spinner CSS to confirm the before/after: the old markup draws the ring straight through the word, the new one stacks spinner over label.

## Notes

- No API or capability changes, so nothing to gate for the Flutter client.
- No new translatable strings — the existing `Loading …`, `Loading settings …`, `Loading calendars …`, `Loading events …`, `Loading appointment data …` and `Importing appointments …` keys are reused unchanged.
- No frontend test infrastructure exists in this repo (only PHPUnit and Playwright e2e), and the loading state is transient enough that an e2e assertion on it would be flaky — the eslint rule is the regression guard instead.


---
_Generated by [Claude Code](https://claude.ai/code/session_01J3asSi1ZYvnSp9GMFC7MJr)_