### PR TITLE
fix: restore spacing below the mobile app banner

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -899,7 +899,7 @@ onMounted(async () => {
 }
 
 .mobile-banner-container {
-    padding: 0 20px;
+    padding: 0 20px 20px;
     max-width: 1200px;
     margin: 0 auto;
 }


### PR DESCRIPTION
The toggle-clearance refactor zeroed the banner container's bottom padding along with the heading's top margin, so the banner ended up flush against the page heading below it.