### PR TITLE
fix(statistics): let a point on the 0 % or 100 % line draw in full

### DIFF
--- a/src/components/statistics/StatisticsCharts.vue
+++ b/src/components/statistics/StatisticsCharts.vue
@@ -75,7 +75,11 @@ const { colors } = useChartTheme()
 const TICK_MAX_CHARS = 16
 const TOOLTIP_TITLE_MAX_CHARS = 40
 
-const LINE_STYLE = { tension: 0.3, borderWidth: 2, pointRadius: 3, pointHoverRadius: 5 }
+// chart.js clips a dataset at the plot area, not at the canvas — so a point on
+// the 0 % or 100 % line loses its outer half. `clip` lets it spill into the
+// layout padding below, which is sized for the hover radius.
+const POINT_OVERFLOW = 8
+const LINE_STYLE = { tension: 0.3, borderWidth: 2, pointRadius: 3, pointHoverRadius: 5, clip: POINT_OVERFLOW }
 const BAR_STYLE = { borderRadius: 4, borderSkipped: false, maxBarThickness: 48, categoryPercentage: 0.7 }
 
 const percent = (rate) => (rate === null || rate === undefined ? null : Math.round(rate * 1000) / 10)
@@ -174,9 +178,8 @@ function baseOptions(labels = null, pointTitles = null) {
 		responsive: true,
 		maintainAspectRatio: false,
 		interaction: { intersect: false, mode: 'index' },
-		// Room for the point radius (and its hover radius) so a value sitting
-		// right on the 0 % or 100 % line isn't clipped by the canvas edge.
-		layout: { padding: { top: 8, right: 8, bottom: 4, left: 4 } },
+		// The room a point on the 0 % or 100 % line spills into.
+		layout: { padding: POINT_OVERFLOW },
 		plugins: {
 			legend: {
 				// chart.js centres over the whole canvas, and the y-axis labels


### PR DESCRIPTION
## Was war das Problem

Punkte im „Zeitlicher Verlauf"-Chart, die genau auf 0 % oder 100 % liegen, werden zur Hälfte abgeschnitten. Der Fix in af0d458c hat dafür `layout.padding` vergrößert — das hat nichts gebracht.

## Warum der letzte Anlauf nicht wirken konnte

Die Annahme war, die Canvas-Kante schneide ab. Tatsächlich clippt chart.js ein Dataset an der **Plot-Area**, und `layout.padding` verschiebt genau diese Grenze mit nach innen. Der Punkt auf dem Achsenlimit verliert seine äußere Hälfte danach also unverändert. Der chart.js-Default für `clip` ist `borderWidth / 2` — daher der 1-px-Splitter, der übrig bleibt.

Nachgemessen auf der Produktivinstanz (Canvas-Pixel, DPR 2):

- 100 %-Gitterlinie: Gerätezeile 91/92
- oberster Pixel des Punkts: Zeile **92**, mit flacher Kante
- Zeilen 85–91 komplett weiß — das Padding hatte dort Platz geschaffen, der ungenutzt blieb

Ein Punkt mit Radius 3 müsste bei 85,5 beginnen.

## Was sich ändert

- `clip: POINT_OVERFLOW` auf dem Line-Dataset, damit der Punkt in das reservierte Padding hineinzeichnen darf
- `layout.padding` jetzt gleichmäßig auf demselben Wert; unten und links standen auf 4 und lagen damit unter dem Hover-Radius von 5

Die Bar-Charts bleiben auf dem Default — ein Balken endet ohnehin an der Kante.

## Verifikation

Isolierte Repro-Seite mit der chart.js-Version aus dem Repo, alte und neue Optionen nebeneinander:

| | chartArea.top | oberster Punkt-Pixel |
|---|---|---|
| vorher | 92 | 92 — abgeschnitten |
| nachher | 92 | 84 — voller Radius |

Gleiches Bild an der 0 %-Kante. eslint und `npm run build` sind grün.

## Für den Review

Rein visuell, keine API- oder Verhaltensänderung — für den Flutter-Client irrelevant.