### PR TITLE
refactor(comment): drop the dead comment-autosave machinery

### DIFF
--- a/src/components/appointment/ResponseEditor.vue
+++ b/src/components/appointment/ResponseEditor.vue
@@ -135,7 +135,7 @@ const localComment = ref(props.comment)
 const commentExpanded = ref(Boolean(props.comment) && !props.compact)
 const commentInput = ref(null)
 
-const { savingComment, errorComment, autoSaveComment, reset } = useAppointmentResponse()
+const { savingComment, errorComment, saveComment: postComment, reset } = useAppointmentResponse()
 
 // Saving a comment does not refresh the parent, so props.comment stays on the
 // value the card was rendered with. Without a local baseline the Save button
@@ -165,7 +165,7 @@ watch(() => props.comment, (next) => {
 async function saveComment() {
 	if (!commentChanged.value || savingComment.value) return
 	const pending = localComment.value
-	await autoSaveComment(props.appointmentId, props.userResponse, pending, false)
+	await postComment(props.appointmentId, props.userResponse, pending)
 	if (!errorComment.value) {
 		savedComment.value = pending
 	}

--- a/src/components/appointment/ResponseEditor.vue
+++ b/src/components/appointment/ResponseEditor.vue
@@ -67,7 +67,7 @@
 
 <script setup>
 import { NcButton, NcInputField } from '@nextcloud/vue'
-import { computed, nextTick, onBeforeUnmount, ref, watch } from 'vue'
+import { computed, nextTick, ref, watch } from 'vue'
 import CheckCircle from 'vue-material-design-icons/CheckCircle.vue'
 import ClockIcon from 'vue-material-design-icons/Clock.vue'
 import CloseCircle from 'vue-material-design-icons/CloseCircle.vue'
@@ -135,7 +135,7 @@ const localComment = ref(props.comment)
 const commentExpanded = ref(Boolean(props.comment) && !props.compact)
 const commentInput = ref(null)
 
-const { savingComment, errorComment, saveComment: postComment, reset } = useAppointmentResponse()
+const { savingComment, saveComment: saveCommentApi } = useAppointmentResponse()
 
 // Saving a comment does not refresh the parent, so props.comment stays on the
 // value the card was rendered with. Without a local baseline the Save button
@@ -165,15 +165,11 @@ watch(() => props.comment, (next) => {
 async function saveComment() {
 	if (!commentChanged.value || savingComment.value) return
 	const pending = localComment.value
-	await postComment(props.appointmentId, props.userResponse, pending)
-	if (!errorComment.value) {
+	const saved = await saveCommentApi(props.appointmentId, props.userResponse, pending)
+	if (saved) {
 		savedComment.value = pending
 	}
 }
-
-// The composable keeps its own spinner/indicator timeouts, which would
-// otherwise keep writing into refs of an unmounted card.
-onBeforeUnmount(reset)
 </script>
 
 <style scoped lang="scss">

--- a/src/composables/useAppointmentResponse.js
+++ b/src/composables/useAppointmentResponse.js
@@ -56,10 +56,30 @@ export function useResponseCooldown(currentResponse, cooldownMs = 800) {
 export function useAppointmentResponse(options = {}) {
 	const { onSuccess, onError } = options
 
-	// Comment state
 	const savingComment = ref(false)
-	const errorComment = ref(false)
-	let errorIndicatorTimeout = null
+
+	/**
+	 * The one transport both save paths share: POST to the respond endpoint
+	 * and throw on a non-2xx status.
+	 *
+	 * @param {number} appointmentId - The appointment ID
+	 * @param {string|null} response - The response (yes, no, maybe) or null to withdraw
+	 * @param {string} comment - The comment text
+	 * @return {Promise<object>} The axios response
+	 */
+	const postRespond = async (appointmentId, response, comment) => {
+		const url = generateUrl('/apps/attendance/api/appointments/{id}/respond', { id: appointmentId })
+		const axiosResponse = await axios.post(url, {
+			response,
+			comment,
+		})
+
+		if (axiosResponse.status < 200 || axiosResponse.status >= 300) {
+			throw new Error(`API returned status ${axiosResponse.status}`)
+		}
+
+		return axiosResponse
+	}
 
 	/**
 	 * Submit a response to an appointment.
@@ -73,15 +93,7 @@ export function useAppointmentResponse(options = {}) {
 		const t = window.t || ((app, text) => text)
 
 		try {
-			const url = generateUrl('/apps/attendance/api/appointments/{id}/respond', { id: appointmentId })
-			const axiosResponse = await axios.post(url, {
-				response,
-				comment,
-			})
-
-			if (axiosResponse.status < 200 || axiosResponse.status >= 300) {
-				throw new Error(`API returned status ${axiosResponse.status}`)
-			}
+			const axiosResponse = await postRespond(appointmentId, response, comment)
 
 			showSuccess(response === null
 				? t('attendance', 'Response withdrawn')
@@ -105,85 +117,51 @@ export function useAppointmentResponse(options = {}) {
 	}
 
 	/**
-	 * Clear error indicator timeout.
-	 */
-	const clearErrorIndicator = () => {
-		if (errorIndicatorTimeout) {
-			clearTimeout(errorIndicatorTimeout)
-			errorIndicatorTimeout = null
-		}
-	}
-
-	/**
 	 * Save a comment. Only ever called from an explicit user action (save
 	 * button, Enter) — comments are never sent while typing.
 	 *
 	 * @param {number} appointmentId - The appointment ID
 	 * @param {string} currentResponse - The current response value
 	 * @param {string} commentText - The comment text
-	 * @return {Promise<void>}
+	 * @return {Promise<boolean>} Whether the save succeeded
 	 */
 	const saveComment = async (appointmentId, currentResponse, commentText) => {
-		if (!currentResponse) return
+		if (!currentResponse) return false
 
 		const t = window.t || ((app, text) => text)
 
-		clearErrorIndicator()
-
 		savingComment.value = true
-		errorComment.value = false
 
 		try {
-			const url = generateUrl('/apps/attendance/api/appointments/{id}/respond', { id: appointmentId })
-			const axiosResponse = await axios.post(url, {
-				response: currentResponse,
-				comment: commentText,
-			})
+			const axiosResponse = await postRespond(appointmentId, currentResponse, commentText)
 
-			if (axiosResponse.status < 200 || axiosResponse.status >= 300) {
-				throw new Error(`API returned status ${axiosResponse.status}`)
-			}
-
-			savingComment.value = false
 			showSuccess(t('attendance', 'Comment updated'))
 
 			if (onSuccess) {
 				onSuccess(axiosResponse.data)
 			}
+
+			return true
 		} catch (error) {
 			console.error('Failed to save comment:', error)
-			savingComment.value = false
-			errorComment.value = true
 			showError(t('attendance', 'Comment could not be saved'))
-
-			// Auto-hide error indicator after 3 seconds
-			errorIndicatorTimeout = setTimeout(() => {
-				errorComment.value = false
-			}, 3000)
 
 			if (onError) {
 				onError(error)
 			}
-		}
-	}
 
-	/**
-	 * Reset all state.
-	 */
-	const reset = () => {
-		clearErrorIndicator()
-		savingComment.value = false
-		errorComment.value = false
+			return false
+		} finally {
+			savingComment.value = false
+		}
 	}
 
 	return {
 		// State
 		savingComment,
-		errorComment,
 
 		// Methods
 		submitResponse,
 		saveComment,
-		reset,
 	}
 }

--- a/src/composables/useAppointmentResponse.js
+++ b/src/composables/useAppointmentResponse.js
@@ -1,12 +1,12 @@
 /**
  * Composable for handling appointment responses and comments.
- * Centralizes response submission and comment auto-save logic.
+ * Centralizes response submission and comment saving.
  */
 
 import axios from '@nextcloud/axios'
 import { showError, showSuccess } from '@nextcloud/dialogs'
 import { generateUrl } from '@nextcloud/router'
-import { nextTick, onBeforeUnmount, ref } from 'vue'
+import { onBeforeUnmount, ref } from 'vue'
 
 /**
  * Short cooldown for the yes/maybe/no buttons that prevents button-smashing
@@ -58,10 +58,7 @@ export function useAppointmentResponse(options = {}) {
 
 	// Comment state
 	const savingComment = ref(false)
-	const commentSaved = ref(false)
 	const errorComment = ref(false)
-	let commentTimeout = null
-	let savedIndicatorTimeout = null
 	let errorIndicatorTimeout = null
 
 	/**
@@ -108,16 +105,6 @@ export function useAppointmentResponse(options = {}) {
 	}
 
 	/**
-	 * Clear saved indicator timeout.
-	 */
-	const clearSavedIndicator = () => {
-		if (savedIndicatorTimeout) {
-			clearTimeout(savedIndicatorTimeout)
-			savedIndicatorTimeout = null
-		}
-	}
-
-	/**
 	 * Clear error indicator timeout.
 	 */
 	const clearErrorIndicator = () => {
@@ -128,26 +115,22 @@ export function useAppointmentResponse(options = {}) {
 	}
 
 	/**
-	 * Auto-save a comment with debouncing.
-	 * Shows visual feedback (spinner, checkmark, error icon).
+	 * Save a comment. Only ever called from an explicit user action (save
+	 * button, Enter) — comments are never sent while typing.
 	 *
 	 * @param {number} appointmentId - The appointment ID
 	 * @param {string} currentResponse - The current response value
 	 * @param {string} commentText - The comment text
-	 * @param {boolean} silent - If true, don't show success message
 	 * @return {Promise<void>}
 	 */
-	const autoSaveComment = async (appointmentId, currentResponse, commentText, silent = true) => {
+	const saveComment = async (appointmentId, currentResponse, commentText) => {
 		if (!currentResponse) return
 
 		const t = window.t || ((app, text) => text)
 
-		// Clear any pending timeouts
-		clearSavedIndicator()
 		clearErrorIndicator()
 
 		savingComment.value = true
-		commentSaved.value = false
 		errorComment.value = false
 
 		try {
@@ -161,20 +144,8 @@ export function useAppointmentResponse(options = {}) {
 				throw new Error(`API returned status ${axiosResponse.status}`)
 			}
 
-			// Show saved indicator with delay for visual feedback
-			setTimeout(() => {
-				savingComment.value = false
-				commentSaved.value = true
-
-				// Auto-hide saved indicator after 2 seconds
-				savedIndicatorTimeout = setTimeout(() => {
-					commentSaved.value = false
-				}, 2000)
-			}, 500)
-
-			if (!silent) {
-				showSuccess(t('attendance', 'Comment updated'))
-			}
+			savingComment.value = false
+			showSuccess(t('attendance', 'Comment updated'))
 
 			if (onSuccess) {
 				onSuccess(axiosResponse.data)
@@ -197,205 +168,22 @@ export function useAppointmentResponse(options = {}) {
 	}
 
 	/**
-	 * Create a debounced comment input handler.
-	 *
-	 * @param {() => string} getCommentText - Getter for the current comment text
-	 * @param {() => string} getCurrentResponse - Getter for the current response
-	 * @param {number} appointmentId - The appointment ID
-	 * @param {number} delay - Debounce delay in ms (default: 500)
-	 * @return {() => void} Input event handler
-	 */
-	const createCommentInputHandler = (getCommentText, getCurrentResponse, appointmentId, delay = 500) => {
-		return () => {
-			if (commentTimeout) {
-				clearTimeout(commentTimeout)
-			}
-
-			commentTimeout = setTimeout(async () => {
-				await nextTick()
-				const text = getCommentText()
-				const response = getCurrentResponse()
-				autoSaveComment(appointmentId, response, text)
-			}, delay)
-		}
-	}
-
-	/**
 	 * Reset all state.
 	 */
 	const reset = () => {
-		if (commentTimeout) {
-			clearTimeout(commentTimeout)
-			commentTimeout = null
-		}
-		clearSavedIndicator()
 		clearErrorIndicator()
 		savingComment.value = false
-		commentSaved.value = false
 		errorComment.value = false
 	}
 
 	return {
 		// State
 		savingComment,
-		commentSaved,
 		errorComment,
 
 		// Methods
 		submitResponse,
-		autoSaveComment,
-		createCommentInputHandler,
+		saveComment,
 		reset,
-	}
-}
-
-/**
- * Create a multi-appointment response handler.
- * Useful for list views where multiple appointments are shown.
- *
- * @param {object} options - Configuration options
- * @return {object} Response handling functions for multiple appointments
- */
-export function useMultiAppointmentResponse(options = {}) {
-	const { onSuccess, onError } = options
-
-	// Per-appointment state
-	const savingComments = {}
-	const savedComments = {}
-	const errorComments = {}
-	const commentTimeouts = {}
-
-	const t = window.t || ((app, text) => text)
-
-	/**
-	 * Submit a response to an appointment.
-	 *
-	 * @param {number} appointmentId - The appointment ID
-	 * @param {string|null} response - The response value (yes/no/maybe) or null to withdraw
-	 * @param {string} comment - Optional comment text
-	 */
-	const submitResponse = async (appointmentId, response, comment = '') => {
-		try {
-			const url = generateUrl('/apps/attendance/api/appointments/{id}/respond', { id: appointmentId })
-			const axiosResponse = await axios.post(url, {
-				response,
-				comment,
-			})
-
-			if (axiosResponse.status < 200 || axiosResponse.status >= 300) {
-				throw new Error(`API returned status ${axiosResponse.status}`)
-			}
-
-			showSuccess(response === null
-				? t('attendance', 'Response withdrawn')
-				: t('attendance', 'Response updated'))
-
-			if (onSuccess) {
-				onSuccess(appointmentId, axiosResponse.data)
-			}
-
-			return axiosResponse.data
-		} catch (error) {
-			console.error('Failed to submit response:', error)
-			showError(t('attendance', 'Error updating response'))
-
-			if (onError) {
-				onError(appointmentId, error)
-			}
-
-			throw error
-		}
-	}
-
-	/**
-	 * Auto-save comment for a specific appointment.
-	 *
-	 * @param {number} appointmentId - The appointment ID
-	 * @param {string} currentResponse - The current response value
-	 * @param {string} commentText - The comment text to save
-	 */
-	const autoSaveComment = async (appointmentId, currentResponse, commentText) => {
-		if (!currentResponse) return
-
-		savingComments[appointmentId] = true
-		savedComments[appointmentId] = false
-		errorComments[appointmentId] = false
-
-		try {
-			const url = generateUrl('/apps/attendance/api/appointments/{id}/respond', { id: appointmentId })
-			await axios.post(url, {
-				response: currentResponse,
-				comment: commentText,
-			})
-
-			setTimeout(() => {
-				savingComments[appointmentId] = false
-				savedComments[appointmentId] = true
-
-				setTimeout(() => {
-					savedComments[appointmentId] = false
-				}, 2000)
-			}, 500)
-		} catch (error) {
-			console.error('Failed to save comment:', error)
-			savingComments[appointmentId] = false
-			errorComments[appointmentId] = true
-			showError(t('attendance', 'Comment could not be saved'))
-
-			setTimeout(() => {
-				errorComments[appointmentId] = false
-			}, 3000)
-		}
-	}
-
-	/**
-	 * Handle comment input with debouncing.
-	 *
-	 * @param {number} appointmentId - The appointment ID
-	 * @param {() => string} getCommentText - Getter for the current comment text
-	 * @param {() => string} getCurrentResponse - Getter for the current response
-	 * @param {number} delay - Debounce delay in milliseconds
-	 */
-	const onCommentInput = (appointmentId, getCommentText, getCurrentResponse, delay = 500) => {
-		if (commentTimeouts[appointmentId]) {
-			clearTimeout(commentTimeouts[appointmentId])
-		}
-
-		commentTimeouts[appointmentId] = setTimeout(async () => {
-			await nextTick()
-			const text = getCommentText()
-			const response = getCurrentResponse()
-			autoSaveComment(appointmentId, response, text)
-		}, delay)
-	}
-
-	/**
-	 * Check if comment is being saved for an appointment.
-	 *
-	 * @param {number} appointmentId - The appointment ID
-	 */
-	const isSaving = (appointmentId) => !!savingComments[appointmentId]
-
-	/**
-	 * Check if comment was saved for an appointment.
-	 *
-	 * @param {number} appointmentId - The appointment ID
-	 */
-	const isSaved = (appointmentId) => !!savedComments[appointmentId]
-
-	/**
-	 * Check if comment save failed for an appointment.
-	 *
-	 * @param {number} appointmentId - The appointment ID
-	 */
-	const hasError = (appointmentId) => !!errorComments[appointmentId]
-
-	return {
-		submitResponse,
-		autoSaveComment,
-		onCommentInput,
-		isSaving,
-		isSaved,
-		hasError,
 	}
 }


### PR DESCRIPTION
## What

An audit for leftover comment autosave-on-keystroke behavior (paired with luflow/attendance-flutter#82, which fixes the real occurrence in the mobile app) confirmed the web UI already saves comments only via the explicit save button (or Enter) everywhere — own response comment (`ResponseEditor`, used on the detail card, list card and dashboard widget) and the check-in comment (`CheckinUserItem`). But `useAppointmentResponse.js` still shipped the old autosave machinery with no callers left. This removes it so nothing invites wiring typing back to the network:

- the debounced input handlers (`createCommentInputHandler`, `useMultiAppointmentResponse.onCommentInput`) and the entire unused `useMultiAppointmentResponse` composable
- the saved-indicator timers (`commentSaved`, the 500 ms delayed spinner) and the `silent` flag
- `autoSaveComment` is renamed to `saveComment`

A follow-up review commit then cleans up what the removal exposed: the shared transport (URL build, POST, non-2xx check) of `submitResponse` and `saveComment` is factored into one `postRespond` helper (the block had already drifted into four copies in this file's history), and `saveComment` reports success via its return value instead of the `errorComment` ref, which no template ever rendered — with the last indicator timer gone, `reset()` and the unmount hook in `ResponseEditor` go too.

No behavior change; all translation strings are kept, so no l10n impact.

## Verification

`./scripts/check.sh` passes: eslint, stylelint, php-cs-fixer, psalm, PHPUnit, vite build, both l10n checks, OpenAPI spec check. The e2e specs already exercise the explicit save-button flow and are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BNpTw85wK6Qv64ZSuF9P3Z

---
_Generated by [Claude Code](https://claude.ai/code/session_01BNpTw85wK6Qv64ZSuF9P3Z)_