### PR TITLE
feat(settings): let admins reorder response summary groups and teams

### DIFF
--- a/l10n/de.js
+++ b/l10n/de.js
@@ -179,7 +179,6 @@ OC.L10N.register(
     "Just for me" : "Nur für mich",
     "Just for you, on any of your Nextcloud accounts" : "Nur für dich, auf allen deinen Nextcloud-Konten",
     "Language" : "Sprache",
-    "Less than one euro a month" : "Weniger als ein Euro im Monat",
     "Most popular" : "Am beliebtesten",
     "NFC is not available." : "NFC ist nicht verfügbar.",
     "Name (optional)" : "Name (optional)",
@@ -228,7 +227,6 @@ OC.L10N.register(
     "Unlimited members" : "Unbegrenzte Mitglieder",
     "Up to {count} members" : "Bis zu {count} Mitgliedern",
     "Use the recipient's server locale" : "Server-Ländereinstellung des Empfängers verwenden",
-    "Using Attendance with a group? One license for the whole group costs less than three personal licenses." : "Du nutzt Attendance mit einer Gruppe? Eine Lizenz für die ganze Gruppe kostet weniger als drei persönliche Lizenzen.",
     "Using account {user} on {server}" : "Konto {user} auf {server} verwenden",
     "What would you be willing to pay?" : "Was wärst du bereit zu zahlen?",
     "What's still holding you back?" : "Was hält dich noch zurück?",
@@ -966,6 +964,10 @@ OC.L10N.register(
     "A Talk room is open for everyone who accepted." : "Für alle, die zugesagt haben, ist ein Talk-Raum eröffnet.",
     "Opens a Talk room with everyone who accepted, as soon as the first person does, so the remaining details can be sorted out there." : "Eröffnet einen Talk-Raum mit allen, die zugesagt haben — sobald die erste Zusage eingeht, damit die restlichen Details dort geklärt werden können.",
     "Talk room for everyone who accepted this appointment. Details: %1$s" : "Talk-Raum für alle, die für diesen Termin zugesagt haben. Details: %1$s",
-    "Open a Talk room for this appointment" : "Talk-Raum für diesen Termin eröffnen"
+    "Open a Talk room for this appointment" : "Talk-Raum für diesen Termin eröffnen",
+    "Move {name} up" : "{name} nach oben verschieben",
+    "Move {name} down" : "{name} nach unten verschieben",
+    "Sections appear in this order. Drag an entry or use the arrows to move it." : "Die Abschnitte erscheinen in dieser Reihenfolge. Ziehe einen Eintrag oder verschiebe ihn mit den Pfeilen.",
+    "Using Attendance with a group? One license for the whole group costs less than {count} personal licenses." : "Du nutzt Attendance mit einer Gruppe? Eine Lizenz für die ganze Gruppe kostet weniger als {count} persönliche Lizenzen."
 },
 "nplurals=2; plural=(n != 1);");

--- a/l10n/de.json
+++ b/l10n/de.json
@@ -177,7 +177,6 @@
     "Just for me" : "Nur für mich",
     "Just for you, on any of your Nextcloud accounts" : "Nur für dich, auf allen deinen Nextcloud-Konten",
     "Language" : "Sprache",
-    "Less than one euro a month" : "Weniger als ein Euro im Monat",
     "Most popular" : "Am beliebtesten",
     "NFC is not available." : "NFC ist nicht verfügbar.",
     "Name (optional)" : "Name (optional)",
@@ -226,7 +225,6 @@
     "Unlimited members" : "Unbegrenzte Mitglieder",
     "Up to {count} members" : "Bis zu {count} Mitgliedern",
     "Use the recipient's server locale" : "Server-Ländereinstellung des Empfängers verwenden",
-    "Using Attendance with a group? One license for the whole group costs less than three personal licenses." : "Du nutzt Attendance mit einer Gruppe? Eine Lizenz für die ganze Gruppe kostet weniger als drei persönliche Lizenzen.",
     "Using account {user} on {server}" : "Konto {user} auf {server} verwenden",
     "What would you be willing to pay?" : "Was wärst du bereit zu zahlen?",
     "What's still holding you back?" : "Was hält dich noch zurück?",
@@ -964,6 +962,10 @@
     "A Talk room is open for everyone who accepted." : "Für alle, die zugesagt haben, ist ein Talk-Raum eröffnet.",
     "Opens a Talk room with everyone who accepted, as soon as the first person does, so the remaining details can be sorted out there." : "Eröffnet einen Talk-Raum mit allen, die zugesagt haben — sobald die erste Zusage eingeht, damit die restlichen Details dort geklärt werden können.",
     "Talk room for everyone who accepted this appointment. Details: %1$s" : "Talk-Raum für alle, die für diesen Termin zugesagt haben. Details: %1$s",
-    "Open a Talk room for this appointment" : "Talk-Raum für diesen Termin eröffnen"
+    "Open a Talk room for this appointment" : "Talk-Raum für diesen Termin eröffnen",
+    "Move {name} up" : "{name} nach oben verschieben",
+    "Move {name} down" : "{name} nach unten verschieben",
+    "Sections appear in this order. Drag an entry or use the arrows to move it." : "Die Abschnitte erscheinen in dieser Reihenfolge. Ziehe einen Eintrag oder verschiebe ihn mit den Pfeilen.",
+    "Using Attendance with a group? One license for the whole group costs less than {count} personal licenses." : "Du nutzt Attendance mit einer Gruppe? Eine Lizenz für die ganze Gruppe kostet weniger als {count} persönliche Lizenzen."
 },"pluralForm" :"nplurals=2; plural=(n != 1);"
 }

