### PR TITLE
ci: validate info.xml, test the PHP span, check the release inputs up front

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,40 @@ jobs:
         uses: actions/checkout@v5
         with:
           path: ${{ env.APP_NAME }}
+      # Everything the store upload needs, checked before minutes go into the
+      # build: tag and info.xml agree, the release notes exist, and the signing
+      # key is a usable PEM. occ/the push action would otherwise produce an
+      # unusable signature and the failure surfaces far from its cause.
+      - name: Pre-flight checks
+        working-directory: ${{ env.APP_NAME }}
+        env:
+          APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+        run: |
+          set -eu
+          version="${{ needs.check_version.outputs.version }}"
+          version="${version#v}"
+          failed=0
+
+          xml_version=$(grep -oE '<version>[^<]+' appinfo/info.xml | head -1 | cut -d'>' -f2)
+          if [ "$xml_version" != "$version" ]; then
+            echo "::error::Tag $version does not match info.xml version $xml_version"
+            failed=1
+          fi
+
+          if ! grep -qE "^## $version\b" CHANGELOG.md; then
+            echo "::error::CHANGELOG.md has no '## $version' section — the app store release notes come from it"
+            failed=1
+          fi
+
+          if [ -z "$APP_PRIVATE_KEY" ]; then
+            echo "::error::APP_PRIVATE_KEY secret is empty"
+            failed=1
+          elif ! printf '%s\n' "$APP_PRIVATE_KEY" | openssl pkey -noout 2>/dev/null; then
+            echo "::error::APP_PRIVATE_KEY is not a readable PEM key — are the -----BEGIN/END----- lines part of the secret?"
+            failed=1
+          fi
+
+          exit "$failed"
       - name: Run build
         run: cd ${{ env.APP_NAME }} && make appstore
       - name: Upload app tarball to release

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,22 @@ on:
   workflow_call:
 
 jobs:
+  appinfo_validation:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Install xmllint
+        run: sudo apt-get update -qq && sudo apt-get install -y -qq libxml2-utils
+
+      # The app store validates against this schema on upload — failing here
+      # beats failing at release time.
+      - name: Validate info.xml against the app store schema
+        run: |
+          curl -fsSL https://apps.nextcloud.com/schema/apps/info.xsd -o /tmp/info.xsd
+          xmllint --noout --schema /tmp/info.xsd appinfo/info.xml
+
   e2e_tests:
     runs-on: ubuntu-latest
     steps:
@@ -114,6 +130,12 @@ jobs:
 
   php_tests:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # The span info.xml admits: min-version 8.1 up to the newest PHP the
+        # supported Nextcloud releases run on.
+        php-version: ['8.1', '8.4']
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -121,7 +143,7 @@ jobs:
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: ${{ matrix.php-version }}
           coverage: none
 
       - name: Install composer dependencies


### PR DESCRIPTION
Ports the three CI safeguards the vereinsbuchhaltung app already has:

- **info.xml schema validation** on every PR — the app store validates against the same XSD on upload, so a schema violation now fails the PR instead of the release.
- **PHP version matrix (8.1 / 8.4)** for the PHPUnit job — `info.xml` only declares `min-version="8.1"`, so supported servers run anything up to 8.4; the suite now covers both ends of that span.
- **Release pre-flight checks** before the build: the tag matches the `info.xml` version, `CHANGELOG.md` has the matching section (the store release notes come from it), and `APP_PRIVATE_KEY` is a readable PEM. The appstore push action signs with whatever key material it gets and reports success either way — a truncated secret currently only surfaces as a store-side rejection, far from its cause.

No workflow is replaced; the existing build and publish steps are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)