### PR TITLE
feat(audit): tell mobile-app entries apart from the web UI

### DIFF
--- a/l10n/de.js
+++ b/l10n/de.js
@@ -791,6 +791,7 @@ OC.L10N.register(
     "Closed automatically on {when}" : "Automatisch geschlossen am {when}",
     "Closed on {when}" : "Geschlossen am {when}",
     "Web" : "Web",
+    "App" : "App",
     "Email link" : "E-Mail-Link",
     "Manager" : "Manager",
     "Self check-in" : "Selbst-Check-in",

--- a/l10n/de.json
+++ b/l10n/de.json
@@ -789,6 +789,7 @@
     "Closed automatically on {when}" : "Automatisch geschlossen am {when}",
     "Closed on {when}" : "Geschlossen am {when}",
     "Web" : "Web",
+    "App" : "App",
     "Email link" : "E-Mail-Link",
     "Manager" : "Manager",
     "Self check-in" : "Selbst-Check-in",

--- a/l10n/de_DE.js
+++ b/l10n/de_DE.js
@@ -791,6 +791,7 @@ OC.L10N.register(
     "Closed automatically on {when}" : "Automatisch geschlossen am {when}",
     "Closed on {when}" : "Geschlossen am {when}",
     "Web" : "Web",
+    "App" : "App",
     "Email link" : "E-Mail-Link",
     "Manager" : "Manager",
     "Self check-in" : "Selbst-Check-in",

--- a/l10n/de_DE.json
+++ b/l10n/de_DE.json
@@ -789,6 +789,7 @@
     "Closed automatically on {when}" : "Automatisch geschlossen am {when}",
     "Closed on {when}" : "Geschlossen am {when}",
     "Web" : "Web",
+    "App" : "App",
     "Email link" : "E-Mail-Link",
     "Manager" : "Manager",
     "Self check-in" : "Selbst-Check-in",

--- a/lib/Audit/Verb.php
+++ b/lib/Audit/Verb.php
@@ -60,7 +60,10 @@ final class Verb {
 		self::APPOINTMENT_UNCANCELLED,
 	];
 
+	// Both arrive through the app's own API; only the mobile client sends
+	// the header that tells them apart.
 	public const SOURCE_APP = 'app';
+	public const SOURCE_MOBILE = 'mobile';
 	public const SOURCE_QUICK_LINK = 'quick_link';
 	public const SOURCE_ADMIN_CHECKIN = 'admin_checkin';
 	public const SOURCE_ADMIN_RESPONSE = 'admin_response';

--- a/lib/Audit/Verb.php
+++ b/lib/Audit/Verb.php
@@ -60,9 +60,19 @@ final class Verb {
 		self::APPOINTMENT_UNCANCELLED,
 	];
 
-	// Both arrive through the app's own API; only the mobile client sends
-	// the header that tells them apart.
-	public const SOURCE_APP = 'app';
+	/**
+	 * What callers pass for "a client did this through our API". Never
+	 * persisted: AuditEventService resolves it to SOURCE_WEB or SOURCE_MOBILE
+	 * depending on whether the request identifies itself as the mobile app.
+	 */
+	public const SOURCE_CLIENT = 'app';
+
+	/**
+	 * The web UI. Its stored value is the historical 'app', from a time when
+	 * "the app" meant this app in a browser and no mobile client existed —
+	 * renaming the string would strand every audit row already written.
+	 */
+	public const SOURCE_WEB = 'app';
 	public const SOURCE_MOBILE = 'mobile';
 	public const SOURCE_QUICK_LINK = 'quick_link';
 	public const SOURCE_ADMIN_CHECKIN = 'admin_checkin';

--- a/lib/Service/AppointmentService.php
+++ b/lib/Service/AppointmentService.php
@@ -168,7 +168,7 @@ class AppointmentService {
 		$this->auditEventService->recordAppointmentLifecycle(
 			\OCA\Attendance\Audit\Verb::APPOINTMENT_CREATED,
 			$appointment->getId(),
-			\OCA\Attendance\Audit\Verb::SOURCE_APP,
+			\OCA\Attendance\Audit\Verb::SOURCE_CLIENT,
 		);
 
 		$this->orgCalendarSyncService->syncAppointment($appointment);
@@ -456,7 +456,7 @@ class AppointmentService {
 	 * Close an appointment inquiry. Marks closedAt with the current UTC time.
 	 * Idempotent: returns the existing appointment unchanged if already closed.
 	 */
-	public function closeAppointment(int $id, string $source = \OCA\Attendance\Audit\Verb::SOURCE_APP): Appointment {
+	public function closeAppointment(int $id, string $source = \OCA\Attendance\Audit\Verb::SOURCE_CLIENT): Appointment {
 		$appointment = $this->appointmentMapper->find($id);
 		if ($appointment->isClosed()) {
 			return $appointment;
@@ -502,7 +502,7 @@ class AppointmentService {
 		$this->auditEventService->recordAppointmentLifecycle(
 			\OCA\Attendance\Audit\Verb::APPOINTMENT_REOPENED,
 			$id,
-			\OCA\Attendance\Audit\Verb::SOURCE_APP,
+			\OCA\Attendance\Audit\Verb::SOURCE_CLIENT,
 		);
 
 		return $updated;
@@ -531,7 +531,7 @@ class AppointmentService {
 		$this->auditEventService->recordAppointmentLifecycle(
 			\OCA\Attendance\Audit\Verb::APPOINTMENT_CANCELLED,
 			$id,
-			\OCA\Attendance\Audit\Verb::SOURCE_APP,
+			\OCA\Attendance\Audit\Verb::SOURCE_CLIENT,
 		);
 
 		$this->orgCalendarSyncService->syncAppointment($updated);
@@ -567,7 +567,7 @@ class AppointmentService {
 		$this->auditEventService->recordAppointmentLifecycle(
 			\OCA\Attendance\Audit\Verb::APPOINTMENT_UNCANCELLED,
 			$id,
-			\OCA\Attendance\Audit\Verb::SOURCE_APP,
+			\OCA\Attendance\Audit\Verb::SOURCE_CLIENT,
 		);
 
 		$this->orgCalendarSyncService->syncAppointment($updated);
@@ -1135,7 +1135,7 @@ class AppointmentService {
 			$response,
 			$comment,
 			null,
-			\OCA\Attendance\Audit\Verb::SOURCE_APP,
+			\OCA\Attendance\Audit\Verb::SOURCE_CLIENT,
 			null,
 		);
 	}

--- a/lib/Service/AuditEventService.php
+++ b/lib/Service/AuditEventService.php
@@ -118,11 +118,11 @@ class AuditEventService {
 	 * untouched, background jobs included.
 	 */
 	private function resolveSource(?string $source): ?string {
-		if ($source !== Verb::SOURCE_APP) {
+		if ($source !== Verb::SOURCE_CLIENT) {
 			return $source;
 		}
 		$client = strtolower(trim($this->request->getHeader(self::CLIENT_HEADER)));
-		return $client === self::CLIENT_MOBILE ? Verb::SOURCE_MOBILE : Verb::SOURCE_APP;
+		return $client === self::CLIENT_MOBILE ? Verb::SOURCE_MOBILE : Verb::SOURCE_WEB;
 	}
 
 	/**
@@ -210,7 +210,7 @@ class AuditEventService {
 	public function recordAppointmentUpdate(
 		int $appointmentId,
 		array $fields,
-		string $source = Verb::SOURCE_APP,
+		string $source = Verb::SOURCE_CLIENT,
 	): ?AuditEvent {
 		return $this->record(
 			Verb::APPOINTMENT_UPDATED,

--- a/lib/Service/AuditEventService.php
+++ b/lib/Service/AuditEventService.php
@@ -8,6 +8,7 @@ use OCA\Attendance\Audit\AuditEventDispatcher;
 use OCA\Attendance\Audit\Verb;
 use OCA\Attendance\Db\AuditEvent;
 use OCA\Attendance\Db\AuditEventMapper;
+use OCP\IRequest;
 use OCP\IUserSession;
 use Psr\Log\LoggerInterface;
 
@@ -23,10 +24,19 @@ use Psr\Log\LoggerInterface;
  * "no actor" context for the timeline renderer.
  */
 class AuditEventService {
+	/**
+	 * Header the mobile app identifies itself with. Its absence is the normal
+	 * case — the web UI never sends it, and neither do app versions predating
+	 * it, which is why nothing gates on a capability here.
+	 */
+	private const CLIENT_HEADER = 'X-Attendance-Client';
+	private const CLIENT_MOBILE = 'mobile';
+
 	private AuditEventMapper $mapper;
 	private AuditEventDispatcher $dispatcher;
 	private ConfigService $configService;
 	private IUserSession $userSession;
+	private IRequest $request;
 	private LoggerInterface $logger;
 
 	public function __construct(
@@ -34,12 +44,14 @@ class AuditEventService {
 		AuditEventDispatcher $dispatcher,
 		ConfigService $configService,
 		IUserSession $userSession,
+		IRequest $request,
 		LoggerInterface $logger,
 	) {
 		$this->mapper = $mapper;
 		$this->dispatcher = $dispatcher;
 		$this->configService = $configService;
 		$this->userSession = $userSession;
+		$this->request = $request;
 		$this->logger = $logger;
 	}
 
@@ -74,7 +86,7 @@ class AuditEventService {
 			$event->setActorId($actorId);
 			$event->setSubjectId($subjectId);
 			$event->setMetaArray($meta);
-			$event->setSource($source);
+			$event->setSource($this->resolveSource($source));
 			$event->setCreatedAt(gmdate('Y-m-d H:i:s'));
 
 			$saved = $this->mapper->insert($event);
@@ -98,6 +110,19 @@ class AuditEventService {
 		}
 
 		return $saved;
+	}
+
+	/**
+	 * Refine the generic client source into the client the request actually
+	 * came from. Every other source is already specific and passes through
+	 * untouched, background jobs included.
+	 */
+	private function resolveSource(?string $source): ?string {
+		if ($source !== Verb::SOURCE_APP) {
+			return $source;
+		}
+		$client = strtolower(trim($this->request->getHeader(self::CLIENT_HEADER)));
+		return $client === self::CLIENT_MOBILE ? Verb::SOURCE_MOBILE : Verb::SOURCE_APP;
 	}
 
 	/**

--- a/lib/Service/ResponseService.php
+++ b/lib/Service/ResponseService.php
@@ -115,7 +115,7 @@ class ResponseService {
 
 		$auditSource = $source === self::SOURCE_QUICK_LINK
 			? \OCA\Attendance\Audit\Verb::SOURCE_QUICK_LINK
-			: \OCA\Attendance\Audit\Verb::SOURCE_APP;
+			: \OCA\Attendance\Audit\Verb::SOURCE_CLIENT;
 		$this->auditEventService->recordResponseChange(
 			$appointmentId,
 			$userId,

--- a/src/utils/auditFormat.js
+++ b/src/utils/auditFormat.js
@@ -14,6 +14,9 @@ function subjectLabel(event) {
 
 export const SOURCE_LABELS = {
 	app: () => t('attendance', 'Web'),
+	// TRANSLATORS: Noun — audit-log source label: the entry was made in the
+	// mobile app, as opposed to "Web" above.
+	mobile: () => t('attendance', 'App'),
 	quick_link: () => t('attendance', 'Email link'),
 	// TRANSLATORS: Noun — audit-log source label: the response was recorded
 	// via the check-in screen.

--- a/tests/unit/Service/AppointmentServiceTest.php
+++ b/tests/unit/Service/AppointmentServiceTest.php
@@ -145,7 +145,7 @@ class AppointmentServiceTest extends TestCase {
 
 		$this->auditEventService->expects($this->once())
 			->method('recordAppointmentLifecycle')
-			->with(Verb::APPOINTMENT_CREATED, 1, Verb::SOURCE_APP);
+			->with(Verb::APPOINTMENT_CREATED, 1, Verb::SOURCE_CLIENT);
 
 		$result = $this->service->createAppointment(
 			$name,
@@ -174,7 +174,7 @@ class AppointmentServiceTest extends TestCase {
 
 		$this->auditEventService->expects($this->once())
 			->method('recordAppointmentLifecycle')
-			->with(Verb::APPOINTMENT_CLOSED, 5, Verb::SOURCE_APP);
+			->with(Verb::APPOINTMENT_CLOSED, 5, Verb::SOURCE_CLIENT);
 
 		$result = $this->service->closeAppointment(5);
 		$this->assertNotNull($result->getClosedAt());
@@ -493,7 +493,7 @@ class AppointmentServiceTest extends TestCase {
 
 		$this->auditEventService->expects($this->once())
 			->method('recordAppointmentLifecycle')
-			->with(Verb::APPOINTMENT_REOPENED, 7, Verb::SOURCE_APP);
+			->with(Verb::APPOINTMENT_REOPENED, 7, Verb::SOURCE_CLIENT);
 
 		$result = $this->service->reopenAppointment(7);
 		$this->assertNull($result->getClosedAt());
@@ -543,7 +543,7 @@ class AppointmentServiceTest extends TestCase {
 
 		$this->auditEventService->expects($this->once())
 			->method('recordAppointmentLifecycle')
-			->with(Verb::APPOINTMENT_CANCELLED, 8, Verb::SOURCE_APP);
+			->with(Verb::APPOINTMENT_CANCELLED, 8, Verb::SOURCE_CLIENT);
 
 		$this->notificationService->expects($this->once())
 			->method('sendCancellationNotifications')
@@ -600,7 +600,7 @@ class AppointmentServiceTest extends TestCase {
 
 		$this->auditEventService->expects($this->once())
 			->method('recordAppointmentLifecycle')
-			->with(Verb::APPOINTMENT_UNCANCELLED, 9, Verb::SOURCE_APP);
+			->with(Verb::APPOINTMENT_UNCANCELLED, 9, Verb::SOURCE_CLIENT);
 
 		$result = $this->service->uncancelAppointment(9);
 		$this->assertNull($result->getCancelledAt());

--- a/tests/unit/Service/AuditEventServiceTest.php
+++ b/tests/unit/Service/AuditEventServiceTest.php
@@ -60,11 +60,11 @@ class AuditEventServiceTest extends TestCase {
 				return $event;
 			});
 
-		$this->service->recordAppointmentLifecycle(Verb::APPOINTMENT_CREATED, 42, Verb::SOURCE_APP);
+		$this->service->recordAppointmentLifecycle(Verb::APPOINTMENT_CREATED, 42, Verb::SOURCE_CLIENT);
 
 		$this->assertSame('alice', $captured->getActorId());
 		$this->assertSame(Verb::APPOINTMENT_CREATED, $captured->getVerb());
-		$this->assertSame(Verb::SOURCE_APP, $captured->getSource());
+		$this->assertSame(Verb::SOURCE_WEB, $captured->getSource());
 	}
 
 	public function testRecordFallsBackToNullActorWhenNoSession(): void {
@@ -122,7 +122,7 @@ class AuditEventServiceTest extends TestCase {
 		$this->mapper->expects($this->never())->method('insert');
 		$this->userSession->expects($this->never())->method('getUser');
 
-		$this->assertNull($service->recordAppointmentLifecycle(Verb::APPOINTMENT_CREATED, 1, Verb::SOURCE_APP));
+		$this->assertNull($service->recordAppointmentLifecycle(Verb::APPOINTMENT_CREATED, 1, Verb::SOURCE_CLIENT));
 	}
 
 	public function testRecordMarksRequestsCarryingTheMobileHeader(): void {
@@ -138,14 +138,15 @@ class AuditEventServiceTest extends TestCase {
 				return $event;
 			});
 
-		$this->service->record(Verb::RESPONSE_SUBMITTED, 1, 'bob', 'bob', [], Verb::SOURCE_APP);
+		$this->service->record(Verb::RESPONSE_SUBMITTED, 1, 'bob', 'bob', [], Verb::SOURCE_CLIENT);
 
 		$this->assertSame(Verb::SOURCE_MOBILE, $captured->getSource());
 	}
 
 	public function testRecordKeepsWebSourceWithoutTheHeader(): void {
 		// An app version predating the header sends none, exactly like the web
-		// UI — both stay SOURCE_APP, which is why no capability gate is needed.
+		// UI — both resolve to SOURCE_WEB, which is why no capability gate
+		// is needed.
 		$this->request->method('getHeader')->willReturn('');
 
 		$captured = null;
@@ -156,9 +157,9 @@ class AuditEventServiceTest extends TestCase {
 				return $event;
 			});
 
-		$this->service->record(Verb::RESPONSE_SUBMITTED, 1, 'bob', 'bob', [], Verb::SOURCE_APP);
+		$this->service->record(Verb::RESPONSE_SUBMITTED, 1, 'bob', 'bob', [], Verb::SOURCE_CLIENT);
 
-		$this->assertSame(Verb::SOURCE_APP, $captured->getSource());
+		$this->assertSame(Verb::SOURCE_WEB, $captured->getSource());
 	}
 
 	public function testRecordLeavesSpecificSourcesAlone(): void {

--- a/tests/unit/Service/AuditEventServiceTest.php
+++ b/tests/unit/Service/AuditEventServiceTest.php
@@ -10,6 +10,7 @@ use OCA\Attendance\Db\AuditEvent;
 use OCA\Attendance\Db\AuditEventMapper;
 use OCA\Attendance\Service\AuditEventService;
 use OCA\Attendance\Service\ConfigService;
+use OCP\IRequest;
 use OCP\IUser;
 use OCP\IUserSession;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -21,6 +22,7 @@ class AuditEventServiceTest extends TestCase {
 	private AuditEventDispatcher|MockObject $dispatcher;
 	private ConfigService|MockObject $configService;
 	private IUserSession|MockObject $userSession;
+	private IRequest|MockObject $request;
 	private LoggerInterface|MockObject $logger;
 	private AuditEventService $service;
 
@@ -29,6 +31,7 @@ class AuditEventServiceTest extends TestCase {
 		$this->dispatcher = $this->createMock(AuditEventDispatcher::class);
 		$this->configService = $this->createMock(ConfigService::class);
 		$this->userSession = $this->createMock(IUserSession::class);
+		$this->request = $this->createMock(IRequest::class);
 		$this->logger = $this->createMock(LoggerInterface::class);
 
 		$this->service = new AuditEventService(
@@ -36,6 +39,7 @@ class AuditEventServiceTest extends TestCase {
 			$this->dispatcher,
 			$this->configService,
 			$this->userSession,
+			$this->request,
 			$this->logger,
 		);
 
@@ -111,6 +115,7 @@ class AuditEventServiceTest extends TestCase {
 			$this->dispatcher,
 			$config,
 			$this->userSession,
+			$this->request,
 			$this->logger,
 		);
 
@@ -118,5 +123,59 @@ class AuditEventServiceTest extends TestCase {
 		$this->userSession->expects($this->never())->method('getUser');
 
 		$this->assertNull($service->recordAppointmentLifecycle(Verb::APPOINTMENT_CREATED, 1, Verb::SOURCE_APP));
+	}
+
+	public function testRecordMarksRequestsCarryingTheMobileHeader(): void {
+		$this->request->method('getHeader')
+			->with('X-Attendance-Client')
+			->willReturn('mobile');
+
+		$captured = null;
+		$this->mapper->expects($this->once())
+			->method('insert')
+			->willReturnCallback(function (AuditEvent $event) use (&$captured) {
+				$captured = $event;
+				return $event;
+			});
+
+		$this->service->record(Verb::RESPONSE_SUBMITTED, 1, 'bob', 'bob', [], Verb::SOURCE_APP);
+
+		$this->assertSame(Verb::SOURCE_MOBILE, $captured->getSource());
+	}
+
+	public function testRecordKeepsWebSourceWithoutTheHeader(): void {
+		// An app version predating the header sends none, exactly like the web
+		// UI — both stay SOURCE_APP, which is why no capability gate is needed.
+		$this->request->method('getHeader')->willReturn('');
+
+		$captured = null;
+		$this->mapper->expects($this->once())
+			->method('insert')
+			->willReturnCallback(function (AuditEvent $event) use (&$captured) {
+				$captured = $event;
+				return $event;
+			});
+
+		$this->service->record(Verb::RESPONSE_SUBMITTED, 1, 'bob', 'bob', [], Verb::SOURCE_APP);
+
+		$this->assertSame(Verb::SOURCE_APP, $captured->getSource());
+	}
+
+	public function testRecordLeavesSpecificSourcesAlone(): void {
+		// A self check-in done in the mobile app is still a self check-in: the
+		// header only refines the generic "came through the API" source.
+		$this->request->method('getHeader')->willReturn('mobile');
+
+		$captured = null;
+		$this->mapper->expects($this->once())
+			->method('insert')
+			->willReturnCallback(function (AuditEvent $event) use (&$captured) {
+				$captured = $event;
+				return $event;
+			});
+
+		$this->service->record(Verb::CHECKIN_RECORDED, 1, 'bob', 'bob', [], Verb::SOURCE_SELF_CHECKIN);
+
+		$this->assertSame(Verb::SOURCE_SELF_CHECKIN, $captured->getSource());
 	}
 }


### PR DESCRIPTION
Answers given on the phone showed up as **Web** in the activity timeline, because the mobile app and the web UI share one REST API and therefore one audit source. A user asked whether that was intended — it was not.

The app now identifies itself with `X-Attendance-Client: mobile`, and `AuditEventService::record()` resolves the generic client source into web or mobile. That is the single point every audit write already passes through, so responses, appointment lifecycle and edits are covered at once. Sources that are already specific — quick links, self check-ins, background jobs — pass through untouched.

**No capability gate.** App versions predating the header send none and record exactly as before, which is also what the web UI does. Rollout order does not matter in either direction.

Only the literal value `mobile` is accepted; anything else falls back to web, so a client cannot write arbitrary strings into the log.

### Also in here: `SOURCE_APP` renamed

It dated from before a mobile client existed, when "the app" meant this app in a browser, and the timeline had already been relabelling it "Web" at render time. With a real mobile source added, the code read as *"if the source is App, make it Mobile"*.

Callers now pass `SOURCE_CLIENT` — the sentinel for "some client did this through our API" — and resolution produces `SOURCE_WEB` or `SOURCE_MOBILE`. `SOURCE_WEB` keeps the stored string `app`, so there is no migration and every row already written still renders.

### Companion

Branch `feature/audit-source-mobile` in [attendance-flutter](https://github.com/luflow/attendance-flutter/pull/new/feature/audit-source-mobile) sends the header and learns the new label for its own timeline.

`./scripts/check.sh` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)