--- a/l10n/de_DE.js
+++ b/l10n/de_DE.js
@@ -179,7 +179,6 @@ OC.L10N.register(
     "Just for me" : "Nur für mich",
     "Just for you, on any of your Nextcloud accounts" : "Nur für Sie, auf allen Ihren Nextcloud-Konten",
     "Language" : "Sprache",
-    "Less than one euro a month" : "Weniger als ein Euro im Monat",
     "Most popular" : "Am beliebtesten",
     "NFC is not available." : "NFC ist nicht verfügbar.",
     "Name (optional)" : "Name (optional)",
@@ -228,7 +227,6 @@ OC.L10N.register(
     "Unlimited members" : "Unbegrenzte Mitglieder",
     "Up to {count} members" : "Bis zu {count} Mitgliedern",
     "Use the recipient's server locale" : "Server-Ländereinstellung des Empfängers verwenden",
-    "Using Attendance with a group? One license for the whole group costs less than three personal licenses." : "Sie nutzen Attendance mit einer Gruppe? Eine Lizenz für die ganze Gruppe kostet weniger als drei persönliche Lizenzen.",
     "Using account {user} on {server}" : "Konto {user} auf {server} verwenden",
     "What would you be willing to pay?" : "Was wären Sie bereit zu zahlen?",
     "What's still holding you back?" : "Was hält Sie noch zurück?",
@@ -966,6 +964,10 @@ OC.L10N.register(
     "A Talk room is open for everyone who accepted." : "Für alle, die zugesagt haben, ist ein Talk-Raum eröffnet.",
     "Opens a Talk room with everyone who accepted, as soon as the first person does, so the remaining details can be sorted out there." : "Eröffnet einen Talk-Raum mit allen, die zugesagt haben — sobald die erste Zusage eingeht, damit die restlichen Details dort geklärt werden können.",
     "Talk room for everyone who accepted this appointment. Details: %1$s" : "Talk-Raum für alle, die für diesen Termin zugesagt haben. Details: %1$s",
-    "Open a Talk room for this appointment" : "Talk-Raum für diesen Termin eröffnen"
+    "Open a Talk room for this appointment" : "Talk-Raum für diesen Termin eröffnen",
+    "Move {name} up" : "{name} nach oben verschieben",
+    "Move {name} down" : "{name} nach unten verschieben",
+    "Sections appear in this order. Drag an entry or use the arrows to move it." : "Die Abschnitte erscheinen in dieser Reihenfolge. Ziehen Sie einen Eintrag oder verschieben Sie ihn mit den Pfeilen.",
+    "Using Attendance with a group? One license for the whole group costs less than {count} personal licenses." : "Sie nutzen Attendance mit einer Gruppe? Eine Lizenz für die ganze Gruppe kostet weniger als {count} persönliche Lizenzen."
 },
 "nplurals=2; plural=(n != 1);");

--- a/l10n/de_DE.json
+++ b/l10n/de_DE.json
@@ -177,7 +177,6 @@
     "Just for me" : "Nur für mich",
     "Just for you, on any of your Nextcloud accounts" : "Nur für Sie, auf allen Ihren Nextcloud-Konten",
     "Language" : "Sprache",
-    "Less than one euro a month" : "Weniger als ein Euro im Monat",
     "Most popular" : "Am beliebtesten",
     "NFC is not available." : "NFC ist nicht verfügbar.",
     "Name (optional)" : "Name (optional)",
@@ -226,7 +225,6 @@
     "Unlimited members" : "Unbegrenzte Mitglieder",
     "Up to {count} members" : "Bis zu {count} Mitgliedern",
     "Use the recipient's server locale" : "Server-Ländereinstellung des Empfängers verwenden",
-    "Using Attendance with a group? One license for the whole group costs less than three personal licenses." : "Sie nutzen Attendance mit einer Gruppe? Eine Lizenz für die ganze Gruppe kostet weniger als drei persönliche Lizenzen.",
     "Using account {user} on {server}" : "Konto {user} auf {server} verwenden",
     "What would you be willing to pay?" : "Was wären Sie bereit zu zahlen?",
     "What's still holding you back?" : "Was hält Sie noch zurück?",
@@ -964,6 +962,10 @@
     "A Talk room is open for everyone who accepted." : "Für alle, die zugesagt haben, ist ein Talk-Raum eröffnet.",
     "Opens a Talk room with everyone who accepted, as soon as the first person does, so the remaining details can be sorted out there." : "Eröffnet einen Talk-Raum mit allen, die zugesagt haben — sobald die erste Zusage eingeht, damit die restlichen Details dort geklärt werden können.",
     "Talk room for everyone who accepted this appointment. Details: %1$s" : "Talk-Raum für alle, die für diesen Termin zugesagt haben. Details: %1$s",
-    "Open a Talk room for this appointment" : "Talk-Raum für diesen Termin eröffnen"
+    "Open a Talk room for this appointment" : "Talk-Raum für diesen Termin eröffnen",
+    "Move {name} up" : "{name} nach oben verschieben",
+    "Move {name} down" : "{name} nach unten verschieben",
+    "Sections appear in this order. Drag an entry or use the arrows to move it." : "Die Abschnitte erscheinen in dieser Reihenfolge. Ziehen Sie einen Eintrag oder verschieben Sie ihn mit den Pfeilen.",
+    "Using Attendance with a group? One license for the whole group costs less than {count} personal licenses." : "Sie nutzen Attendance mit einer Gruppe? Eine Lizenz für die ganze Gruppe kostet weniger als {count} persönliche Lizenzen."
 },"pluralForm" :"nplurals=2; plural=(n != 1);"
 }

--- a/src/components/admin/OrderedSelectionList.vue
+++ b/src/components/admin/OrderedSelectionList.vue
@@ -1,0 +1,165 @@
+<template>
+	<ul class="ordered-selection" :data-test="dataTest">
+		<li v-for="(item, index) in modelValue"
+			:key="item.id"
+			class="ordered-selection__item"
+			:class="{
+				'ordered-selection__item--dragged': dragIndex === index,
+				'ordered-selection__item--target': overIndex === index && dragIndex !== index,
+			}"
+			draggable="true"
+			:data-test="`${dataTest}-item`"
+			@dragstart="onDragStart(index, $event)"
+			@dragover.prevent="overIndex = index"
+			@dragleave="onDragLeave(index)"
+			@drop.prevent="onDrop(index)"
+			@dragend="resetDrag">
+			<DragIcon class="ordered-selection__handle" :size="20" />
+			<span class="ordered-selection__position">{{ index + 1 }}</span>
+			<span class="ordered-selection__label">{{ labelOf(item) }}</span>
+			<NcButton variant="tertiary"
+				:disabled="index === 0"
+				:aria-label="t('attendance', 'Move {name} up', { name: labelOf(item) })"
+				:title="t('attendance', 'Move {name} up', { name: labelOf(item) })"
+				:data-test="`${dataTest}-up`"
+				@click="move(index, -1)">
+				<template #icon>
+					<ArrowUp :size="20" />
+				</template>
+			</NcButton>
+			<NcButton variant="tertiary"
+				:disabled="index === modelValue.length - 1"
+				:aria-label="t('attendance', 'Move {name} down', { name: labelOf(item) })"
+				:title="t('attendance', 'Move {name} down', { name: labelOf(item) })"
+				:data-test="`${dataTest}-down`"
+				@click="move(index, 1)">
+				<template #icon>
+					<ArrowDown :size="20" />
+				</template>
+			</NcButton>
+		</li>
+	</ul>
+</template>
+
+<script setup>
+import { NcButton } from '@nextcloud/vue'
+import { ref } from 'vue'
+import ArrowDown from 'vue-material-design-icons/ArrowDown.vue'
+import ArrowUp from 'vue-material-design-icons/ArrowUp.vue'
+import DragIcon from 'vue-material-design-icons/DragHorizontalVariant.vue'
+
+const props = defineProps({
+	/** Ordered selection, each entry `{ id, … }` */
+	modelValue: {
+		type: Array,
+		default: () => [],
+	},
+	/** Property holding the human-readable name of an entry */
+	labelKey: {
+		type: String,
+		default: 'displayName',
+	},
+	/** Overrides `labelKey`, e.g. to translate system group ids */
+	formatLabel: {
+		type: Function,
+		default: null,
+	},
+	dataTest: {
+		type: String,
+		default: 'ordered-selection',
+	},
+})
+
+const emit = defineEmits(['update:modelValue'])
+
+const dragIndex = ref(null)
+const overIndex = ref(null)
+
+function labelOf(item) {
+	if (props.formatLabel) return props.formatLabel(item)
+	return item[props.labelKey] || item.id
+}
+
+function reorder(from, to) {
+	const items = [...props.modelValue]
+	const [moved] = items.splice(from, 1)
+	items.splice(to, 0, moved)
+	emit('update:modelValue', items)
+}
+
+function move(index, offset) {
+	const target = index + offset
+	if (target < 0 || target >= props.modelValue.length) return
+	reorder(index, target)
+}
+
+function onDragStart(index, event) {
+	dragIndex.value = index
+	event.dataTransfer.effectAllowed = 'move'
+	// Firefox only starts a drag once some data is attached.
+	event.dataTransfer.setData('text/plain', String(index))
+}
+
+function onDragLeave(index) {
+	if (overIndex.value === index) overIndex.value = null
+}
+
+function onDrop(index) {
+	if (dragIndex.value !== null && dragIndex.value !== index) {
+		reorder(dragIndex.value, index)
+	}
+	resetDrag()
+}
+
+function resetDrag() {
+	dragIndex.value = null
+	overIndex.value = null
+}
+</script>
+
+<style scoped>
+.ordered-selection {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+	margin-block: 8px;
+	max-width: 480px;
+}
+
+.ordered-selection__item {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	padding: 4px 8px;
+	border: 2px solid transparent;
+	border-radius: var(--border-radius-element, var(--border-radius-large));
+	background-color: var(--color-background-hover);
+	cursor: grab;
+}
+
+.ordered-selection__item--dragged {
+	opacity: 0.5;
+}
+
+.ordered-selection__item--target {
+	border-color: var(--color-primary-element);
+}
+
+.ordered-selection__handle {
+	color: var(--color-text-maxcontrast);
+}
+
+.ordered-selection__position {
+	color: var(--color-text-maxcontrast);
+	font-size: 0.9em;
+	min-width: 1.5em;
+	text-align: end;
+}
+
+.ordered-selection__label {
+	flex: 1 1 auto;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+</style>

--- a/src/components/common/GroupSelect.vue
+++ b/src/components/common/GroupSelect.vue
@@ -25,7 +25,7 @@
 		<OrderedSelectionList v-if="sortable"
 			:modelValue="modelValue"
 			:formatLabel="groupLabel"
-			:dataTest="orderDataTest"
+			dataTest="order-groups"
 			@update:modelValue="$emit('update:modelValue', $event)" />
 	</div>
 </template>
@@ -59,22 +59,17 @@ const props = defineProps({
 		type: Boolean,
 		default: false,
 	},
-	orderDataTest: {
-		type: String,
-		default: 'order-groups',
-	},
 })
 
 defineEmits(['update:modelValue'])
 
