### PR TITLE
fix(summary): list visibility-group members outside the whitelist under Others

### DIFF
--- a/l10n/de.js
+++ b/l10n/de.js
@@ -183,7 +183,6 @@ OC.L10N.register(
     "Most popular" : "Am beliebtesten",
     "NFC is not available." : "NFC ist nicht verfügbar.",
     "Name (optional)" : "Name (optional)",
-    "New: scan the check-in code to check yourself in" : "Neu: Check-in-Code scannen und selbst einchecken",
     "Next appointment" : "Nächster Termin",
     "No appointment right now" : "Im Moment ist kein Termin verfügbar",
     "Not buying for a whole group? Get a license just for you." : "Du kaufst nicht für eine ganze Gruppe? Hol dir eine Lizenz nur für dich.",
@@ -932,6 +931,11 @@ OC.L10N.register(
     "Detail" : "Detailgrad",
     "Compact" : "Kompakt",
     "Full" : "Vollständig",
-    "Filter" : "Filter"
+    "Filter" : "Filter",
+    "Copy location" : "Ort kopieren",
+    "Location copied" : "Ort kopiert",
+    "Maps app" : "Karten-App",
+    "Notify users who can see this appointment about its creation" : "Benutzer, die diesen Termin sehen können, über die Erstellung benachrichtigen",
+    "OpenStreetMap" : "OpenStreetMap"
 },
 "nplurals=2; plural=(n != 1);");

--- a/l10n/de.json
+++ b/l10n/de.json
@@ -181,7 +181,6 @@
     "Most popular" : "Am beliebtesten",
     "NFC is not available." : "NFC ist nicht verfügbar.",
     "Name (optional)" : "Name (optional)",
-    "New: scan the check-in code to check yourself in" : "Neu: Check-in-Code scannen und selbst einchecken",
     "Next appointment" : "Nächster Termin",
     "No appointment right now" : "Im Moment ist kein Termin verfügbar",
     "Not buying for a whole group? Get a license just for you." : "Du kaufst nicht für eine ganze Gruppe? Hol dir eine Lizenz nur für dich.",
@@ -930,6 +929,11 @@
     "Detail" : "Detailgrad",
     "Compact" : "Kompakt",
     "Full" : "Vollständig",
-    "Filter" : "Filter"
+    "Filter" : "Filter",
+    "Copy location" : "Ort kopieren",
+    "Location copied" : "Ort kopiert",
+    "Maps app" : "Karten-App",
+    "Notify users who can see this appointment about its creation" : "Benutzer, die diesen Termin sehen können, über die Erstellung benachrichtigen",
+    "OpenStreetMap" : "OpenStreetMap"
 },"pluralForm" :"nplurals=2; plural=(n != 1);"
 }

--- a/l10n/de_DE.js
+++ b/l10n/de_DE.js
@@ -183,7 +183,6 @@ OC.L10N.register(
     "Most popular" : "Am beliebtesten",
     "NFC is not available." : "NFC ist nicht verfügbar.",
     "Name (optional)" : "Name (optional)",
-    "New: scan the check-in code to check yourself in" : "Neu: Check-in-Code scannen und selbst einchecken",
     "Next appointment" : "Nächster Termin",
     "No appointment right now" : "Im Moment ist kein Termin verfügbar",
     "Not buying for a whole group? Get a license just for you." : "Sie kaufen nicht für eine ganze Gruppe? Holen Sie sich eine Lizenz nur für sich.",
@@ -932,6 +931,11 @@ OC.L10N.register(
     "Detail" : "Detailgrad",
     "Compact" : "Kompakt",
     "Full" : "Vollständig",
-    "Filter" : "Filter"
+    "Filter" : "Filter",
+    "Copy location" : "Ort kopieren",
+    "Location copied" : "Ort kopiert",
+    "Maps app" : "Karten-App",
+    "Notify users who can see this appointment about its creation" : "Benutzer, die diesen Termin sehen können, über die Erstellung benachrichtigen",
+    "OpenStreetMap" : "OpenStreetMap"
 },
 "nplurals=2; plural=(n != 1);");

--- a/l10n/de_DE.json
+++ b/l10n/de_DE.json
@@ -181,7 +181,6 @@
     "Most popular" : "Am beliebtesten",
     "NFC is not available." : "NFC ist nicht verfügbar.",
     "Name (optional)" : "Name (optional)",
-    "New: scan the check-in code to check yourself in" : "Neu: Check-in-Code scannen und selbst einchecken",
     "Next appointment" : "Nächster Termin",
     "No appointment right now" : "Im Moment ist kein Termin verfügbar",
     "Not buying for a whole group? Get a license just for you." : "Sie kaufen nicht für eine ganze Gruppe? Holen Sie sich eine Lizenz nur für sich.",
@@ -930,6 +929,11 @@
     "Detail" : "Detailgrad",
     "Compact" : "Kompakt",
     "Full" : "Vollständig",
-    "Filter" : "Filter"
+    "Filter" : "Filter",
+    "Copy location" : "Ort kopieren",
+    "Location copied" : "Ort kopiert",
+    "Maps app" : "Karten-App",
+    "Notify users who can see this appointment about its creation" : "Benutzer, die diesen Termin sehen können, über die Erstellung benachrichtigen",
+    "OpenStreetMap" : "OpenStreetMap"
 },"pluralForm" :"nplurals=2; plural=(n != 1);"
 }

