### PR TITLE
Correct how the l10n-autotranslate skill describes the German sync protection

### DIFF
--- a/.claude/skills/l10n-autotranslate/SKILL.md
+++ b/.claude/skills/l10n-autotranslate/SKILL.md
@@ -6,10 +6,21 @@ description: Keep the German l10n files in step with the code — fill every sou
 # German translations (owned by this repo)
 
 Transifex is the source of truth for every language **except German**. `de` and
-`de_DE` are excluded from the sync in `.tx/config` — both are mapped to a local
-directory starting with a dot, which translationtool's `findLanguages()` skips,
-so `l10n/de.*` and `l10n/de_DE.*` are never regenerated. Repeated syncs had been
-overwriting reviewed German with worse wording and broken placeholders.
+`de_DE` are owned by this repo, because repeated syncs kept overwriting reviewed
+German with worse wording and broken placeholders.
+
+They are not excluded from the sync — **they cannot be.**
+`handleAppsTranslations.sh` runs `rm -f l10n/*.js l10n/*.json` and then rebuilds
+only what `convert-po-files` produces, so a language the pull skips is *deleted*,
+not preserved. A `lang_map` entry pointing de/de_DE at a dot-directory was tried
+and wiped all four files on the next nightly run. Do not try that again;
+`.tx/config` carries a warning.
+
+What protects German is `.github/workflows/protect-german-l10n.yml`: when a
+commit by the Transifex bot touches any of the four files on `main`, it restores
+them from the preceding commit and pushes. German therefore survives each sync,
+but only *after* it — expect one restore commit behind every nightly run that
+touched it.
 
 That makes this skill the **canonical path**: a string added with a fresh `t()` /
 `n()` call stays English until someone runs it. Nothing downstream will fix it


### PR DESCRIPTION
Noticed while running the skill on another branch: `.claude/skills/l10n-autotranslate/SKILL.md` still opens with

> `de` and `de_DE` are excluded from the sync in `.tx/config` — both are mapped to a local directory starting with a dot, which translationtool's `findLanguages()` skips, so `l10n/de.*` and `l10n/de_DE.*` are never regenerated.

That is the mechanism #159 removed, because it did the opposite of what it looks like: the pull runs `rm -f l10n/*.js l10n/*.json` and rebuilds only what `convert-po-files` produces, so a language the convert step skips gets **deleted** rather than left alone. Pointing de/de_DE at a dot-directory wiped all four German files on the next nightly run.

`CLAUDE.md` and `.tx/config` were corrected then; this skill was not. It matters more than a stale comment usually would, because the skill is the first thing a run reads on this topic — so it currently presents as settled fact the one approach that commit explicitly marks "do not try again", and it does so right next to the instruction to edit the German files by hand.

## What changed

The opening section now describes what actually protects German — `.github/workflows/protect-german-l10n.yml` restoring the four files after a bot commit touches them — and states plainly why the `.tx/config` route cannot work. It also spells out that German is overwritten by each sync and put back afterwards, so a restore commit trailing a sync is the system working, not a symptom.

**Text only.** The five working steps, the scripts and the frontmatter are untouched, so what the skill *does* is unchanged.

## Testing

Documentation only — no code, no gates affected. I did verify every reference it now makes: `.github/workflows/protect-german-l10n.yml` exists and carries the same explanation in its header, and `.tx/config` carries the warning the text points at.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SKCVdTUrsoeFrrZWwGNsxU)_