### PR TITLE
fix(talk): keep moderators and room state in sync after the initial open

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -11,7 +11,9 @@ use OCA\Attendance\BackgroundJob\TalkRoomSyncJob;
 use OCA\Attendance\Dashboard\Widget;
 use OCA\Attendance\Listener\CalendarObjectUpdateListener;
 use OCA\Attendance\Listener\ResponseChangeNotificationListener;
+use OCA\Attendance\Listener\TalkRoomDeletedListener;
 use OCA\Attendance\Listener\UserDeletedListener;
+use OCA\Talk\Events\RoomDeletedEvent;
 use OCP\AppFramework\App;
 use OCP\AppFramework\Bootstrap\IBootContext;
 use OCP\AppFramework\Bootstrap\IBootstrap;
@@ -29,6 +31,9 @@ class Application extends App implements IBootstrap {
 		$context->registerDashboardWidget(Widget::class);
 		$context->registerNotifierService(\OCA\Attendance\Notification\Notifier::class);
 		$context->registerEventListener(UserDeletedEvent::class, UserDeletedListener::class);
+		// Talk may not be installed; registering by class name is safe since it
+		// never autoloads the class, only Talk actually dispatching it would.
+		$context->registerEventListener(RoomDeletedEvent::class, TalkRoomDeletedListener::class);
 
 		$this->registerCalendarListeners($context);
 	}

--- a/lib/Db/AppointmentMapper.php
+++ b/lib/Db/AppointmentMapper.php
@@ -368,6 +368,23 @@ class AppointmentMapper extends QBMapper {
 	}
 
 	/**
+	 * Active appointments linked to this Talk room token. Normally at most
+	 * one — a list defends against the token somehow surviving on more than
+	 * one row rather than assuming it can't.
+	 *
+	 * @return list<Appointment>
+	 */
+	public function findByTalkRoomToken(string $token): array {
+		$qb = $this->db->getQueryBuilder();
+		$qb->select('*')
+			->from($this->getTableName())
+			->where($qb->expr()->eq('is_active', $qb->createNamedParameter(1, IQueryBuilder::PARAM_INT)))
+			->andWhere($qb->expr()->eq('talk_room_token', $qb->createNamedParameter($token)));
+
+		return $this->findEntities($qb);
+	}
+
+	/**
 	 * Active inquiries whose response_deadline or start_datetime is at or
 	 * before the given timestamp. Once an appointment has started, further
 	 * responses are pointless, so it qualifies regardless of any configured

--- a/lib/Listener/TalkRoomDeletedListener.php
+++ b/lib/Listener/TalkRoomDeletedListener.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\Attendance\Listener;
+
+use OCA\Attendance\Service\TalkRoomService;
+use OCA\Talk\Events\RoomDeletedEvent;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Forgets a linked Talk room the moment it is deleted directly in Talk,
+ * instead of waiting on TalkRoomSyncJob's hourly safety net to notice the
+ * token is stale.
+ *
+ * @template-implements IEventListener<Event>
+ */
+final class TalkRoomDeletedListener implements IEventListener {
+	public function __construct(
+		private TalkRoomService $talkRoomService,
+		private LoggerInterface $logger,
+	) {
+	}
+
+	#[\Override]
+	public function handle(Event $event): void {
+		if (!($event instanceof RoomDeletedEvent)) {
+			return;
+		}
+
+		try {
+			$this->talkRoomService->handleRoomDeleted($event->getRoom()->getToken());
+		} catch (\Throwable $e) {
+			$this->logger->error('Handling a deleted Talk room failed', [
+				'app' => 'attendance',
+				'exception' => $e,
+			]);
+		}
+	}
+}

--- a/lib/Service/AppointmentService.php
+++ b/lib/Service/AppointmentService.php
@@ -267,6 +267,12 @@ class AppointmentService {
 
 		$this->orgCalendarSyncService->syncAppointment($updated);
 		$this->talkRoomService->syncRoomDetails($updated);
+		if (in_array('organizers', $changedFields, true)) {
+			// A new organiser needs moderator rank and a place in the room; one
+			// who lost the role needs the rank back, or the room entirely if they
+			// no longer hold a place either.
+			$this->talkRoomService->syncParticipants($updated);
+		}
 
 		return $changedFields;
 	}