-// Rewrite the displayName for known system groups (e.g. guest_app → "Guests")
-// before they reach NcSelect, so the option list, the selected-options pill,
-// and the search filter all see the same friendly label.
+// Known system groups (e.g. guest_app → "Guests") must read the same in the
+// option list, the search filter, the pills and the order list — stored ids
+// come back undecorated, so every one of them goes through this.
+const groupLabel = (group) => formatGroupLabel(group.id, group.displayName)
+
 const decoratedOptions = computed(() => props.options.map((option) => ({
 	...option,
-	displayName: formatGroupLabel(option.id, option.displayName),
+	displayName: groupLabel(option),
 })))
-
-// Stored ids come back undecorated, so the order list relabels them itself.
-const groupLabel = (group) => formatGroupLabel(group.id, group.displayName)
 </script>

--- a/src/components/common/GroupSelect.vue
+++ b/src/components/common/GroupSelect.vue
@@ -1,32 +1,40 @@
 <template>
-	<NcSelect
-		:modelValue="modelValue"
-		:options="decoratedOptions"
-		:placeholder="placeholder"
-		:multiple="true"
-		:disabled="disabled"
-		label="displayName"
-		trackBy="id"
-		@update:modelValue="$emit('update:modelValue', $event)">
-		<template #option="{ displayName }">
-			<span style="display: flex; align-items: center; gap: 8px;">
-				<AccountGroup :size="20" />
-				<span>{{ displayName }}</span>
-			</span>
-		</template>
-		<template #selected-option="{ displayName }">
-			<span style="display: flex; align-items: center; gap: 8px;">
-				<AccountGroup :size="16" />
-				<span>{{ displayName }}</span>
-			</span>
-		</template>
-	</NcSelect>
+	<div>
+		<NcSelect
+			:modelValue="modelValue"
+			:options="decoratedOptions"
+			:placeholder="placeholder"
+			:multiple="true"
+			:disabled="disabled"
+			label="displayName"
+			trackBy="id"
+			@update:modelValue="$emit('update:modelValue', $event)">
+			<template #option="{ displayName }">
+				<span style="display: flex; align-items: center; gap: 8px;">
+					<AccountGroup :size="20" />
+					<span>{{ displayName }}</span>
+				</span>
+			</template>
+			<template #selected-option="{ displayName }">
+				<span style="display: flex; align-items: center; gap: 8px;">
+					<AccountGroup :size="16" />
+					<span>{{ displayName }}</span>
+				</span>
+			</template>
+		</NcSelect>
+		<OrderedSelectionList v-if="sortable"
+			:modelValue="modelValue"
+			:formatLabel="groupLabel"
+			:dataTest="orderDataTest"
+			@update:modelValue="$emit('update:modelValue', $event)" />
+	</div>
 </template>
 
 <script setup>
 import { NcSelect } from '@nextcloud/vue'
 import { computed } from 'vue'
 import AccountGroup from 'vue-material-design-icons/AccountGroup.vue'