--- a/lib/Service/CheckinService.php
+++ b/lib/Service/CheckinService.php
@@ -126,8 +126,8 @@ class CheckinService {
 		// Get whitelisted groups for filtering
 		$whitelistedGroups = $this->configService->getWhitelistedGroups();
 
-		// Get relevant users efficiently - this filters by whitelisted groups when configured
-		$relevantUsers = $this->visibilityService->getRelevantUsersForAppointment($appointment, $whitelistedGroups);
+		// Get the target attendees efficiently - filters by whitelisted groups when configured
+		$targetAttendees = $this->visibilityService->getTargetAttendees($appointment, $whitelistedGroups);
 
 		// Create a map of user responses
 		$userResponseMap = [];
@@ -138,7 +138,7 @@ class CheckinService {
 		// Build group list for filtering UI
 		$userGroups = $this->buildGroupList($whitelistedGroups);
 
-		$users = $this->buildUserList($appointment, $relevantUsers, $userResponseMap, $whitelistedGroups);
+		$users = $this->buildUserList($targetAttendees, $userResponseMap, $whitelistedGroups);
 
 		return [
 			'appointment' => $appointment->jsonSerialize(),
@@ -171,29 +171,20 @@ class CheckinService {
 	/**
 	 * Build the unified user list with response data.
 	 *
-	 * @param \OCA\Attendance\Db\Appointment $appointment The appointment
-	 * @param array<string, \OCP\IUser> $relevantUsers Map of userId => IUser (pre-filtered by whitelisted groups)
+	 * @param array<string, \OCP\IUser> $targetAttendees Map of userId => IUser (the appointment's audience)
 	 * @param array $userResponseMap Map of userId => AttendanceResponse
 	 * @param array $whitelistedGroups List of whitelisted group IDs
 	 * @return array List of user data arrays
 	 */
 	private function buildUserList(
-		$appointment,
-		array $relevantUsers,
+		array $targetAttendees,
 		array $userResponseMap,
 		array $whitelistedGroups,
 	): array {
 		$users = [];
 
-		foreach ($relevantUsers as $userId => $user) {
-			// Filter: Only include users who are target attendees for this appointment
-			// This excludes admins who can "see" all appointments but aren't actual attendees
-			if (!$this->visibilityService->isUserTargetAttendee($appointment, $userId)) {
-				continue;
-			}
-
-			$userData = $this->buildUserData($user, $userResponseMap, $whitelistedGroups);
-			$users[] = $userData;
+		foreach ($targetAttendees as $user) {
+			$users[] = $this->buildUserData($user, $userResponseMap, $whitelistedGroups);
 		}
 
 		return $users;
@@ -212,8 +203,8 @@ class CheckinService {
 		// Get whitelisted groups for filtering
 		$whitelistedGroups = $this->configService->getWhitelistedGroups();
 
-		// Get relevant users - this filters by whitelisted groups when configured
-		$relevantUsers = $this->visibilityService->getRelevantUsersForAppointment($appointment, $whitelistedGroups);
+		// Get the target attendees - filters by whitelisted groups when configured
+		$targetAttendees = $this->visibilityService->getTargetAttendees($appointment, $whitelistedGroups);
 
 		// Create a map of user responses
 		$userResponseMap = [];
@@ -226,12 +217,7 @@ class CheckinService {
 		$absent = 0;
 		$notCheckedIn = 0;
 
-		foreach ($relevantUsers as $userId => $user) {
-			// Only count users who are target attendees
-			if (!$this->visibilityService->isUserTargetAttendee($appointment, $userId)) {
-				continue;
-			}
-
+		foreach ($targetAttendees as $userId => $user) {
 			if (isset($userResponseMap[$userId])) {
 				$checkinState = $userResponseMap[$userId]->getCheckinState();
 				if ($checkinState === 'yes') {

--- a/lib/Service/ResponseSummaryService.php
+++ b/lib/Service/ResponseSummaryService.php
@@ -146,7 +146,6 @@ class ResponseSummaryService {
 
 		$visibilitySettings = $this->visibilityService->getVisibilitySettings($appointment);
 		$appointmentHasRestrictions = $this->visibilityService->hasRestrictedVisibility($appointment);
-		$appointmentVisibleUsers = $visibilitySettings['users'];
 		$appointmentVisibleGroups = $visibilitySettings['groups'];
 		$appointmentVisibleGroupsLower = array_map('strtolower', $appointmentVisibleGroups);
 		$appointmentVisibleTeams = $visibilitySettings['teams'];
@@ -223,7 +222,6 @@ class ResponseSummaryService {
 			'allUserGroups' => $allUserGroups,
 			// Appointment-specific visibility restrictions
 			'appointmentHasRestrictions' => $appointmentHasRestrictions,
-			'appointmentVisibleUsers' => $appointmentVisibleUsers,
 			'appointmentVisibleGroups' => $appointmentVisibleGroups,
 			'appointmentVisibleGroupsLower' => $appointmentVisibleGroupsLower,
 			'appointmentVisibleTeams' => $appointmentVisibleTeams,
@@ -635,12 +633,10 @@ class ResponseSummaryService {
 				}
 			}
 
-			// Direct visibleUsers entries must render regardless of group
-			// membership; otherwise an individually invited user with no
-			// whitelisted-group ties would never reach the Others bucket.
-			$isDirectlyAddressedUser = in_array($userId, $cache['appointmentVisibleUsers'], true);
-
-			if (!$hasAllowedGroup && !$hasRelevantTeam && !$hasVisibleGroup && !$isDirectlyAddressedUser) {
+			// Skipping only guards open appointments, where Others would list
+			// the whole instance; a restricted one invited every relevant user.
+			if (!$cache['appointmentHasRestrictions']
+				&& !$hasAllowedGroup && !$hasRelevantTeam && !$hasVisibleGroup) {
 				continue;
 			}
 

--- a/lib/Service/ResponseSummaryService.php
+++ b/lib/Service/ResponseSummaryService.php
@@ -146,8 +146,7 @@ class ResponseSummaryService {
 
 		$visibilitySettings = $this->visibilityService->getVisibilitySettings($appointment);
 		$appointmentHasRestrictions = $this->visibilityService->hasRestrictedVisibility($appointment);
-		$appointmentVisibleGroups = $visibilitySettings['groups'];
-		$appointmentVisibleGroupsLower = array_map('strtolower', $appointmentVisibleGroups);
+		$appointmentVisibleGroupsLower = array_map('strtolower', $visibilitySettings['groups']);
 		$appointmentVisibleTeams = $visibilitySettings['teams'];
 
 		// Pre-fetch all users from responses
@@ -222,7 +221,6 @@ class ResponseSummaryService {
 			'allUserGroups' => $allUserGroups,
 			// Appointment-specific visibility restrictions
 			'appointmentHasRestrictions' => $appointmentHasRestrictions,
-			'appointmentVisibleGroups' => $appointmentVisibleGroups,
 			'appointmentVisibleGroupsLower' => $appointmentVisibleGroupsLower,
 			'appointmentVisibleTeams' => $appointmentVisibleTeams,
 		];
@@ -240,7 +238,7 @@ class ResponseSummaryService {
 		}
 
 		// Second check: if appointment has restrictions, group must be in visible groups
-		if ($cache['appointmentHasRestrictions'] && !empty($cache['appointmentVisibleGroups'])) {
+		if ($cache['appointmentHasRestrictions'] && !empty($cache['appointmentVisibleGroupsLower'])) {
 			return in_array(strtolower($groupId), $cache['appointmentVisibleGroupsLower']);
 		}
 
@@ -592,6 +590,7 @@ class ResponseSummaryService {
 		$totalMaybe = [];
 		$othersNonResponding = [];
 		$othersMaybe = [];
+		$skipUnaffiliated = !$cache['appointmentHasRestrictions'];
 
 		foreach ($cache['allUsers'] as $user) {
 			$userId = $user->getUID();
@@ -610,12 +609,14 @@ class ResponseSummaryService {
 			$hasVisibleGroup = false;
 			foreach ($userGroups as $group) {
 				$gid = $group->getGID();
-				if ($this->isGroupAllowedCached($gid, $cache)) {
+				if ($this->isGroupVisibleAsSection($gid, $cache)) {
 					$hasAllowedGroup = true;
-					if ($this->isGroupVisibleAsSection($gid, $cache)) {
-						$hasVisibleGroup = true;
-						break;
-					}
+					$hasVisibleGroup = true;
+					break;
+				}
+				// Allowed-but-hidden groups (guest_app) still count as affiliation.
+				if ($skipUnaffiliated && !$hasAllowedGroup) {
+					$hasAllowedGroup = $this->isGroupAllowedCached($gid, $cache);
 				}
 			}
 
@@ -633,10 +634,9 @@ class ResponseSummaryService {
 				}
 			}
 
-			// Skipping only guards open appointments, where Others would list
-			// the whole instance; a restricted one invited every relevant user.
-			if (!$cache['appointmentHasRestrictions']
-				&& !$hasAllowedGroup && !$hasRelevantTeam && !$hasVisibleGroup) {
+			// A restricted appointment invited every relevant user; open ones
+			// skip users tied to no allowed group or team — not audience.
+			if ($skipUnaffiliated && !$hasAllowedGroup && !$hasRelevantTeam) {
 				continue;
 			}
 

--- a/lib/Service/ResponseSummaryService.php
+++ b/lib/Service/ResponseSummaryService.php
@@ -74,7 +74,7 @@ class ResponseSummaryService {
 		// Single pass: populate the global non-responder list AND the Others
 		// bucket (target attendees who don't surface in any visible section,
 		// e.g. guests whose `guest_app` group is hidden).
-		$this->collectMissingResponders($appointment, $summary, $respondedUserIds, $cache);
+		$this->collectMissingResponders($summary, $respondedUserIds, $cache);
 
 		// Filter out empty groups and teams (can occur with visibility restrictions)
 		$summary['by_group'] = $this->filterEmptyGroups($summary['by_group']);
@@ -117,11 +117,9 @@ class ResponseSummaryService {
 		}
 
 		$whitelistedGroups = $this->configService->getWhitelistedGroups();
-		$relevantUsers = $this->visibilityService->getRelevantUsersForAppointment($appointment, $whitelistedGroups);
-		foreach ($relevantUsers as $user) {
-			$userId = $user->getUID();
-			if (!isset($respondedUserIds[$userId])
-				&& $this->visibilityService->isUserTargetAttendee($appointment, $userId)) {
+		$targetAttendees = $this->visibilityService->getTargetAttendees($appointment, $whitelistedGroups);
+		foreach ($targetAttendees as $user) {
+			if (!isset($respondedUserIds[$user->getUID()])) {
 				$counts['no_response']++;
 			}
 		}
@@ -189,16 +187,16 @@ class ResponseSummaryService {
 			}
 		}
 
-		// OPTIMIZATION: Only load relevant users based on appointment visibility
-		// instead of loading ALL users in the system
-		$relevantUsers = $this->visibilityService->getRelevantUsersForAppointment(
+		// OPTIMIZATION: Only load the appointment's target attendees based on
+		// visibility instead of loading ALL users in the system
+		$targetAttendees = $this->visibilityService->getTargetAttendees(
 			$appointment,
 			$whitelistedGroups
 		);
 
 		$allUsersMap = [];
 		$allUserGroups = [];
-		foreach ($relevantUsers as $uid => $user) {
+		foreach ($targetAttendees as $uid => $user) {
 			$allUsersMap[$uid] = $user;
 			if (!isset($userGroups[$uid])) {
 				$allUserGroups[$uid] = $this->groupManager->getUserGroups($user);
@@ -581,7 +579,6 @@ class ResponseSummaryService {
 	 * renders) — typically a guest with only `guest_app` membership.
 	 */
 	private function collectMissingResponders(
-		Appointment $appointment,
 		array &$summary,
 		array $respondedUserIds,
 		array $cache,
@@ -592,12 +589,9 @@ class ResponseSummaryService {
 		$othersMaybe = [];
 		$skipUnaffiliated = !$cache['appointmentHasRestrictions'];
 
+		/** @var \OCP\IUser $user */
 		foreach ($cache['allUsers'] as $user) {
 			$userId = $user->getUID();
-
-			if (!$this->visibilityService->isUserTargetAttendee($appointment, $userId)) {
-				continue;
-			}
 
 			$userResponse = $respondedUserIds[$userId] ?? null;
 			if ($userResponse !== null && $userResponse !== 'maybe') {

--- a/lib/Service/VisibilityService.php
+++ b/lib/Service/VisibilityService.php
@@ -148,7 +148,7 @@ class VisibilityService {
 	 * Get relevant users for an appointment efficiently.
 	 *
 	 * This method avoids loading ALL users in the system by:
-	 * - For restricted appointments: only loading users from visible_users and visible_groups
+	 * - For restricted appointments: only loading users from visible_users, visible_groups and visible_teams
 	 * - For unrestricted appointments: loading users from specified whitelisted groups
 	 *
 	 * @param Appointment $appointment The appointment
@@ -179,6 +179,19 @@ class VisibilityService {
 				}
 			}
 
+			// Add members of visible teams
+			foreach ($settings['teams'] as $teamId) {
+				foreach ($this->getTeamMembers($teamId) as $memberId) {
+					if (isset($relevantUsers[$memberId])) {
+						continue;
+					}
+					$user = $this->userManager->get($memberId);
+					if ($user) {
+						$relevantUsers[$memberId] = $user;
+					}
+				}
+			}
+
 			return $relevantUsers;
 		}
 
@@ -204,6 +217,28 @@ class VisibilityService {
 		}
 
 		return $relevantUsers;
+	}
+
+	/**
+	 * The appointment's audience: relevant users narrowed to actual target
+	 * attendees. The one definition shared by the response summary, the
+	 * counts endpoint and the check-in views — call this instead of pairing
+	 * getRelevantUsersForAppointment() with isUserTargetAttendee() by hand.
+	 *
+	 * @param Appointment $appointment The appointment
+	 * @param array<string> $whitelistedGroups Groups to consider (from ConfigService)
+	 * @return array<string, \OCP\IUser> Map of userId => IUser
+	 */
+	public function getTargetAttendees(Appointment $appointment, array $whitelistedGroups = []): array {
+		$attendees = [];
+		foreach ($this->getRelevantUsersForAppointment($appointment, $whitelistedGroups) as $user) {
+			// UID from the object — array keys coerce numeric UIDs to int (issue #63).
+			$userId = $user->getUID();
+			if ($this->isUserTargetAttendee($appointment, $userId)) {
+				$attendees[$userId] = $user;
+			}
+		}
+		return $attendees;
 	}
 
 	/**

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -2129,7 +2129,6 @@
       <code><![CDATA[$userId]]></code>
       <code><![CDATA[$userId]]></code>
       <code><![CDATA[$userId]]></code>
-      <code><![CDATA[$userId]]></code>
     </MixedArgument>
     <MixedArrayAccess>
       <code><![CDATA[$cache['groupUsers'][$groupId]]]></code>
@@ -2222,10 +2221,8 @@
       <code><![CDATA[$teamMemberIds]]></code>
       <code><![CDATA[$user]]></code>
       <code><![CDATA[$user]]></code>
-      <code><![CDATA[$user]]></code>
       <code><![CDATA[$userGroups]]></code>
       <code><![CDATA[$userGroups]]></code>
-      <code><![CDATA[$userId]]></code>
       <code><![CDATA[$userId]]></code>
       <code><![CDATA[$userId]]></code>
       <code><![CDATA[$userId]]></code>
@@ -2237,11 +2234,9 @@
       <code><![CDATA[getDisplayName]]></code>
       <code><![CDATA[getDisplayName]]></code>
       <code><![CDATA[getDisplayName]]></code>
-      <code><![CDATA[getDisplayName]]></code>
       <code><![CDATA[getGID]]></code>
       <code><![CDATA[getGID]]></code>
       <code><![CDATA[getResponse]]></code>
-      <code><![CDATA[getUID]]></code>
       <code><![CDATA[getUID]]></code>
       <code><![CDATA[getUID]]></code>
       <code><![CDATA[getUserId]]></code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -2105,7 +2105,6 @@
     <MixedArgument>
       <code><![CDATA[$cache['appointmentVisibleGroupsLower']]]></code>
       <code><![CDATA[$cache['appointmentVisibleTeams']]]></code>
-      <code><![CDATA[$cache['appointmentVisibleUsers']]]></code>
       <code><![CDATA[$cache['groupUsers']]]></code>
       <code><![CDATA[$cache['whitelistedGroups']]]></code>
       <code><![CDATA[$cache['whitelistedGroupsLower']]]></code>

--- a/src/App.vue
+++ b/src/App.vue
@@ -448,6 +448,7 @@ t('attendance', 'Check-in recorded: {state}')
 t('attendance', 'Check-in updated: {state}')
 t('attendance', 'Checked in at {time}')
 t('attendance', 'Common')
+t('attendance', 'Copy location')
 t('attendance', 'Could not load language and group options: {error}')
 t('attendance', 'Create')
 t('attendance', 'Created guest account for {email}')
@@ -484,18 +485,21 @@ t('attendance', 'Language')
 // TRANSLATORS: Framing for the yearly personal plan (11.99 € per year). The
 // price itself always comes from the app store, never from this string.
 t('attendance', 'Less than one euro a month')
+t('attendance', 'Location copied')
+// TRANSLATORS: Android action-sheet entry opening the location in the phone's installed maps app.
+t('attendance', 'Maps app')
 // TRANSLATORS: Badge on the recommended subscription plan.
 t('attendance', 'Most popular')
 t('attendance', 'NFC is not available.')
 t('attendance', 'Name (optional)')
-// TRANSLATORS: One-time banner in the mobile app announcing self-check-in.
-t('attendance', 'New: scan the check-in code to check yourself in')
 t('attendance', 'Next appointment')
 t('attendance', 'No appointment right now')
 t('attendance', 'Not buying for a whole group? Get a license just for you.')
 t('attendance', 'Not ready to decide? Add 14 days, free')
 t('attendance', 'Not signed in on this server')
+t('attendance', 'Notify users who can see this appointment about its creation')
 t('attendance', 'One license covers everyone on your server.')
+t('attendance', 'OpenStreetMap')
 // TRANSLATORS: Subscription status shown for a license that covers one person
 // rather than the whole Nextcloud instance.
 t('attendance', 'Personal license')

--- a/tests/unit/Service/ResponseSummaryServiceTest.php
+++ b/tests/unit/Service/ResponseSummaryServiceTest.php
@@ -89,7 +89,7 @@ class ResponseSummaryServiceTest extends TestCase {
 			->willReturn(['users' => [], 'groups' => [], 'teams' => []]);
 		$this->visibilityService->method('hasRestrictedVisibility')->willReturn(false);
 		$this->visibilityService->method('isUserTargetAttendee')->willReturn(true);
-		$this->visibilityService->method('getRelevantUsersForAppointment')->willReturn([]);
+		$this->visibilityService->method('getTargetAttendees')->willReturn([]);
 
 		$numericGroup = $this->createMock(IGroup::class);
 		$numericGroup->method('getGID')->willReturn('123');
@@ -104,9 +104,10 @@ class ResponseSummaryServiceTest extends TestCase {
 	}
 
 	/**
-	 * Regression test for the second leg of issue #63: iterating $cache['allUsers']
-	 * via `as $userId => $user` coerced numeric-string UIDs to int, which then
-	 * tripped VisibilityService::isUserTargetAttendee()'s string type hint.
+	 * Regression test for the second leg of issue #63: numeric-string UIDs
+	 * become int array keys in $cache['allUsers'] and must not trip any
+	 * string type hint. The cast at the source lives in
+	 * VisibilityService::getTargetAttendees() (see VisibilityServiceTest).
 	 */
 	public function testGetResponseSummaryWithNumericUserIdDoesNotThrowTypeError(): void {
 		$appointmentId = 2;
@@ -138,14 +139,9 @@ class ResponseSummaryServiceTest extends TestCase {
 		$this->groupManager->method('getUserGroups')->willReturn([$staffGroup]);
 
 		// Keyed by the numeric-string UID; PHP coerces the key to int 456.
-		$this->visibilityService->method('getRelevantUsersForAppointment')
+		$this->visibilityService->method('getTargetAttendees')
 			->willReturn(['456' => $numericUser]);
-
-		// Strict string type — the original bug surfaced here too.
-		$this->visibilityService->expects($this->atLeastOnce())
-			->method('isUserTargetAttendee')
-			->with($this->anything(), $this->isType('string'))
-			->willReturn(true);
+		$this->visibilityService->method('isUserTargetAttendee')->willReturn(true);
 
 		$summary = $this->service->getResponseSummary($appointmentId);
 
@@ -190,7 +186,7 @@ class ResponseSummaryServiceTest extends TestCase {
 		$this->groupManager->method('get')->with('staff')->willReturn($staffGroup);
 		$this->groupManager->method('getUserGroups')->willReturn([]);
 
-		$this->visibilityService->method('getRelevantUsersForAppointment')
+		$this->visibilityService->method('getTargetAttendees')
 			->willReturn(['new_hire' => $newHire]);
 
 		$summary = $this->service->getResponseSummary($appointmentId);
@@ -252,7 +248,7 @@ class ResponseSummaryServiceTest extends TestCase {
 		$this->userManager->method('get')->with('alice')->willReturn($alice);
 		$this->groupManager->method('getUserGroups')->willReturn([$boardGroup]);
 
-		$this->visibilityService->method('getRelevantUsersForAppointment')
+		$this->visibilityService->method('getTargetAttendees')
 			->willReturn(['alice' => $alice, 'bob' => $bob]);
 
 		$summary = $this->service->getResponseSummary($appointmentId);
@@ -267,6 +263,55 @@ class ResponseSummaryServiceTest extends TestCase {
 		$this->assertSame(1, $summary['others']['no_response']);
 		$othersIds = array_map(static fn (array $u): string => $u['userId'], $summary['others']['non_responding_users']);
 		$this->assertSame(['bob'], $othersIds);
+	}
+
+	/**
+	 * Same regression for teams: members reaching an appointment only through
+	 * a visibility team outside the whitelisted teams must surface under
+	 * Others and in the global non-responder count.
+	 */
+	public function testGetResponseSummaryListsVisibleTeamMembersOutsideWhitelistUnderOthers(): void {
+		$appointmentId = 7;
+		$appointment = new Appointment();
+		$appointment->setId($appointmentId);
+		$appointment->setVisibleUsers('[]');
+		$appointment->setVisibleGroups('[]');
+		$appointment->setVisibleTeams(json_encode(['team-1']));
+
+		$this->appointmentMapper->method('find')->with($appointmentId)->willReturn($appointment);
+		$this->responseMapper->method('findByAppointment')->with($appointmentId)->willReturn([]);
+
+		$this->configService->method('getWhitelistedGroups')->willReturn(['staff']);
+		$this->configService->method('getWhitelistedTeams')->willReturn([]);
+
+		$this->visibilityService->method('getVisibilitySettings')
+			->willReturn(['users' => [], 'groups' => [], 'teams' => ['team-1']]);
+		$this->visibilityService->method('hasRestrictedVisibility')->willReturn(true);
+		$this->visibilityService->method('isUserTargetAttendee')->willReturn(true);
+
+		$carol = $this->createMock(IUser::class);
+		$carol->method('getUID')->willReturn('carol');
+		$carol->method('getDisplayName')->willReturn('Carol');
+
+		$staffGroup = $this->createMock(IGroup::class);
+		$staffGroup->method('getGID')->willReturn('staff');
+		$staffGroup->method('getUsers')->willReturn([]);
+
+		$this->groupManager->method('get')->with('staff')->willReturn($staffGroup);
+		$this->groupManager->method('getUserGroups')->willReturn([]);
+
+		// getTargetAttendees now folds team members into the audience.
+		$this->visibilityService->method('getTargetAttendees')
+			->willReturn(['carol' => $carol]);
+
+		$summary = $this->service->getResponseSummary($appointmentId);
+
+		$this->assertSame([], $summary['by_group']);
+		$this->assertSame([], $summary['by_team']);
+		$this->assertSame(1, $summary['no_response']);
+		$this->assertSame(1, $summary['others']['no_response']);
+		$othersIds = array_map(static fn (array $u): string => $u['userId'], $summary['others']['non_responding_users']);
+		$this->assertSame(['carol'], $othersIds);
 	}
 
 	/**
@@ -302,7 +347,7 @@ class ResponseSummaryServiceTest extends TestCase {
 			->willReturn(['users' => [], 'groups' => [], 'teams' => []]);
 		$this->visibilityService->method('hasRestrictedVisibility')->willReturn(false);
 		$this->visibilityService->method('isUserTargetAttendee')->willReturn(true);
-		$this->visibilityService->method('getRelevantUsersForAppointment')->willReturn([]);
+		$this->visibilityService->method('getTargetAttendees')->willReturn([]);
 
 		$alice = $this->createMock(IUser::class);
 		$alice->method('getUID')->willReturn('alice');
@@ -362,7 +407,7 @@ class ResponseSummaryServiceTest extends TestCase {
 		$bob->method('getDisplayName')->willReturn('Bob');
 
 		// Bob never answered → counted as no_response.
-		$this->visibilityService->method('getRelevantUsersForAppointment')
+		$this->visibilityService->method('getTargetAttendees')
 			->willReturn(['alice' => $alice, 'bob' => $bob]);
 
 		$counts = $this->service->getResponseCounts($appointmentId);

--- a/tests/unit/Service/ResponseSummaryServiceTest.php
+++ b/tests/unit/Service/ResponseSummaryServiceTest.php
@@ -249,7 +249,7 @@ class ResponseSummaryServiceTest extends TestCase {
 		$staffGroup->method('getUsers')->willReturn([]);
 
 		$this->groupManager->method('get')->with('staff')->willReturn($staffGroup);
-		$this->userManager->method('get')->willReturnMap([['alice', $alice], ['bob', $bob]]);
+		$this->userManager->method('get')->with('alice')->willReturn($alice);
 		$this->groupManager->method('getUserGroups')->willReturn([$boardGroup]);
 
 		$this->visibilityService->method('getRelevantUsersForAppointment')

--- a/tests/unit/Service/ResponseSummaryServiceTest.php
+++ b/tests/unit/Service/ResponseSummaryServiceTest.php
@@ -204,6 +204,72 @@ class ResponseSummaryServiceTest extends TestCase {
 	}
 
 	/**
+	 * Regression: members reaching an appointment only through a visibility
+	 * group outside the admin whitelist used to vanish — no group section
+	 * (correct), but also no Others entry and no global non-responder count.
+	 * They must surface under Others like directly invited users do.
+	 */
+	public function testGetResponseSummaryListsVisibleGroupMembersOutsideWhitelistUnderOthers(): void {
+		$appointmentId = 6;
+		$appointment = new Appointment();
+		$appointment->setId($appointmentId);
+		$appointment->setVisibleUsers('[]');
+		$appointment->setVisibleGroups(json_encode(['board']));
+		$appointment->setVisibleTeams('[]');
+
+		$response = new AttendanceResponse();
+		$response->setId(1);
+		$response->setAppointmentId($appointmentId);
+		$response->setUserId('alice');
+		$response->setResponse('yes');
+
+		$this->appointmentMapper->method('find')->with($appointmentId)->willReturn($appointment);
+		$this->responseMapper->method('findByAppointment')->with($appointmentId)->willReturn([$response]);
+
+		// The whitelist names a different group than the appointment targets.
+		$this->configService->method('getWhitelistedGroups')->willReturn(['staff']);
+		$this->configService->method('getWhitelistedTeams')->willReturn([]);
+
+		$this->visibilityService->method('getVisibilitySettings')
+			->willReturn(['users' => [], 'groups' => ['board'], 'teams' => []]);
+		$this->visibilityService->method('hasRestrictedVisibility')->willReturn(true);
+		$this->visibilityService->method('isUserTargetAttendee')->willReturn(true);
+
+		$alice = $this->createMock(IUser::class);
+		$alice->method('getUID')->willReturn('alice');
+		$alice->method('getDisplayName')->willReturn('Alice');
+		$bob = $this->createMock(IUser::class);
+		$bob->method('getUID')->willReturn('bob');
+		$bob->method('getDisplayName')->willReturn('Bob');
+
+		$boardGroup = $this->createMock(IGroup::class);
+		$boardGroup->method('getGID')->willReturn('board');
+		$staffGroup = $this->createMock(IGroup::class);
+		$staffGroup->method('getGID')->willReturn('staff');
+		$staffGroup->method('getUsers')->willReturn([]);
+
+		$this->groupManager->method('get')->with('staff')->willReturn($staffGroup);
+		$this->userManager->method('get')->willReturnMap([['alice', $alice], ['bob', $bob]]);
+		$this->groupManager->method('getUserGroups')->willReturn([$boardGroup]);
+
+		$this->visibilityService->method('getRelevantUsersForAppointment')
+			->willReturn(['alice' => $alice, 'bob' => $bob]);
+
+		$summary = $this->service->getResponseSummary($appointmentId);
+
+		// 'board' is not whitelisted, so no group section renders for it …
+		$this->assertSame([], $summary['by_group']);
+		// … but Alice's answer and Bob's silence both surface under Others.
+		$this->assertSame(1, $summary['others']['yes']);
+		$this->assertCount(1, $summary['others']['responses']);
+		$this->assertSame('Alice', $summary['others']['responses'][0]['userName']);
+		$this->assertSame(1, $summary['no_response']);
+		$this->assertSame(1, $summary['others']['no_response']);
+		$othersIds = array_map(static fn (array $u): string => $u['userId'], $summary['others']['non_responding_users']);
+		$this->assertSame(['bob'], $othersIds);
+	}
+
+	/**
 	 * Security regression: the free-text comment / checkinComment fields carry
 	 * potentially sensitive content and must only be exposed to callers who
 	 * hold PERMISSION_SEE_COMMENTS. With $includeComments = false the serialized

--- a/tests/unit/Service/VisibilityServiceTest.php
+++ b/tests/unit/Service/VisibilityServiceTest.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\Attendance\Tests\Unit\Service;
+
+use OCA\Attendance\Db\Appointment;
+use OCA\Attendance\Service\PermissionService;
+use OCA\Attendance\Service\VisibilityService;
+use OCP\IGroupManager;
+use OCP\IUser;
+use OCP\IUserManager;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+
+class VisibilityServiceTest extends TestCase {
+	/** @var IGroupManager|MockObject */
+	private $groupManager;
+
+	/** @var IUserManager|MockObject */
+	private $userManager;
+
+	/** @var PermissionService|MockObject */
+	private $permissionService;
+
+	/** @var ContainerInterface|MockObject */
+	private $container;
+
+	protected function setUp(): void {
+		$this->groupManager = $this->createMock(IGroupManager::class);
+		$this->userManager = $this->createMock(IUserManager::class);
+		$this->permissionService = $this->createMock(PermissionService::class);
+		// No Circles app in unit tests — the service must cope without it.
+		$this->container = $this->createMock(ContainerInterface::class);
+		$this->container->method('get')->willThrowException(new \Exception('Circles not available'));
+	}
+
+	/**
+	 * @param array<string, list<string>> $membersByTeam
+	 * @return VisibilityService|MockObject
+	 */
+	private function serviceWithTeamMembers(array $membersByTeam) {
+		$service = $this->getMockBuilder(VisibilityService::class)
+			->setConstructorArgs([
+				$this->groupManager,
+				$this->userManager,
+				$this->permissionService,
+				$this->container,
+			])
+			->onlyMethods(['getTeamMembers'])
+			->getMock();
+		$service->method('getTeamMembers')
+			->willReturnCallback(static fn (string $teamId): array => $membersByTeam[$teamId] ?? []);
+		return $service;
+	}
+
+	/**
+	 * Regression: the restricted branch loaded visible_users and
+	 * visible_groups but not visible_teams, so a team-only restricted
+	 * appointment reported an empty audience — no non-responders anywhere.
+	 */
+	public function testGetRelevantUsersIncludesVisibleTeamMembers(): void {
+		$appointment = new Appointment();
+		$appointment->setVisibleUsers(json_encode(['carol']));
+		$appointment->setVisibleGroups('[]');
+		$appointment->setVisibleTeams(json_encode(['team-1']));
+
+		$carol = $this->createMock(IUser::class);
+		$dave = $this->createMock(IUser::class);
+		$this->userManager->method('get')->willReturnMap([
+			['carol', $carol],
+			['dave', $dave],
+		]);
+
+		$service = $this->serviceWithTeamMembers(['team-1' => ['carol', 'dave']]);
+		$relevant = $service->getRelevantUsersForAppointment($appointment);
+
+		// Carol appears once even though she is invited directly AND via team.
+		$this->assertSame(['carol', 'dave'], array_keys($relevant));
+	}
+
+	/**
+	 * getTargetAttendees is the one shared audience definition: relevant
+	 * users narrowed by isUserTargetAttendee. Numeric-string UIDs become int
+	 * array keys (issue #63); reading the UID from the object must keep the
+	 * strict string type hint satisfied instead of every caller doing so.
+	 */
+	public function testGetTargetAttendeesFiltersNonAttendeesAndSurvivesNumericIds(): void {
+		$appointment = new Appointment();
+		$appointment->setVisibleUsers(json_encode(['alice', '456']));
+		$appointment->setVisibleGroups('[]');
+		$appointment->setVisibleTeams('[]');
+
+		$alice = $this->createMock(IUser::class);
+		$alice->method('getUID')->willReturn('alice');
+		$mallory = $this->createMock(IUser::class);
+		$mallory->method('getUID')->willReturn('mallory');
+		$numericUser = $this->createMock(IUser::class);
+		$numericUser->method('getUID')->willReturn('456');
+
+		$service = $this->getMockBuilder(VisibilityService::class)
+			->setConstructorArgs([
+				$this->groupManager,
+				$this->userManager,
+				$this->permissionService,
+				$this->container,
+			])
+			->onlyMethods(['getRelevantUsersForAppointment'])
+			->getMock();
+		$service->method('getRelevantUsersForAppointment')
+			->willReturn(['alice' => $alice, 'mallory' => $mallory, '456' => $numericUser]);
+
+		$attendees = $service->getTargetAttendees($appointment);
+
+		// Mallory is relevant but no target attendee; 456 survives the
+		// int-key round trip without tripping the string type hint.
+		$this->assertSame(['alice', 456], array_keys($attendees));
+	}
+}


### PR DESCRIPTION
Two things ride on this branch:

## Response summary: complete audience for restricted appointments

Members reaching an appointment **only through a visibility group or team that is not in the admin whitelist** vanished from the response summary: no Others entry, no global non-responder count — while `getResponseCounts` on the list endpoint did count them, so list and detail view disagreed. Responders already landed under Others; non-responders were dropped.

Three commits, verified red-before/green-after with regression tests:

- **Groups** (`fix(summary)`): the skip in `collectMissingResponders()` now only applies to open appointments (it filters users tied to no allowed group or team); a restricted appointment invited every relevant user, so nobody is dropped there.
- **Teams** (`fix(visibility)`): `getRelevantUsersForAppointment()` loaded `visible_users` and `visible_groups` but not `visible_teams`, so a team-only restricted appointment reported an empty audience everywhere. The restricted branch now folds in team members — healing the summary, counts, check-in lists and reminders at once.
- **One audience definition**: the `getRelevantUsersForAppointment()` + `isUserTargetAttendee()` pairing that the summary, the counts endpoint and both check-in views re-implemented by hand now lives in `VisibilityService::getTargetAttendees()`, with the issue-#63 numeric-UID guard at the source. New `VisibilityServiceTest` covers both. The statistics service keeps its ID-based audience set on purpose (bulk computation with its own caches); a review follow-up commit also tightens the missing-responder walk.

## l10n: register the mobile app's new strings

Registers `Maps app`, `OpenStreetMap`, `Copy location`, `Location copied` (from luflow/attendance-flutter#79) plus the previously unregistered notification hint, drops the retired self-check-in banner string, and adds the German entries. The Flutter app already ships this German via the paired PR; merging this lets Transifex pick the strings up for the other languages.

`./scripts/check.sh` passes (eslint, stylelint, php-cs-fixer, psalm, PHPUnit 322 tests, vite build, l10n checks, OpenAPI spec check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F9ddZ12ZeSSn81cBRTRrLK