--- a/lib/Service/TalkRoomService.php
+++ b/lib/Service/TalkRoomService.php
@@ -48,6 +48,7 @@ class TalkRoomService {
 	private const ROOM_TYPE_GROUP = 2;          // Room::TYPE_GROUP
 	private const ACTOR_USERS = 'users';        // Attendee::ACTOR_USERS
 	private const PARTICIPANT_MODERATOR = 2;    // Participant::MODERATOR
+	private const PARTICIPANT_USER = 3;         // Participant::USER
 	private const REASON_REMOVED = 'remove';    // AAttendeeRemovedEvent::REASON_REMOVED
 	private const NAME_MAX_LENGTH = 255;        // conversations.name column
 	private const DESCRIPTION_MAX_LENGTH = 2000; // Room::DESCRIPTION_MAXIMUM_LENGTH
@@ -242,6 +243,20 @@ class TalkRoomService {
 	}
 
 	/**
+	 * React to a room being deleted directly in Talk — same end state as
+	 * deleteForAppointment(), reached without anyone clicking anything here.
+	 * Without this, the appointment would keep pointing at a gone token until
+	 * TalkRoomSyncJob's hourly sweep happens to notice.
+	 */
+	public function handleRoomDeleted(string $token): void {
+		foreach ($this->appointmentMapper->findByTalkRoomToken($token) as $appointment) {
+			$appointment->setTalkRoomToken(null);
+			$appointment->setCreateTalkRoom(false);
+			$this->appointmentMapper->update($appointment);
+		}
+	}
+
+	/**
 	 * Carry an edited name, date or description into the room. Talk drops a
 	 * write that changes nothing, so an edit that touched neither costs a read.
 	 *
@@ -412,23 +427,35 @@ class TalkRoomService {
 			$participantService->removeUser($room, $user, self::REASON_REMOVED);
 		}
 
-		$this->promoteOrganisers($room, $appointment, $participantService, $byActor);
+		$this->reconcileModerators($room, $appointment, $participantService, $byActor);
 	}
 
 	/**
 	 * Organisers hand out the final details, so they need to be able to rename
-	 * the room and pull someone in. The creator is already owner.
-	 */
-	/**
+	 * the room and pull someone in — promote them. Someone who stopped being an
+	 * organiser loses that again, back to a plain participant; if they no
+	 * longer hold a place either, the removal above has already taken them out
+	 * of the room entirely. The creator is already owner and outranks
+	 * moderator either way, so this never touches them.
+	 *
 	 * @param array<string, Participant> $byActor
 	 */
-	private function promoteOrganisers(Room $room, Appointment $appointment, ParticipantService $participantService, array $byActor): void {
-		foreach ($appointment->getOrganizersList() as $userId) {
+	private function reconcileModerators(Room $room, Appointment $appointment, ParticipantService $participantService, array $byActor): void {
+		$organizers = $appointment->getOrganizersList();
+
+		foreach ($organizers as $userId) {
 			$participant = $byActor[$userId] ?? null;
-			// Owner outranks moderator — do not demote the creator.
 			if ($participant !== null && $participant->getAttendee()->getParticipantType() > self::PARTICIPANT_MODERATOR) {
 				$participantService->updateParticipantType($room, $participant, self::PARTICIPANT_MODERATOR);
 			}
+		}
+
+		foreach ($byActor as $userId => $participant) {
+			if (in_array($userId, $organizers, true)
+				|| $participant->getAttendee()->getParticipantType() !== self::PARTICIPANT_MODERATOR) {
+				continue;
+			}
+			$participantService->updateParticipantType($room, $participant, self::PARTICIPANT_USER);
 		}
 	}
 

--- a/lib/Service/TalkRoomService.php
+++ b/lib/Service/TalkRoomService.php
@@ -235,9 +235,7 @@ class TalkRoomService {
 			return false;
 		}
 
-		$appointment->setTalkRoomToken(null);
-		$appointment->setCreateTalkRoom(false);
-		$this->appointmentMapper->update($appointment);
+		$this->forgetRoom($appointment);
 
 		return true;
 	}
@@ -250,10 +248,18 @@ class TalkRoomService {
 	 */
 	public function handleRoomDeleted(string $token): void {
 		foreach ($this->appointmentMapper->findByTalkRoomToken($token) as $appointment) {
-			$appointment->setTalkRoomToken(null);
-			$appointment->setCreateTalkRoom(false);
-			$this->appointmentMapper->update($appointment);
+			$this->forgetRoom($appointment);
 		}
+	}
+
+	/**
+	 * Clear the link to a room that is gone for good, and the opt-in with it —
+	 * left standing, the next answer or edit would open a fresh one.
+	 */
+	private function forgetRoom(Appointment $appointment): void {
+		$appointment->setTalkRoomToken(null);
+		$appointment->setCreateTalkRoom(false);
+		$this->appointmentMapper->update($appointment);
 	}
 
 	/**
@@ -443,19 +449,14 @@ class TalkRoomService {
 	private function reconcileModerators(Room $room, Appointment $appointment, ParticipantService $participantService, array $byActor): void {
 		$organizers = $appointment->getOrganizersList();
 
-		foreach ($organizers as $userId) {
-			$participant = $byActor[$userId] ?? null;
-			if ($participant !== null && $participant->getAttendee()->getParticipantType() > self::PARTICIPANT_MODERATOR) {
-				$participantService->updateParticipantType($room, $participant, self::PARTICIPANT_MODERATOR);
-			}
-		}
-
 		foreach ($byActor as $userId => $participant) {
-			if (in_array($userId, $organizers, true)
-				|| $participant->getAttendee()->getParticipantType() !== self::PARTICIPANT_MODERATOR) {
-				continue;
+			$type = $participant->getAttendee()->getParticipantType();
+			$isOrganizer = in_array($userId, $organizers, true);
+			if ($isOrganizer && $type > self::PARTICIPANT_MODERATOR) {
+				$participantService->updateParticipantType($room, $participant, self::PARTICIPANT_MODERATOR);
+			} elseif (!$isOrganizer && $type === self::PARTICIPANT_MODERATOR) {
+				$participantService->updateParticipantType($room, $participant, self::PARTICIPANT_USER);
 			}
-			$participantService->updateParticipantType($room, $participant, self::PARTICIPANT_USER);
 		}
 	}
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -893,6 +893,11 @@
       <code><![CDATA[handle]]></code>
     </PossiblyUnusedMethod>
   </file>
+  <file src="lib/Listener/TalkRoomDeletedListener.php">
+    <PossiblyUnusedMethod>
+      <code><![CDATA[__construct]]></code>
+    </PossiblyUnusedMethod>
+  </file>
   <file src="lib/Listener/UserDeletedListener.php">
     <ClassMustBeFinal>
       <code><![CDATA[UserDeletedListener]]></code>

--- a/tests/stubs/talk.php
+++ b/tests/stubs/talk.php
@@ -126,3 +126,16 @@ class ParticipantService {
 	public function updateParticipantType(Room $room, Participant $participant, int $participantType): void {
 	}
 }
+
+namespace OCA\Talk\Events;
+
+use OCA\Talk\Room;
+use OCP\EventDispatcher\Event;
+
+abstract class ARoomEvent extends Event {
+	public function getRoom(): Room {
+	}
+}
+
+class RoomDeletedEvent extends ARoomEvent {
+}

--- a/tests/unit/Listener/TalkRoomDeletedListenerTest.php
+++ b/tests/unit/Listener/TalkRoomDeletedListenerTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\Attendance\Tests\Unit\Listener;
+
+use OCA\Attendance\Listener\TalkRoomDeletedListener;
+use OCA\Attendance\Service\TalkRoomService;
+use OCA\Talk\Events\RoomDeletedEvent;
+use OCA\Talk\Room;
+use OCP\User\Events\UserDeletedEvent;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+class TalkRoomDeletedListenerTest extends TestCase {
+	private TalkRoomService|MockObject $talkRoomService;
+	private LoggerInterface|MockObject $logger;
+	private TalkRoomDeletedListener $listener;
+
+	protected function setUp(): void {
+		$this->talkRoomService = $this->createMock(TalkRoomService::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
+		$this->listener = new TalkRoomDeletedListener($this->talkRoomService, $this->logger);
+	}
+
+	private function roomDeletedEvent(string $token): RoomDeletedEvent {
+		$room = $this->createMock(Room::class);
+		$room->method('getToken')->willReturn($token);
+
+		$event = $this->createMock(RoomDeletedEvent::class);
+		$event->method('getRoom')->willReturn($room);
+
+		return $event;
+	}
+
+	public function testForwardsTheTokenToTheService(): void {
+		$this->talkRoomService->expects($this->once())
+			->method('handleRoomDeleted')
+			->with('tok123');
+
+		$this->listener->handle($this->roomDeletedEvent('tok123'));
+	}
+
+	public function testIgnoresEventsOfAnyOtherType(): void {
+		$this->talkRoomService->expects($this->never())->method('handleRoomDeleted');
+
+		$this->listener->handle($this->createMock(UserDeletedEvent::class));
+	}
+
+	public function testLogsRatherThanThrowsWhenTheServiceFails(): void {
+		$this->talkRoomService->method('handleRoomDeleted')
+			->willThrowException(new \RuntimeException('boom'));
+
+		$this->logger->expects($this->once())->method('error');
+
+		$this->listener->handle($this->roomDeletedEvent('tok123'));
+	}
+}

--- a/tests/unit/Service/AppointmentServiceTest.php
+++ b/tests/unit/Service/AppointmentServiceTest.php
@@ -1501,6 +1501,37 @@ class AppointmentServiceTest extends TestCase {
 		$this->assertEquals(['alice', 'bob'], $result->getOrganizersList());
 	}
 
+	/**
+	 * A new organiser needs moderator rank in the Talk room and a former one
+	 * needs it taken away again — neither happens unless the participant sync
+	 * actually runs when the organizer list changes.
+	 */
+	public function testUpdateAppointmentSyncsTalkParticipantsWhenOrganizersChange(): void {
+		$this->expectKnownUsers(['alice', 'bob']);
+		$appointment = $this->setUpOrganizerUpdate(['alice'], false);
+
+		$this->talkRoomService->expects($this->once())
+			->method('syncParticipants')
+			->with($appointment);
+
+		$this->service->updateAppointment(
+			3, 'Meeting', '', '2026-01-01T10:00:00Z', '2026-01-01T11:00:00Z',
+			'alice', [], [], [], null, ['alice', 'bob'],
+		);
+	}
+
+	public function testUpdateAppointmentDoesNotSyncTalkParticipantsWhenOrganizersAreUnchanged(): void {
+		$this->expectKnownUsers(['alice']);
+		$this->setUpOrganizerUpdate(['alice'], false);
+
+		$this->talkRoomService->expects($this->never())->method('syncParticipants');
+
+		$this->service->updateAppointment(
+			3, 'New name', '', '2026-01-01T10:00:00Z', '2026-01-01T11:00:00Z',
+			'alice', [], [], [], null, ['alice'],
+		);
+	}
+
 	public function testOrganizerCanRemoveOnlyThemselves(): void {
 		$this->expectKnownUsers(['alice', 'bob']);
 		$this->setUpOrganizerUpdate(['alice', 'bob'], false);

--- a/tests/unit/Service/TalkRoomServiceTest.php
+++ b/tests/unit/Service/TalkRoomServiceTest.php
@@ -634,4 +634,80 @@ class TalkRoomServiceTest extends TestCase {
 
 		$this->service->syncParticipants($this->appointment(['olivia', 'oscar'], 'tok123'));
 	}
+
+	/**
+	 * A co-organiser added after the room already exists is exactly the gap
+	 * that made this bug worth writing down: promotion must not depend on the
+	 * room having just been created.
+	 */
+	public function testANewlyAddedOrganiserGetsPromotedOnTheNextSync(): void {
+		$this->configService->method('isBookingEnabled')->willReturn(true);
+		$this->responseMapper->method('findByAppointment')->willReturn([
+			$this->response('oscar', 'yes', 'booked'),
+		]);
+
+		$room = $this->room();
+		$this->talkManager->method('getRoomByToken')->willReturn($room);
+		// olivia is already moderator; oscar holds a place as a plain
+		// participant and has just been made a co-organiser.
+		$this->participantService->method('getParticipantsForRoom')->willReturn([
+			...$this->participants(['olivia'], 2),
+			...$this->participants(['oscar'], 3),
+		]);
+
+		$this->participantService->expects($this->once())
+			->method('updateParticipantType')
+			->with($room, $this->callback(fn (Participant $p) => $p->getAttendee()->getActorId() === 'oscar'), 2);
+
+		$this->service->syncParticipants($this->appointment(['olivia', 'oscar'], 'tok123'));
+	}
+
+	/**
+	 * Someone who is no longer an organiser but still holds a place loses the
+	 * moderator rank again — demoted to a plain participant rather than left a
+	 * moderator forever.
+	 */
+	public function testAFormerOrganiserIsDemotedBackToAParticipant(): void {
+		$this->configService->method('isBookingEnabled')->willReturn(true);
+		$this->responseMapper->method('findByAppointment')->willReturn([
+			$this->response('oscar', 'yes', 'booked'),
+		]);
+
+		$room = $this->room();
+		$this->talkManager->method('getRoomByToken')->willReturn($room);
+		// oscar is still a moderator from when he was an organiser, but the
+		// current organizer list (just 'olivia') no longer includes him.
+		$this->participantService->method('getParticipantsForRoom')
+			->willReturn($this->participants(['olivia', 'oscar'], 2));
+
+		$this->participantService->expects($this->once())
+			->method('updateParticipantType')
+			->with($room, $this->callback(fn (Participant $p) => $p->getAttendee()->getActorId() === 'oscar'), 3);
+
+		$this->service->syncParticipants($this->appointment(['olivia'], 'tok123'));
+	}
+
+	/**
+	 * A room deleted directly in Talk is discovered without waiting on
+	 * TalkRoomSyncJob's hourly sweep — the listener calls this the moment
+	 * Talk fires its RoomDeletedEvent.
+	 */
+	public function testHandleRoomDeletedForgetsTheLinkedRoom(): void {
+		$appointment = $this->appointment(token: 'tok123');
+		$appointment->setCreateTalkRoom(true);
+		$this->appointmentMapper->method('findByTalkRoomToken')->with('tok123')->willReturn([$appointment]);
+		$this->appointmentMapper->expects($this->once())->method('update')->with($appointment);
+
+		$this->service->handleRoomDeleted('tok123');
+
+		$this->assertNull($appointment->getTalkRoomToken());
+		$this->assertFalse($appointment->getCreateTalkRoom());
+	}
+
+	public function testHandleRoomDeletedIsANoOpForAnUnknownToken(): void {
+		$this->appointmentMapper->method('findByTalkRoomToken')->willReturn([]);
+		$this->appointmentMapper->expects($this->never())->method('update');
+
+		$this->service->handleRoomDeleted('unknown');
+	}
 }


### PR DESCRIPTION
## Summary

Two gaps in the Talk room integration:

- **Organizer changes weren't reflected in the Talk room.** `AppointmentService::commitAppointmentChange()` (used by both single and series appointment edits) only pushed name/description changes into the linked Talk room, never the participant reconcile. A newly added organizer never got invited or promoted to moderator, and a former organizer kept moderator rank forever. `syncParticipants()` now also runs whenever the organizer list changes, and `TalkRoomService`'s reconcile now demotes anyone who is no longer an organizer back to a plain participant (or removes them entirely if they no longer hold a place, which already worked).
- **A room deleted directly in Talk went unnoticed.** There was already an hourly safety-net cron (`TalkRoomSyncJob`) that eventually detects and clears a stale token, but nothing reacted immediately. Added `TalkRoomDeletedListener` on Talk's `RoomDeletedEvent` (registered defensively — Talk's classes are only autoloaded if Talk itself dispatches the event) so the linked appointment forgets the room as soon as it's deleted, instead of waiting up to an hour.

A follow-up commit dedupes the room-unlink logic shared by `deleteForAppointment()`/`handleRoomDeleted()` into one helper, and collapses the moderator promote/demote logic into a single pass.

## Test plan

- [x] `composer test:unit` (376 tests, including new coverage for organizer promotion/demotion on edit, and the new listener)
- [x] `composer psalm` — no errors
- [x] `composer cs:check` — clean
- [ ] `./scripts/check.sh` in full (JS/CSS/vite gates not run — this change is PHP-only and `node_modules` wasn't available in the review environment)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AuK3iM5eE38Yk29matvjFU)_