+import OrderedSelectionList from './OrderedSelectionList.vue'
 import { formatGroupLabel } from '../../utils/groups.js'
 
 const props = defineProps({
@@ -46,6 +54,15 @@ const props = defineProps({
 		type: Boolean,
 		default: false,
 	},
+	/** Offer the selection as a reorderable list — the order groups appear in */
+	sortable: {
+		type: Boolean,
+		default: false,
+	},
+	orderDataTest: {
+		type: String,
+		default: 'order-groups',
+	},
 })
 
 defineEmits(['update:modelValue'])
@@ -57,4 +74,7 @@ const decoratedOptions = computed(() => props.options.map((option) => ({
 	...option,
 	displayName: formatGroupLabel(option.id, option.displayName),
 })))
+
+// Stored ids come back undecorated, so the order list relabels them itself.
+const groupLabel = (group) => formatGroupLabel(group.id, group.displayName)
 </script>

--- a/src/components/common/OrderedSelectionList.vue
+++ b/src/components/common/OrderedSelectionList.vue
@@ -1,44 +1,49 @@
 <template>
-	<ul class="ordered-selection" :data-test="dataTest">
-		<li v-for="(item, index) in modelValue"
-			:key="item.id"
-			class="ordered-selection__item"
-			:class="{
-				'ordered-selection__item--dragged': dragIndex === index,
-				'ordered-selection__item--target': overIndex === index && dragIndex !== index,
-			}"
-			draggable="true"
-			:data-test="`${dataTest}-item`"
-			@dragstart="onDragStart(index, $event)"
-			@dragover.prevent="overIndex = index"
-			@dragleave="onDragLeave(index)"
-			@drop.prevent="onDrop(index)"
-			@dragend="resetDrag">
-			<DragIcon class="ordered-selection__handle" :size="20" />
-			<span class="ordered-selection__position">{{ index + 1 }}</span>
-			<span class="ordered-selection__label">{{ labelOf(item) }}</span>
-			<NcButton variant="tertiary"
-				:disabled="index === 0"
-				:aria-label="t('attendance', 'Move {name} up', { name: labelOf(item) })"
-				:title="t('attendance', 'Move {name} up', { name: labelOf(item) })"
-				:data-test="`${dataTest}-up`"
-				@click="move(index, -1)">
-				<template #icon>
-					<ArrowUp :size="20" />
-				</template>
-			</NcButton>
-			<NcButton variant="tertiary"
-				:disabled="index === modelValue.length - 1"
-				:aria-label="t('attendance', 'Move {name} down', { name: labelOf(item) })"
-				:title="t('attendance', 'Move {name} down', { name: labelOf(item) })"
-				:data-test="`${dataTest}-down`"
-				@click="move(index, 1)">
-				<template #icon>
-					<ArrowDown :size="20" />
-				</template>
-			</NcButton>
-		</li>
-	</ul>
+	<div v-if="modelValue.length > 1">
+		<p class="ordered-selection__hint">
+			{{ t('attendance', 'Sections appear in this order. Drag an entry or use the arrows to move it.') }}
+		</p>
+		<ul class="ordered-selection" :data-test="dataTest">
+			<li v-for="(item, index) in modelValue"
+				:key="item.id"
+				class="ordered-selection__item"
+				:class="{
+					'ordered-selection__item--dragged': dragIndex === index,
+					'ordered-selection__item--target': overIndex === index && dragIndex !== index,
+				}"
+				draggable="true"
+				:data-test="`${dataTest}-item`"
+				@dragstart="onDragStart(index, $event)"
+				@dragover.prevent="overIndex = index"
+				@dragleave="onDragLeave(index)"
+				@drop.prevent="onDrop(index)"
+				@dragend="resetDrag">
+				<DragIcon class="ordered-selection__handle" :size="20" />
+				<span class="ordered-selection__position">{{ index + 1 }}</span>
+				<span class="ordered-selection__label">{{ labelOf(item) }}</span>
+				<NcButton variant="tertiary"
+					:disabled="index === 0"
+					:aria-label="t('attendance', 'Move {name} up', { name: labelOf(item) })"
+					:title="t('attendance', 'Move {name} up', { name: labelOf(item) })"
+					:data-test="`${dataTest}-up`"
+					@click="move(index, -1)">
+					<template #icon>
+						<ArrowUp :size="20" />
+					</template>
+				</NcButton>
+				<NcButton variant="tertiary"
+					:disabled="index === modelValue.length - 1"
+					:aria-label="t('attendance', 'Move {name} down', { name: labelOf(item) })"
+					:title="t('attendance', 'Move {name} down', { name: labelOf(item) })"
+					:data-test="`${dataTest}-down`"
+					@click="move(index, 1)">
+					<template #icon>
+						<ArrowDown :size="20" />
+					</template>
+				</NcButton>
+			</li>
+		</ul>
+	</div>
 </template>
 
 <script setup>
