### PR TITLE
refactor(visibility): memoize settings decode, drop re-derived audience checks

### DIFF
--- a/lib/Service/CheckinService.php
+++ b/lib/Service/CheckinService.php
@@ -138,7 +138,10 @@ class CheckinService {
 		// Build group list for filtering UI
 		$userGroups = $this->buildGroupList($whitelistedGroups);
 
-		$users = $this->buildUserList($targetAttendees, $userResponseMap, $whitelistedGroups);
+		$users = array_map(
+			fn ($user) => $this->buildUserData($user, $userResponseMap, $whitelistedGroups),
+			array_values($targetAttendees),
+		);
 
 		return [
 			'appointment' => $appointment->jsonSerialize(),
@@ -169,28 +172,6 @@ class CheckinService {
 	}
 
 	/**
-	 * Build the unified user list with response data.
-	 *
-	 * @param array<string, \OCP\IUser> $targetAttendees Map of userId => IUser (the appointment's audience)
-	 * @param array $userResponseMap Map of userId => AttendanceResponse
-	 * @param array $whitelistedGroups List of whitelisted group IDs
-	 * @return array List of user data arrays
-	 */
-	private function buildUserList(
-		array $targetAttendees,
-		array $userResponseMap,
-		array $whitelistedGroups,
-	): array {
-		$users = [];
-
-		foreach ($targetAttendees as $user) {
-			$users[] = $this->buildUserData($user, $userResponseMap, $whitelistedGroups);
-		}
-
-		return $users;
-	}
-
-	/**
 	 * Get checkin summary counts for an appointment.
 	 *
 	 * @param int $appointmentId The appointment ID
@@ -217,7 +198,7 @@ class CheckinService {
 		$absent = 0;
 		$notCheckedIn = 0;
 
-		foreach ($targetAttendees as $userId => $user) {
+		foreach (array_keys($targetAttendees) as $userId) {
 			if (isset($userResponseMap[$userId])) {
 				$checkinState = $userResponseMap[$userId]->getCheckinState();
 				if ($checkinState === 'yes') {

--- a/lib/Service/ResponseSummaryService.php
+++ b/lib/Service/ResponseSummaryService.php
@@ -68,7 +68,7 @@ class ResponseSummaryService {
 		}
 
 		// Add non-responding users to groups and teams
-		$this->addNonRespondingUsers($appointment, $summary, $respondedUserIds, $cache);
+		$this->addNonRespondingUsers($summary, $respondedUserIds, $cache);
 		$this->addNonRespondingTeamUsers($appointment, $summary, $respondedUserIds, $cache);
 
 		// Single pass: populate the global non-responder list AND the Others
@@ -194,15 +194,9 @@ class ResponseSummaryService {
 			$whitelistedGroups
 		);
 
-		$allUsersMap = [];
 		$allUserGroups = [];
 		foreach ($targetAttendees as $uid => $user) {
-			$allUsersMap[$uid] = $user;
-			if (!isset($userGroups[$uid])) {
-				$allUserGroups[$uid] = $this->groupManager->getUserGroups($user);
-			} else {
-				$allUserGroups[$uid] = $userGroups[$uid];
-			}
+			$allUserGroups[$uid] = $userGroups[$uid] ?? $this->groupManager->getUserGroups($user);
 		}
 
 		return [
@@ -215,7 +209,7 @@ class ResponseSummaryService {
 			'users' => $users,
 			'userGroups' => $userGroups,
 			'groupUsers' => $groupUsers,
-			'allUsers' => $allUsersMap,
+			'allUsers' => $targetAttendees,
 			'allUserGroups' => $allUserGroups,
 			// Appointment-specific visibility restrictions
 			'appointmentHasRestrictions' => $appointmentHasRestrictions,
@@ -444,7 +438,6 @@ class ResponseSummaryService {
 	 * Add non-responding users to group summaries.
 	 */
 	private function addNonRespondingUsers(
-		Appointment $appointment,
 		array &$summary,
 		array $respondedUserIds,
 		array $cache,
@@ -478,11 +471,12 @@ class ResponseSummaryService {
 			$nonRespondingUsers = [];
 			$maybeUsers = [];
 
+			/** @var \OCP\IUser $user */
 			foreach ($groupUsers as $user) {
 				$userId = $user->getUID();
 
-				// Filter to only actual target attendees
-				if (!$this->visibilityService->isUserTargetAttendee($appointment, $userId)) {
+				// allUsers already is the audience — a hash lookup replaces the check.
+				if (!isset($cache['allUsers'][$userId])) {
 					continue;
 				}
 
@@ -538,12 +532,14 @@ class ResponseSummaryService {
 			}
 
 			// Get team members from cache
+			/** @var list<string> $teamMemberIds */
 			$teamMemberIds = $cache['teamMembers'][$teamId] ?? [];
 			$nonRespondingUsers = [];
 			$maybeUsers = [];
 
 			foreach ($teamMemberIds as $userId) {
-				// Filter to only actual target attendees
+				// Not an allUsers lookup: on an open appointment with a group
+				// whitelist, team members outside those groups are absent there.
 				if (!$this->visibilityService->isUserTargetAttendee($appointment, $userId)) {
 					continue;
 				}

--- a/lib/Service/VisibilityService.php
+++ b/lib/Service/VisibilityService.php
@@ -26,6 +26,9 @@ class VisibilityService {
 	private array $userGroupIdsCache = [];
 	/** @var array<string, list<string>> teamId → member user IDs. */
 	private array $teamMembersCache = [];
+	/** @var array<string, array{users: array<string>, groups: array<string>, teams: array<string>}>
+	 * Keyed by the raw JSON columns, so an in-request edit misses naturally. */
+	private array $visibilitySettingsCache = [];
 
 	public function __construct(
 		IGroupManager $groupManager,
@@ -79,14 +82,10 @@ class VisibilityService {
 	 * @return bool True if the user is a target attendee
 	 */
 	public function isUserTargetAttendee(Appointment $appointment, string $userId): bool {
-		$visibleUsers = $appointment->getVisibleUsers();
-		$visibleGroups = $appointment->getVisibleGroups();
-		$visibleTeams = $appointment->getVisibleTeams();
-
-		// Decode JSON fields
-		$visibleUsersList = $visibleUsers ? json_decode($visibleUsers, true) : [];
-		$visibleGroupsList = $visibleGroups ? json_decode($visibleGroups, true) : [];
-		$visibleTeamsList = $visibleTeams ? json_decode($visibleTeams, true) : [];
+		$settings = $this->getVisibilitySettings($appointment);
+		$visibleUsersList = $settings['users'];
+		$visibleGroupsList = $settings['groups'];
+		$visibleTeamsList = $settings['teams'];
 
 		// If all are empty/null, appointment is visible to all
 		if (empty($visibleUsersList) && empty($visibleGroupsList) && empty($visibleTeamsList)) {
@@ -252,11 +251,17 @@ class VisibilityService {
 		$visibleGroups = $appointment->getVisibleGroups();
 		$visibleTeams = $appointment->getVisibleTeams();
 
-		return [
-			'users' => $visibleUsers ? (json_decode($visibleUsers, true) ?: []) : [],
-			'groups' => $visibleGroups ? (json_decode($visibleGroups, true) ?: []) : [],
-			'teams' => $visibleTeams ? (json_decode($visibleTeams, true) ?: []) : [],
-		];
+		$key = $visibleUsers . '|' . $visibleGroups . '|' . $visibleTeams;
+		if (!isset($this->visibilitySettingsCache[$key])) {
+			/** @var array{users: array<string>, groups: array<string>, teams: array<string>} $settings */
+			$settings = [
+				'users' => $visibleUsers ? (json_decode($visibleUsers, true) ?: []) : [],
+				'groups' => $visibleGroups ? (json_decode($visibleGroups, true) ?: []) : [],
+				'teams' => $visibleTeams ? (json_decode($visibleTeams, true) ?: []) : [],
+			];
+			$this->visibilitySettingsCache[$key] = $settings;
+		}
+		return $this->visibilitySettingsCache[$key];
 	}
 
 	/**

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1644,9 +1644,6 @@
     <RedundantCastGivenDocblockType>
       <code><![CDATA[(string)$saved->getCheckinComment()]]></code>
     </RedundantCastGivenDocblockType>
-    <UnusedForeachValue>
-      <code><![CDATA[$user]]></code>
-    </UnusedForeachValue>
   </file>
   <file src="lib/Service/ConfigService.php">
     <ClassMustBeFinal>
@@ -2127,8 +2124,6 @@
       <code><![CDATA[$user->getUID()]]></code>
       <code><![CDATA[$userId]]></code>
       <code><![CDATA[$userId]]></code>
-      <code><![CDATA[$userId]]></code>
-      <code><![CDATA[$userId]]></code>
     </MixedArgument>
     <MixedArrayAccess>
       <code><![CDATA[$cache['groupUsers'][$groupId]]]></code>
@@ -2218,13 +2213,9 @@
       <code><![CDATA[$teamInfo]]></code>
       <code><![CDATA[$teamMemberIds]]></code>
       <code><![CDATA[$teamMemberIds]]></code>
-      <code><![CDATA[$teamMemberIds]]></code>
-      <code><![CDATA[$user]]></code>
       <code><![CDATA[$user]]></code>
       <code><![CDATA[$userGroups]]></code>
       <code><![CDATA[$userGroups]]></code>
-      <code><![CDATA[$userId]]></code>
-      <code><![CDATA[$userId]]></code>
       <code><![CDATA[$userId]]></code>
       <code><![CDATA[$userId]]></code>
       <code><![CDATA[$userResponse]]></code>
@@ -2232,12 +2223,9 @@
     </MixedAssignment>
     <MixedMethodCall>
       <code><![CDATA[getDisplayName]]></code>
-      <code><![CDATA[getDisplayName]]></code>
-      <code><![CDATA[getDisplayName]]></code>
       <code><![CDATA[getGID]]></code>
       <code><![CDATA[getGID]]></code>
       <code><![CDATA[getResponse]]></code>
-      <code><![CDATA[getUID]]></code>
       <code><![CDATA[getUID]]></code>
       <code><![CDATA[getUserId]]></code>
       <code><![CDATA[getUserId]]></code>
@@ -2324,9 +2312,6 @@
       <code><![CDATA[search]]></code>
     </DeprecatedMethod>
     <MixedArgument>
-      <code><![CDATA[$teamId]]></code>
-      <code><![CDATA[$visibleGroupsList]]></code>
-      <code><![CDATA[$visibleUsersList]]></code>
       <code><![CDATA[CirclesManager::class]]></code>
     </MixedArgument>
     <MixedAssignment>
@@ -2334,12 +2319,8 @@
       <code><![CDATA[$circle]]></code>
       <code><![CDATA[$member]]></code>
       <code><![CDATA[$members]]></code>
-      <code><![CDATA[$teamId]]></code>
       <code><![CDATA[$this->teamsManager]]></code>
       <code><![CDATA[$userIds[]]]></code>
-      <code><![CDATA[$visibleGroupsList]]></code>
-      <code><![CDATA[$visibleTeamsList]]></code>
-      <code><![CDATA[$visibleUsersList]]></code>
     </MixedAssignment>
     <MixedMethodCall>
       <code><![CDATA[getDisplayName]]></code>
@@ -2352,13 +2333,7 @@
     </MixedPropertyTypeCoercion>
     <MixedReturnTypeCoercion>
       <code><![CDATA[$userIds]]></code>
-      <code><![CDATA[[
-			'users' => $visibleUsers ? (json_decode($visibleUsers, true) ?: []) : [],
-			'groups' => $visibleGroups ? (json_decode($visibleGroups, true) ?: []) : [],
-			'teams' => $visibleTeams ? (json_decode($visibleTeams, true) ?: []) : [],
-		]]]></code>
       <code><![CDATA[array<string>]]></code>
-      <code><![CDATA[array{users: array<string>, groups: array<string>, teams: array<string>}]]></code>
     </MixedReturnTypeCoercion>
     <PossiblyUnusedMethod>
       <code><![CDATA[__construct]]></code>
@@ -2372,12 +2347,6 @@
       <code><![CDATA[empty($settings['groups'])]]></code>
       <code><![CDATA[empty($settings['teams'])]]></code>
       <code><![CDATA[empty($settings['users'])]]></code>
-      <code><![CDATA[empty($visibleGroupsList)]]></code>
-      <code><![CDATA[empty($visibleGroupsList)]]></code>
-      <code><![CDATA[empty($visibleTeamsList)]]></code>
-      <code><![CDATA[empty($visibleTeamsList)]]></code>
-      <code><![CDATA[empty($visibleUsersList)]]></code>
-      <code><![CDATA[empty($visibleUsersList)]]></code>
     </RiskyTruthyFalsyComparison>
     <UndefinedClass>
       <code><![CDATA[$this->teamsManager]]></code>

--- a/tests/unit/Service/VisibilityServiceTest.php
+++ b/tests/unit/Service/VisibilityServiceTest.php
@@ -37,19 +37,27 @@ class VisibilityServiceTest extends TestCase {
 	}
 
 	/**
-	 * @param array<string, list<string>> $membersByTeam
+	 * @param list<string> $stubbedMethods
 	 * @return VisibilityService|MockObject
 	 */
-	private function serviceWithTeamMembers(array $membersByTeam) {
-		$service = $this->getMockBuilder(VisibilityService::class)
+	private function partialMock(array $stubbedMethods) {
+		return $this->getMockBuilder(VisibilityService::class)
 			->setConstructorArgs([
 				$this->groupManager,
 				$this->userManager,
 				$this->permissionService,
 				$this->container,
 			])
-			->onlyMethods(['getTeamMembers'])
+			->onlyMethods($stubbedMethods)
 			->getMock();
+	}
+
+	/**
+	 * @param array<string, list<string>> $membersByTeam
+	 * @return VisibilityService|MockObject
+	 */
+	private function serviceWithTeamMembers(array $membersByTeam) {
+		$service = $this->partialMock(['getTeamMembers']);
 		$service->method('getTeamMembers')
 			->willReturnCallback(static fn (string $teamId): array => $membersByTeam[$teamId] ?? []);
 		return $service;
@@ -99,15 +107,7 @@ class VisibilityServiceTest extends TestCase {
 		$numericUser = $this->createMock(IUser::class);
 		$numericUser->method('getUID')->willReturn('456');
 
-		$service = $this->getMockBuilder(VisibilityService::class)
-			->setConstructorArgs([
-				$this->groupManager,
-				$this->userManager,
-				$this->permissionService,
-				$this->container,
-			])
-			->onlyMethods(['getRelevantUsersForAppointment'])
-			->getMock();
+		$service = $this->partialMock(['getRelevantUsersForAppointment']);
 		$service->method('getRelevantUsersForAppointment')
 			->willReturn(['alice' => $alice, 'mallory' => $mallory, '456' => $numericUser]);
 


### PR DESCRIPTION
Review follow-up to #167 (landed there after the merge, so it rides separately):

- `getVisibilitySettings()` memoizes per raw-column key and `isUserTargetAttendee()` reads from it — per-user audience checks no longer re-decode the same three JSON columns each time. A detail view's target-attendees pass drops from 3×N decodes to 3; the appointment list ran that twice per appointment.
- `addNonRespondingUsers()` answers "is this user audience?" with a lookup into the cache's `allUsers` map instead of re-deriving it per group member. The team walk keeps the real check on purpose: on an open appointment with a group whitelist, team members outside those groups are absent from that map (commented in code).
- Smaller strokes: `buildCache` stops copying the attendee map key by key, `CheckinService` inlines the one-loop `buildUserList` and drops an unused foreach binding, the visibility test file builds its partial mocks through one helper.
- 25 psalm-baseline entries retire with the now-typed code paths; none added.

No behavior change — `./scripts/check.sh` passes (psalm clean, 322 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F9ddZ12ZeSSn81cBRTRrLK

---
_Generated by [Claude Code](https://claude.ai/code/session_01F9ddZ12ZeSSn81cBRTRrLK)_