@@ -118,6 +123,12 @@ function resetDrag() {
 </script>
 
 <style scoped>
+.ordered-selection__hint {
+	margin-top: 8px;
+	color: var(--color-text-maxcontrast);
+	font-size: 13px;
+}
+
 .ordered-selection {
 	display: flex;
 	flex-direction: column;

--- a/src/components/common/OrderedSelectionList.vue
+++ b/src/components/common/OrderedSelectionList.vue
@@ -4,8 +4,8 @@
 			{{ t('attendance', 'Sections appear in this order. Drag an entry or use the arrows to move it.') }}
 		</p>
 		<ul class="ordered-selection" :data-test="dataTest">
-			<li v-for="(item, index) in modelValue"
-				:key="item.id"
+			<li v-for="(row, index) in rows"
+				:key="row.item.id"
 				class="ordered-selection__item"
 				:class="{
 					'ordered-selection__item--dragged': dragIndex === index,
@@ -20,23 +20,23 @@
 				@dragend="resetDrag">
 				<DragIcon class="ordered-selection__handle" :size="20" />
 				<span class="ordered-selection__position">{{ index + 1 }}</span>
-				<span class="ordered-selection__label">{{ labelOf(item) }}</span>
+				<span class="ordered-selection__label">{{ row.label }}</span>
 				<NcButton variant="tertiary"
 					:disabled="index === 0"
-					:aria-label="t('attendance', 'Move {name} up', { name: labelOf(item) })"
-					:title="t('attendance', 'Move {name} up', { name: labelOf(item) })"
+					:aria-label="row.moveUp"
+					:title="row.moveUp"
 					:data-test="`${dataTest}-up`"
-					@click="move(index, -1)">
+					@click="reorder(index, index - 1)">
 					<template #icon>
 						<ArrowUp :size="20" />
 					</template>
 				</NcButton>
 				<NcButton variant="tertiary"
-					:disabled="index === modelValue.length - 1"
-					:aria-label="t('attendance', 'Move {name} down', { name: labelOf(item) })"
-					:title="t('attendance', 'Move {name} down', { name: labelOf(item) })"
+					:disabled="index === rows.length - 1"
+					:aria-label="row.moveDown"
+					:title="row.moveDown"
 					:data-test="`${dataTest}-down`"
-					@click="move(index, 1)">
+					@click="reorder(index, index + 1)">
 					<template #icon>
 						<ArrowDown :size="20" />
 					</template>
@@ -48,7 +48,7 @@
 
 <script setup>
 import { NcButton } from '@nextcloud/vue'
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
 import ArrowDown from 'vue-material-design-icons/ArrowDown.vue'
 import ArrowUp from 'vue-material-design-icons/ArrowUp.vue'
 import DragIcon from 'vue-material-design-icons/DragHorizontalVariant.vue'
@@ -59,15 +59,9 @@ const props = defineProps({
 		type: Array,
 		default: () => [],
 	},
-	/** Property holding the human-readable name of an entry */
-	labelKey: {
-		type: String,
-		default: 'displayName',
-	},
-	/** Overrides `labelKey`, e.g. to translate system group ids */
 	formatLabel: {
 		type: Function,
-		default: null,
+		required: true,
 	},
 	dataTest: {
 		type: String,
@@ -80,10 +74,15 @@ const emit = defineEmits(['update:modelValue'])
 const dragIndex = ref(null)
 const overIndex = ref(null)
 
-function labelOf(item) {
-	if (props.formatLabel) return props.formatLabel(item)
-	return item[props.labelKey] || item.id
-}
+const rows = computed(() => props.modelValue.map((item) => {
+	const label = props.formatLabel(item)
+	return {
+		item,
+		label,
+		moveUp: t('attendance', 'Move {name} up', { name: label }),
+		moveDown: t('attendance', 'Move {name} down', { name: label }),
+	}
+}))
 
 function reorder(from, to) {
 	const items = [...props.modelValue]
@@ -92,17 +91,11 @@ function reorder(from, to) {
 	emit('update:modelValue', items)
 }
 
-function move(index, offset) {
-	const target = index + offset
-	if (target < 0 || target >= props.modelValue.length) return
-	reorder(index, target)
-}
-
 function onDragStart(index, event) {
 	dragIndex.value = index
 	event.dataTransfer.effectAllowed = 'move'
 	// Firefox only starts a drag once some data is attached.
-	event.dataTransfer.setData('text/plain', String(index))
+	event.dataTransfer.setData('text/plain', '')
 }
 
 function onDragLeave(index) {

--- a/src/components/common/TeamSelect.vue
+++ b/src/components/common/TeamSelect.vue
@@ -1,0 +1,96 @@
+<template>
+	<div>
+		<NcSelect
+			:modelValue="modelValue"
+			:options="options"
+			:placeholder="placeholder"
+			:multiple="true"
+			:loading="isSearching"
+			:filterable="false"
+			label="label"
+			trackBy="id"
+			@search="search"
+			@update:modelValue="$emit('update:modelValue', $event)">
+			<template #option="{ label }">
+				<span style="display: flex; align-items: center; gap: 8px;">
+					<AccountStar :size="20" />
+					<span>{{ label }}</span>
+				</span>
+			</template>
+			<template #selected-option="{ label }">
+				<span style="display: flex; align-items: center; gap: 8px;">
+					<AccountStar :size="16" />
+					<span>{{ label }}</span>
+				</span>
+			</template>
+		</NcSelect>
+		<OrderedSelectionList v-if="sortable"
+			:modelValue="modelValue"
+			labelKey="label"
+			:dataTest="orderDataTest"
+			@update:modelValue="$emit('update:modelValue', $event)" />
+	</div>
+</template>
+
+<script setup>
+import axios from '@nextcloud/axios'
+import { generateUrl } from '@nextcloud/router'
+import { NcSelect } from '@nextcloud/vue'
+import { computed, ref } from 'vue'
+import AccountStar from 'vue-material-design-icons/AccountStar.vue'
+import OrderedSelectionList from './OrderedSelectionList.vue'
+
+const props = defineProps({
+	modelValue: {
+		type: Array,
+		default: () => [],
+	},
+	placeholder: {
+		type: String,
+		default: '',
+	},
+	/** Offer the selection as a reorderable list — the order teams appear in */
+	sortable: {
+		type: Boolean,
+		default: false,
+	},
+	orderDataTest: {
+		type: String,
+		default: 'order-teams',
+	},
+})
+
+defineEmits(['update:modelValue'])
+
+const searchResults = ref([])
+const isSearching = ref(false)
+
+// Teams are searched server-side, so the dropdown would otherwise drop the
+// current selection as soon as it no longer matches the query.
+const options = computed(() => {
+	const selectedIds = props.modelValue.map((team) => team.id)
+	return [...props.modelValue, ...searchResults.value.filter((team) => !selectedIds.includes(team.id))]
+})
+
+async function search(query) {
+	if (!query) {
+		searchResults.value = []
+		return
+	}
+
+	isSearching.value = true
+	try {
+		const response = await axios.get(
+			generateUrl('/apps/attendance/api/search/users-groups-teams'),
+			{ params: { search: query } },
+		)
+		searchResults.value = response.data
+			.filter((item) => item.type === 'team')
+			.map((item) => ({ id: item.id, label: item.label, type: 'team' }))
+	} catch (error) {
+		console.error('Error searching teams:', error)
+	} finally {
+		isSearching.value = false
+	}
+}
+</script>

--- a/src/components/common/TeamSelect.vue
+++ b/src/components/common/TeamSelect.vue
@@ -26,8 +26,8 @@
 		</NcSelect>
 		<OrderedSelectionList v-if="sortable"
 			:modelValue="modelValue"
-			labelKey="label"
-			:dataTest="orderDataTest"
+			:formatLabel="teamLabel"
+			dataTest="order-teams"
 			@update:modelValue="$emit('update:modelValue', $event)" />
 	</div>
 </template>
@@ -54,10 +54,6 @@ const props = defineProps({
 		type: Boolean,
 		default: false,
 	},
-	orderDataTest: {
-		type: String,
-		default: 'order-teams',
-	},
 })
 
 defineEmits(['update:modelValue'])
@@ -65,11 +61,13 @@ defineEmits(['update:modelValue'])
 const searchResults = ref([])
 const isSearching = ref(false)
 
+const teamLabel = (team) => team.label
+
 // Teams are searched server-side, so the dropdown would otherwise drop the
 // current selection as soon as it no longer matches the query.
 const options = computed(() => {
-	const selectedIds = props.modelValue.map((team) => team.id)
-	return [...props.modelValue, ...searchResults.value.filter((team) => !selectedIds.includes(team.id))]
+	const selectedIds = new Set(props.modelValue.map((team) => team.id))
+	return [...props.modelValue, ...searchResults.value.filter((team) => !selectedIds.has(team.id))]
 })
 
 async function search(query) {

--- a/src/components/onboarding/OnboardingWizard.vue
+++ b/src/components/onboarding/OnboardingWizard.vue
@@ -55,7 +55,6 @@
 						:options="availableGroups"
 						:placeholder="t('attendance', 'Select groups …')"
 						:sortable="true"
-						orderDataTest="order-onboarding-summary-groups"
 						data-test="onboarding-summary-groups" />
 				</template>
 

--- a/src/components/onboarding/OnboardingWizard.vue
+++ b/src/components/onboarding/OnboardingWizard.vue
@@ -54,6 +54,8 @@
 						v-model="whitelistedGroups"
 						:options="availableGroups"
 						:placeholder="t('attendance', 'Select groups …')"
+						:sortable="true"
+						orderDataTest="order-onboarding-summary-groups"
 						data-test="onboarding-summary-groups" />
 				</template>
 

--- a/src/views/AdminSettings.vue
+++ b/src/views/AdminSettings.vue
@@ -39,6 +39,14 @@
 					:options="availableGroups"
 					:placeholder="t('attendance', 'Select groups …')"
 					data-test="select-whitelisted-groups" />
+				<template v-if="selectedGroups.length > 1">
+					<p class="hint-text">
+						{{ t('attendance', 'Sections appear in this order. Drag an entry or use the arrows to move it.') }}
+					</p>
+					<OrderedSelectionList v-model="selectedGroups"
+						:formatLabel="groupLabel"
+						dataTest="order-whitelisted-groups" />
+				</template>
 				<p class="hint-text">
 					{{ n('attendance', '%n group selected', '%n groups selected', selectedGroups.length, { n: selectedGroups.length }) }}
 				</p>
@@ -73,6 +81,14 @@
 						</span>
 					</template>
 				</NcSelect>
+				<template v-if="selectedTeams.length > 1">
+					<p class="hint-text">
+						{{ t('attendance', 'Sections appear in this order. Drag an entry or use the arrows to move it.') }}
+					</p>
+					<OrderedSelectionList v-model="selectedTeams"
+						labelKey="label"
+						dataTest="order-whitelisted-teams" />
+				</template>
 				<p class="hint-text">
 					{{ n('attendance', '%n team selected', '%n teams selected', selectedTeams.length, { n: selectedTeams.length }) }}
 				</p>
@@ -704,6 +720,7 @@ import Pencil from 'vue-material-design-icons/Pencil.vue'
 import RocketLaunchIcon from 'vue-material-design-icons/RocketLaunch.vue'
 import TrashCan from 'vue-material-design-icons/TrashCan.vue'
 import CategoryIconPicker from '../components/admin/CategoryIconPicker.vue'
+import OrderedSelectionList from '../components/admin/OrderedSelectionList.vue'
 import PermissionRow from '../components/admin/PermissionRow.vue'
 import SectionLink from '../components/admin/SectionLink.vue'
 import GroupSelect from '../components/common/GroupSelect.vue'
@@ -711,7 +728,7 @@ import LoadingState from '../components/common/LoadingState.vue'
 import { categoryIconComponent, DEFAULT_CATEGORY_ICON } from '../utils/categoryIcons.js'
 import { copyToClipboard } from '../utils/clipboard.js'
 import { formatDate, formatDateTimeMedium } from '../utils/datetime.js'
-import { toGroupObjects } from '../utils/groups.js'
+import { formatGroupLabel, toGroupObjects } from '../utils/groups.js'
 import { MOBILE_APP_STORES } from '../utils/mobileApp.js'
 import { AUDIT_VISIBILITIES, permissionGroups as buildPermissionGroups, emptyPermissionState, PERMISSION_NAMES, PERMISSION_ROWS, REMINDER_TARGETS } from '../utils/permissions.js'
 
@@ -851,6 +868,10 @@ function implicationLinkFor(name) {
 const availableGroups = ref([])
 const selectedGroups = ref([])
 const selectedTeams = ref([])
+
+// Groups stored in the config carry their raw id, so system groups need the
+// same relabelling the select applies to its options.
+const groupLabel = (group) => formatGroupLabel(group.id, group.displayName)
 const teamSearchResults = ref([])
 const isSearchingTeams = ref(false)
 const teamsAvailable = ref(false)

--- a/src/views/AdminSettings.vue
+++ b/src/views/AdminSettings.vue
@@ -39,7 +39,6 @@
 					:options="availableGroups"
 					:placeholder="t('attendance', 'Select groups …')"
 					:sortable="true"
-					orderDataTest="order-whitelisted-groups"
 					data-test="select-whitelisted-groups" />
 				<p class="hint-text">
 					{{ n('attendance', '%n group selected', '%n groups selected', selectedGroups.length, { n: selectedGroups.length }) }}
@@ -55,7 +54,6 @@
 					v-model="selectedTeams"
 					:placeholder="t('attendance', 'Search and select teams …')"
 					:sortable="true"
-					orderDataTest="order-whitelisted-teams"
 					data-test="select-whitelisted-teams" />
 				<p class="hint-text">
 					{{ n('attendance', '%n team selected', '%n teams selected', selectedTeams.length, { n: selectedTeams.length }) }}
@@ -1075,11 +1073,8 @@ async function loadSettings() {
 		availableGroups.value = groups
 		selectedGroups.value = toGroupObjects(config.whitelistedGroups, groups)
 
-		// Load teams settings
 		teamsAvailable.value = caps.teamsAvailable || false
-		if (config.whitelistedTeams) {
-			selectedTeams.value = config.whitelistedTeams
-		}
+		selectedTeams.value = config.whitelistedTeams ?? []
 
 		// Load permission settings
 		if (config.permissions) {

--- a/src/views/AdminSettings.vue
+++ b/src/views/AdminSettings.vue
@@ -38,15 +38,9 @@
 					v-model="selectedGroups"
 					:options="availableGroups"
 					:placeholder="t('attendance', 'Select groups …')"
+					:sortable="true"
+					orderDataTest="order-whitelisted-groups"
 					data-test="select-whitelisted-groups" />
-				<template v-if="selectedGroups.length > 1">
-					<p class="hint-text">
-						{{ t('attendance', 'Sections appear in this order. Drag an entry or use the arrows to move it.') }}
-					</p>
-					<OrderedSelectionList v-model="selectedGroups"
-						:formatLabel="groupLabel"
-						dataTest="order-whitelisted-groups" />
-				</template>
 				<p class="hint-text">
 					{{ n('attendance', '%n group selected', '%n groups selected', selectedGroups.length, { n: selectedGroups.length }) }}
 				</p>
@@ -57,38 +51,12 @@
 				:name="t('attendance', 'Response summary teams')"
 				:description="t('attendance', 'Select which teams to include in response summaries. Team members will be grouped together like regular groups.')"
 				data-test="section-tracking-teams">
-				<NcSelect
+				<TeamSelect
 					v-model="selectedTeams"
-					:options="teamSearchResults"
 					:placeholder="t('attendance', 'Search and select teams …')"
-					:multiple="true"
-					:loading="isSearchingTeams"
-					:filterable="false"
-					label="label"
-					trackBy="id"
-					data-test="select-whitelisted-teams"
-					@search="searchTeams">
-					<template #option="{ label }">
-						<span style="display: flex; align-items: center; gap: 8px;">
-							<AccountStar :size="20" />
-							<span>{{ label }}</span>
-						</span>
-					</template>
-					<template #selected-option="{ label }">
-						<span style="display: flex; align-items: center; gap: 8px;">
-							<AccountStar :size="16" />
-							<span>{{ label }}</span>
-						</span>
-					</template>
-				</NcSelect>
-				<template v-if="selectedTeams.length > 1">
-					<p class="hint-text">
-						{{ t('attendance', 'Sections appear in this order. Drag an entry or use the arrows to move it.') }}
-					</p>
-					<OrderedSelectionList v-model="selectedTeams"
-						labelKey="label"
-						dataTest="order-whitelisted-teams" />
-				</template>
+					:sortable="true"
+					orderDataTest="order-whitelisted-teams"
+					data-test="select-whitelisted-teams" />
 				<p class="hint-text">
 					{{ n('attendance', '%n team selected', '%n teams selected', selectedTeams.length, { n: selectedTeams.length }) }}
 				</p>
@@ -709,7 +677,6 @@ import {
 } from '@nextcloud/vue'
 import QRCode from 'qrcode'
 import { computed, defineAsyncComponent, nextTick, onMounted, reactive, ref, watch } from 'vue'
-import AccountStar from 'vue-material-design-icons/AccountStar.vue'
 import BellRingIcon from 'vue-material-design-icons/BellRing.vue'
 import CalendarSyncIcon from 'vue-material-design-icons/CalendarSync.vue'
 import CellphoneCheck from 'vue-material-design-icons/CellphoneCheck.vue'
@@ -720,15 +687,15 @@ import Pencil from 'vue-material-design-icons/Pencil.vue'
 import RocketLaunchIcon from 'vue-material-design-icons/RocketLaunch.vue'
 import TrashCan from 'vue-material-design-icons/TrashCan.vue'
 import CategoryIconPicker from '../components/admin/CategoryIconPicker.vue'
-import OrderedSelectionList from '../components/admin/OrderedSelectionList.vue'
 import PermissionRow from '../components/admin/PermissionRow.vue'
 import SectionLink from '../components/admin/SectionLink.vue'
 import GroupSelect from '../components/common/GroupSelect.vue'
 import LoadingState from '../components/common/LoadingState.vue'
+import TeamSelect from '../components/common/TeamSelect.vue'
 import { categoryIconComponent, DEFAULT_CATEGORY_ICON } from '../utils/categoryIcons.js'
 import { copyToClipboard } from '../utils/clipboard.js'
 import { formatDate, formatDateTimeMedium } from '../utils/datetime.js'
-import { formatGroupLabel, toGroupObjects } from '../utils/groups.js'
+import { toGroupObjects } from '../utils/groups.js'
 import { MOBILE_APP_STORES } from '../utils/mobileApp.js'
 import { AUDIT_VISIBILITIES, permissionGroups as buildPermissionGroups, emptyPermissionState, PERMISSION_NAMES, PERMISSION_ROWS, REMINDER_TARGETS } from '../utils/permissions.js'
 
@@ -868,12 +835,6 @@ function implicationLinkFor(name) {
 const availableGroups = ref([])
 const selectedGroups = ref([])
 const selectedTeams = ref([])
-
-// Groups stored in the config carry their raw id, so system groups need the
-// same relabelling the select applies to its options.
-const groupLabel = (group) => formatGroupLabel(group.id, group.displayName)
-const teamSearchResults = ref([])
-const isSearchingTeams = ref(false)
 const teamsAvailable = ref(false)
 const permissions = ref(emptyPermissionState())
 const selfCheckinWindowMinutes = ref(30)
@@ -1118,8 +1079,6 @@ async function loadSettings() {
 		teamsAvailable.value = caps.teamsAvailable || false
 		if (config.whitelistedTeams) {
 			selectedTeams.value = config.whitelistedTeams
-			// Also add to search results so they appear in the dropdown
-			teamSearchResults.value = [...config.whitelistedTeams]
 		}
 
 		// Load permission settings
@@ -1193,35 +1152,6 @@ async function loadSettings() {
 		// Let the watchers flush the load mutations before arming auto-save
 		await nextTick()
 		suppressSaves = false
-	}
-}
-
-async function searchTeams(query) {
-	if (!query || query.length < 1) {
-		// Keep selected teams visible in results
-		teamSearchResults.value = [...selectedTeams.value]
-		return
-	}
-
-	isSearchingTeams.value = true
-	try {
-		const response = await axios.get(
-			generateUrl('/apps/attendance/api/search/users-groups-teams'),
-			{ params: { search: query } },
-		)
-		// Filter to only show teams
-		const teams = response.data
-			.filter((item) => item.type === 'team')
-			.map((item) => ({ id: item.id, label: item.label, type: 'team' }))
-
-		// Merge with selected teams to keep them visible
-		const selectedIds = selectedTeams.value.map((t) => t.id)
-		const newTeams = teams.filter((t) => !selectedIds.includes(t.id))
-		teamSearchResults.value = [...selectedTeams.value, ...newTeams]
-	} catch (error) {
-		console.error('Error searching teams:', error)
-	} finally {
-		isSearchingTeams.value = false
 	}
 }
 

--- a/tests/e2e/4-admin-settings.spec.js
+++ b/tests/e2e/4-admin-settings.spec.js
@@ -1,4 +1,4 @@
-import { createGroupViaOCS, deleteAllAppointments, expect, resetAdminSettings, restrictPermissionToGroup, saveAdminSettings, test, waitForSettingsSave } from './fixtures/nextcloud.js'
+import { addUserToGroupViaOCS, createAppointmentViaAPI, createGroupViaOCS, deleteAllAppointments, expect, PERMISSIVE_PERMISSIONS, resetAdminSettings, restrictPermissionToGroup, saveAdminSettings, test, waitForSettingsSave } from './fixtures/nextcloud.js'
 
 /**
  * Admin Settings E2E Tests
@@ -278,7 +278,18 @@ test.describe('Attendance App - Admin Settings', () => {
 		test.beforeAll(async ({ request }) => {
 			await createGroupViaOCS(request, firstGroup)
 			await createGroupViaOCS(request, secondGroup)
-			await saveAdminSettings(request, { whitelistedGroups: [firstGroup, secondGroup] })
+			// Sections are dropped when nobody is in them, so each group needs a member
+			await addUserToGroupViaOCS(request, 'test1', firstGroup)
+			await addUserToGroupViaOCS(request, 'test2', secondGroup)
+		})
+
+		test.beforeEach(async ({ request }) => {
+			await saveAdminSettings(request, {
+				whitelistedGroups: [firstGroup, secondGroup],
+				whitelistedTeams: [],
+				permissions: { ...PERMISSIVE_PERMISSIONS },
+				reminders: { enabled: false },
+			})
 		})
 
 		test.afterAll(async ({ request }) => {
@@ -294,6 +305,10 @@ test.describe('Attendance App - Admin Settings', () => {
 			await expect(items).toHaveCount(2)
 			await expect(items.first()).toContainText(firstGroup)
 
+			// Nothing to move past at either end
+			await expect(items.first().locator('[data-test="order-groups-up"]')).toBeDisabled()
+			await expect(items.last().locator('[data-test="order-groups-down"]')).toBeDisabled()
+
 			const saved = waitForSettingsSave(page)
 			await items.first().locator('[data-test="order-groups-down"]').click()
 			await saved
@@ -301,9 +316,57 @@ test.describe('Attendance App - Admin Settings', () => {
 			await page.reload()
 			await page.waitForLoadState('networkidle')
 
-			const reloaded = page.locator('[data-test="order-groups-item"]')
-			await expect(reloaded.first()).toContainText(secondGroup)
-			await expect(reloaded.last()).toContainText(firstGroup)
+			await expect(items.first()).toContainText(secondGroup)
+			await expect(items.last()).toContainText(firstGroup)
+
+			// And back up again
+			const savedAgain = waitForSettingsSave(page)
+			await items.last().locator('[data-test="order-groups-up"]').click()
+			await savedAgain
+
+			await page.reload()
+			await page.waitForLoadState('networkidle')
+
+			await expect(items.first()).toContainText(firstGroup)
+		})
+
+		test('should not offer the order list for fewer than two groups', async ({ page, loginAsUser, request }) => {
+			await saveAdminSettings(request, { whitelistedGroups: [firstGroup] })
+
+			await loginAsUser('admin', 'admin')
+			await page.goto('/settings/admin/attendance')
+			await page.waitForLoadState('networkidle')
+
+			await expect(page.locator('[data-test="select-whitelisted-groups"]')).toBeVisible()
+			await expect(page.locator('[data-test="order-groups-item"]')).toHaveCount(0)
+		})
+
+		test('should render the response summary sections in the configured order', async ({ page, loginAsUser, request }) => {
+			const appointment = await createAppointmentViaAPI(request, {
+				name: 'Group Order Summary',
+				daysFromNow: 5,
+				visibleGroups: [firstGroup, secondGroup],
+			})
+
+			await loginAsUser('admin', 'admin')
+			const sections = page.locator('[data-test="group-summary"] .group-name')
+
+			await page.goto(`/apps/attendance/appointment/${appointment.id}`)
+			await page.waitForLoadState('networkidle')
+			await expect(sections.nth(0)).toContainText(firstGroup)
+			await expect(sections.nth(1)).toContainText(secondGroup)
+
+			await page.goto('/settings/admin/attendance')
+			await page.waitForLoadState('networkidle')
+			const saved = waitForSettingsSave(page)
+			const items = page.locator('[data-test="order-groups-item"]')
+			await items.first().locator('[data-test="order-groups-down"]').click()
+			await saved
+
+			await page.goto(`/apps/attendance/appointment/${appointment.id}`)
+			await page.waitForLoadState('networkidle')
+			await expect(sections.nth(0)).toContainText(secondGroup)
+			await expect(sections.nth(1)).toContainText(firstGroup)
 		})
 	})
 

--- a/tests/e2e/4-admin-settings.spec.js
+++ b/tests/e2e/4-admin-settings.spec.js
@@ -1,4 +1,4 @@
-import { deleteAllAppointments, expect, resetAdminSettings, restrictPermissionToGroup, test, waitForSettingsSave } from './fixtures/nextcloud.js'
+import { createGroupViaOCS, deleteAllAppointments, expect, resetAdminSettings, restrictPermissionToGroup, saveAdminSettings, test, waitForSettingsSave } from './fixtures/nextcloud.js'
 
 /**
  * Admin Settings E2E Tests
@@ -268,6 +268,42 @@ test.describe('Attendance App - Admin Settings', () => {
 			const saved = waitForSettingsSave(page)
 			await adminOption.click()
 			await saved
+		})
+	})
+
+	test.describe('Group Order Configuration', () => {
+		const firstGroup = 'attendance-e2e-order-a'
+		const secondGroup = 'attendance-e2e-order-b'
+
+		test.beforeAll(async ({ request }) => {
+			await createGroupViaOCS(request, firstGroup)
+			await createGroupViaOCS(request, secondGroup)
+			await saveAdminSettings(request, { whitelistedGroups: [firstGroup, secondGroup] })
+		})
+
+		test.afterAll(async ({ request }) => {
+			await resetAdminSettings(request)
+		})
+
+		test('should reorder whitelisted groups and persist the new order', async ({ page, loginAsUser }) => {
+			await loginAsUser('admin', 'admin')
+			await page.goto('/settings/admin/attendance')
+			await page.waitForLoadState('networkidle')
+
+			const items = page.locator('[data-test="order-whitelisted-groups-item"]')
+			await expect(items).toHaveCount(2)
+			await expect(items.first()).toContainText(firstGroup)
+
+			const saved = waitForSettingsSave(page)
+			await items.first().locator('[data-test="order-whitelisted-groups-down"]').click()
+			await saved
+
+			await page.reload()
+			await page.waitForLoadState('networkidle')
+
+			const reloaded = page.locator('[data-test="order-whitelisted-groups-item"]')
+			await expect(reloaded.first()).toContainText(secondGroup)
+			await expect(reloaded.last()).toContainText(firstGroup)
 		})
 	})
 

--- a/tests/e2e/4-admin-settings.spec.js
+++ b/tests/e2e/4-admin-settings.spec.js
@@ -290,18 +290,18 @@ test.describe('Attendance App - Admin Settings', () => {
 			await page.goto('/settings/admin/attendance')
 			await page.waitForLoadState('networkidle')
 
-			const items = page.locator('[data-test="order-whitelisted-groups-item"]')
+			const items = page.locator('[data-test="order-groups-item"]')
 			await expect(items).toHaveCount(2)
 			await expect(items.first()).toContainText(firstGroup)
 
 			const saved = waitForSettingsSave(page)
-			await items.first().locator('[data-test="order-whitelisted-groups-down"]').click()
+			await items.first().locator('[data-test="order-groups-down"]').click()
 			await saved
 
 			await page.reload()
 			await page.waitForLoadState('networkidle')
 
-			const reloaded = page.locator('[data-test="order-whitelisted-groups-item"]')
+			const reloaded = page.locator('[data-test="order-groups-item"]')
 			await expect(reloaded.first()).toContainText(secondGroup)
 			await expect(reloaded.last()).toContainText(firstGroup)
 		})

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -248,7 +248,7 @@ The page auto-saves; there is no save button. Wait for the POST to
 
 - `admin-settings` - Admin settings container
 - `select-whitelisted-groups` - Whitelisted groups selector
-- `order-whitelisted-groups-item` - Entry of the group order list, with `order-whitelisted-groups-up|down` buttons (same for `order-whitelisted-teams-*`)
+- `order-groups-item` - Entry of the group order list, with `order-groups-up|down` buttons (same for `order-teams-*`)
 - `permission-<name>` - Permission row (e.g. `permission-manage_appointments`) with `permission-<name>-mode-all|groups|nobody` radios and a `permission-<name>-groups` group selector (visible in "Specific groups" mode)
 - `switch-reminders-enabled` - Enable reminders switch
 - `input-reminder-days` - Reminder days input

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -248,6 +248,7 @@ The page auto-saves; there is no save button. Wait for the POST to
 
 - `admin-settings` - Admin settings container
 - `select-whitelisted-groups` - Whitelisted groups selector
+- `order-whitelisted-groups-item` - Entry of the group order list, with `order-whitelisted-groups-up|down` buttons (same for `order-whitelisted-teams-*`)
 - `permission-<name>` - Permission row (e.g. `permission-manage_appointments`) with `permission-<name>-mode-all|groups|nobody` radios and a `permission-<name>-groups` group selector (visible in "Specific groups" mode)
 - `switch-reminders-enabled` - Enable reminders switch
 - `input-reminder-days` - Reminder days input


### PR DESCRIPTION
Closes #183.

The response summary already renders its sections in the order the whitelist stores them — `ResponseSummaryService::sortGroups()` walks the configured ids first, and `StatisticsService::sortSections()` does the same for the statistics view. What was missing is a way to *change* that order: the admin settings offered only an `NcSelect`, which appends. Getting a newly founded orchestra's Oboe group above Flute and Horn meant removing both and adding them back.

No backend, API or migration change — the stored array order is already the contract, this only lets an admin edit it.

## What changed

Selected groups and teams now also render as an ordered list: drag an entry by its handle, or move it with per-row arrow buttons so the whole thing stays keyboard-reachable. The list appears from two entries on (with one there is nothing to order), and the existing debounced auto-save picks a reorder up like any other change on the page.

The select and the order list always belong together, so the pair lives inside the select rather than being composed per section:

- `GroupSelect` takes a `sortable` flag and owns the list — it also relabels system groups for it, so `guest_app` reads "Guests" in the order list too.
- `TeamSelect` is new: the teams `NcSelect`, its search call and its loading state move out of `AdminSettings.vue` into a component with the same flag. Its dropdown options are now `selection + search results` computed on the fly, instead of the view seeding a results ref from the loaded config and every search re-merging the selection into it.
- The onboarding wizard writes the same whitelist, so it gains ordering from the same flag.

`AdminSettings.vue` comes out 54 lines lighter.

## Note for the empty-whitelist case

An empty whitelist means "every group gets a section", and the summary then sorts alphabetically. There is no stored list to reorder in that case — the set is whatever groups exist on the server at render time — so a custom order requires naming the groups explicitly. Unchanged behaviour, but it is what the "leave empty to include all groups" hint now implies.

## Tests

`tests/e2e/4-admin-settings.spec.js` gains a `Group Order Configuration` block:

- the summary itself: an appointment visible to two member-carrying groups, section headers read on the appointment page, reordered in the settings, read again — the full chain from the arrow button to the rendered order
- the settings round trip: order persists across a reload, moving back up works, and the arrows are disabled at both ends
- no order list while fewer than two groups are selected

Drag-and-drop is deliberately not covered — it drives the same `reorder()` the arrows do, and a native-DnD test is the flakiest thing that could be added here. The teams list would need the Circles app for `teamsAvailable`, so it is untested as well.

## Verification

`./scripts/check.sh` passes: eslint, stylelint, php-cs-fixer, psalm, PHPUnit, vite build, both l10n checks and the OpenAPI spec check. The e2e suite needs Docker, which the environment this was written in does not have, so the new specs first run in CI.

German is filled in for the three new strings (informal `de`, formal `de_DE`); the same run also translated one previously missing string and dropped two orphaned keys, kept in its own commit.

## Mobile

No capability flag: no endpoint, response field or client-visible UI is added, and the server already emitted an order — an older Flutter build sees a byte-identical response. Worth confirming on the app side that the summary screen iterates `by_group` / `by_team` in received order rather than re-sorting the keys, since that order is now something an admin chose. Dart's `json.decode` yields an insertion-ordered map, so plain iteration is enough.

---
_Generated by [Claude Code](https://claude.ai/code/session_014MVPyNN6jb4CJDkfTHXaDS)_