### PR TITLE
fix(summary): keep grouping intact on appointments with restricted access

### DIFF
--- a/lib/Service/ResponseSummaryService.php
+++ b/lib/Service/ResponseSummaryService.php
@@ -218,18 +218,16 @@ class ResponseSummaryService {
 	/**
 	 * Check if a group may appear as a section in the summary (using cache).
 	 *
-	 * Visibility restrictions narrow the audience, not the grouping: a
-	 * configured whitelist alone decides the sections, so restricting access
-	 * to a status group keeps answers grouped by instrument (issue #199).
-	 * Only without a whitelist does a group-restricted appointment group by
-	 * its restriction groups; empty sections are filtered out later.
+	 * A configured whitelist alone decides the sections — visibility
+	 * restrictions only narrow the audience (issue #199). Without a whitelist,
+	 * a group-restricted appointment groups by its restriction groups.
 	 */
 	private function isGroupAllowedCached(string $groupId, array $cache): bool {
 		if (!$cache['allowAllGroups']) {
 			return in_array(strtolower($groupId), $cache['whitelistedGroupsLower']);
 		}
 
-		if ($cache['appointmentHasRestrictions'] && !empty($cache['appointmentVisibleGroupsLower'])) {
+		if (!empty($cache['appointmentVisibleGroupsLower'])) {
 			return in_array(strtolower($groupId), $cache['appointmentVisibleGroupsLower']);
 		}
 
@@ -513,9 +511,12 @@ class ResponseSummaryService {
 			$maybeUsers = [];
 
 			foreach ($teamMemberIds as $userId) {
-				// Not an allUsers lookup: on an open appointment with a group
-				// whitelist, team members outside those groups are absent there.
-				if (!$this->visibilityService->isUserTargetAttendee($appointment, $userId)) {
+				// Restricted: allUsers is the whole audience. Open with a group
+				// whitelist: team members outside those groups are absent there.
+				$isAttendee = $cache['appointmentHasRestrictions']
+					? isset($cache['allUsers'][$userId])
+					: $this->visibilityService->isUserTargetAttendee($appointment, $userId);
+				if (!$isAttendee) {
 					continue;
 				}
 

--- a/lib/Service/ResponseSummaryService.php
+++ b/lib/Service/ResponseSummaryService.php
@@ -144,7 +144,6 @@ class ResponseSummaryService {
 		$visibilitySettings = $this->visibilityService->getVisibilitySettings($appointment);
 		$appointmentHasRestrictions = $this->visibilityService->hasRestrictedVisibility($appointment);
 		$appointmentVisibleGroupsLower = array_map('strtolower', $visibilitySettings['groups']);
-		$appointmentVisibleTeams = $visibilitySettings['teams'];
 
 		// Pre-fetch all users from responses
 		$userIds = array_unique(array_map(fn ($r) => $r->getUserId(), $responses));
@@ -213,22 +212,23 @@ class ResponseSummaryService {
 			// Appointment-specific visibility restrictions
 			'appointmentHasRestrictions' => $appointmentHasRestrictions,
 			'appointmentVisibleGroupsLower' => $appointmentVisibleGroupsLower,
-			'appointmentVisibleTeams' => $appointmentVisibleTeams,
 		];
 	}
 
 	/**
-	 * Check if a group is allowed (using cache).
-	 * Checks both admin whitelist and appointment-specific restrictions.
+	 * Check if a group may appear as a section in the summary (using cache).
+	 *
+	 * Visibility restrictions narrow the audience, not the grouping: a
+	 * configured whitelist alone decides the sections, so restricting access
+	 * to a status group keeps answers grouped by instrument (issue #199).
+	 * Only without a whitelist does a group-restricted appointment group by
+	 * its restriction groups; empty sections are filtered out later.
 	 */
 	private function isGroupAllowedCached(string $groupId, array $cache): bool {
-		// First check: group must be in whitelist (or all groups allowed)
-		$inWhitelist = $cache['allowAllGroups'] || in_array(strtolower($groupId), $cache['whitelistedGroupsLower']);
-		if (!$inWhitelist) {
-			return false;
+		if (!$cache['allowAllGroups']) {
+			return in_array(strtolower($groupId), $cache['whitelistedGroupsLower']);
 		}
 
-		// Second check: if appointment has restrictions, group must be in visible groups
 		if ($cache['appointmentHasRestrictions'] && !empty($cache['appointmentVisibleGroupsLower'])) {
 			return in_array(strtolower($groupId), $cache['appointmentVisibleGroupsLower']);
 		}
@@ -249,24 +249,6 @@ class ResponseSummaryService {
 			return false;
 		}
 		return $this->isGroupAllowedCached($groupId, $cache);
-	}
-
-	/**
-	 * Check if a team is allowed for the appointment (using cache).
-	 * Checks both admin whitelist and appointment-specific restrictions.
-	 */
-	private function isTeamAllowedCached(string $teamId, array $cache): bool {
-		// First check: team must be in whitelist
-		if (!in_array($teamId, $cache['whitelistedTeams'])) {
-			return false;
-		}
-
-		// Second check: if appointment has restrictions, team must be in visible teams
-		if ($cache['appointmentHasRestrictions'] && !empty($cache['appointmentVisibleTeams'])) {
-			return in_array($teamId, $cache['appointmentVisibleTeams']);
-		}
-
-		return true;
 	}
 
 	/**
@@ -340,12 +322,9 @@ class ResponseSummaryService {
 			}
 
 			// Check teams (user can be in both groups AND teams - duplicates allowed)
-			foreach ($cache['whitelistedTeams'] as $teamId) {
-				// Skip teams not allowed for this appointment
-				if (!$this->isTeamAllowedCached($teamId, $cache)) {
-					continue;
-				}
-
+			/** @var list<string> $whitelistedTeams */
+			$whitelistedTeams = $cache['whitelistedTeams'];
+			foreach ($whitelistedTeams as $teamId) {
 				$teamMemberIds = $cache['teamMembers'][$teamId] ?? [];
 				if (in_array($userId, $teamMemberIds)) {
 					$userInWhitelistedTeam = true;
@@ -510,12 +489,9 @@ class ResponseSummaryService {
 		array $respondedUserIds,
 		array $cache,
 	): void {
-		foreach ($cache['whitelistedTeams'] as $teamId) {
-			// Skip teams not allowed for this appointment
-			if (!$this->isTeamAllowedCached($teamId, $cache)) {
-				continue;
-			}
-
+		/** @var list<string> $whitelistedTeams */
+		$whitelistedTeams = $cache['whitelistedTeams'];
+		foreach ($whitelistedTeams as $teamId) {
 			$teamInfo = $cache['teamInfo'][$teamId] ?? null;
 
 			if (!isset($summary['by_team'][$teamId])) {
@@ -583,6 +559,8 @@ class ResponseSummaryService {
 		$othersNonResponding = [];
 		$othersMaybe = [];
 		$skipUnaffiliated = !$cache['appointmentHasRestrictions'];
+		/** @var list<string> $whitelistedTeams */
+		$whitelistedTeams = $cache['whitelistedTeams'];
 
 		/** @var \OCP\IUser $user */
 		foreach ($cache['allUsers'] as $user) {
@@ -611,10 +589,7 @@ class ResponseSummaryService {
 
 			$hasRelevantTeam = false;
 			if (!$hasVisibleGroup) {
-				foreach ($cache['whitelistedTeams'] as $teamId) {
-					if (!$this->isTeamAllowedCached($teamId, $cache)) {
-						continue;
-					}
+				foreach ($whitelistedTeams as $teamId) {
 					$teamMemberIds = $cache['teamMembers'][$teamId] ?? [];
 					if (in_array($userId, $teamMemberIds)) {
 						$hasRelevantTeam = true;

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1992,12 +1992,10 @@
     </MissingParamType>
     <MixedArgument>
       <code><![CDATA[$cache['appointmentVisibleGroupsLower']]]></code>
-      <code><![CDATA[$cache['appointmentVisibleTeams']]]></code>
       <code><![CDATA[$cache['groupUsers']]]></code>
       <code><![CDATA[$cache['whitelistedGroups']]]></code>
       <code><![CDATA[$cache['whitelistedGroupsLower']]]></code>
       <code><![CDATA[$cache['whitelistedGroupsLower']]]></code>
-      <code><![CDATA[$cache['whitelistedTeams']]]></code>
       <code><![CDATA[$cache['whitelistedTeams']]]></code>
       <code><![CDATA[$gid]]></code>
       <code><![CDATA[$groupId]]></code>
@@ -2007,9 +2005,6 @@
       <code><![CDATA[$nameB]]></code>
       <code><![CDATA[$summary['by_group']]]></code>
       <code><![CDATA[$summary['by_team']]]></code>
-      <code><![CDATA[$teamId]]></code>
-      <code><![CDATA[$teamId]]></code>
-      <code><![CDATA[$teamId]]></code>
       <code><![CDATA[$teamMemberIds]]></code>
       <code><![CDATA[$teamMemberIds]]></code>
       <code><![CDATA[$user->getUID()]]></code>
@@ -2095,9 +2090,6 @@
       <code><![CDATA[$summary[$responseValue]]]></code>
       <code><![CDATA[$summary['by_group'][$groupId][$responseValue]]]></code>
       <code><![CDATA[$summary['others'][$responseValue]]]></code>
-      <code><![CDATA[$teamId]]></code>
-      <code><![CDATA[$teamId]]></code>
-      <code><![CDATA[$teamId]]></code>
       <code><![CDATA[$teamId]]></code>
       <code><![CDATA[$teamInfo]]></code>
       <code><![CDATA[$teamInfo]]></code>

--- a/tests/unit/Service/ResponseSummaryServiceTest.php
+++ b/tests/unit/Service/ResponseSummaryServiceTest.php
@@ -428,4 +428,192 @@ class ResponseSummaryServiceTest extends TestCase {
 		$this->assertStringNotContainsString('bob', $encoded);
 		$this->assertStringNotContainsString('Secret', $encoded);
 	}
+
+	/**
+	 * Regression for issue #199: restricting an appointment to a group (here a
+	 * status group like 'active') must not disable grouping — the audience
+	 * still renders under the whitelisted groups (instruments) they belong
+	 * to, not under Others.
+	 */
+	public function testGetResponseSummaryKeepsWhitelistedGroupingWhenVisibilityRestricted(): void {
+		$appointmentId = 8;
+		$appointment = new Appointment();
+		$appointment->setId($appointmentId);
+		$appointment->setVisibleUsers('[]');
+		$appointment->setVisibleGroups(json_encode(['active']));
+		$appointment->setVisibleTeams('[]');
+
+		$response = new AttendanceResponse();
+		$response->setId(1);
+		$response->setAppointmentId($appointmentId);
+		$response->setUserId('alice');
+		$response->setResponse('yes');
+
+		$this->appointmentMapper->method('find')->with($appointmentId)->willReturn($appointment);
+		$this->responseMapper->method('findByAppointment')->with($appointmentId)->willReturn([$response]);
+
+		// Grouping is configured by instrument, access is restricted by status.
+		$this->configService->method('getWhitelistedGroups')->willReturn(['sopranos', 'altos']);
+		$this->configService->method('getWhitelistedTeams')->willReturn([]);
+
+		$this->visibilityService->method('getVisibilitySettings')
+			->willReturn(['users' => [], 'groups' => ['active'], 'teams' => []]);
+		$this->visibilityService->method('hasRestrictedVisibility')->willReturn(true);
+		$this->visibilityService->method('isUserTargetAttendee')->willReturn(true);
+
+		$alice = $this->createMock(IUser::class);
+		$alice->method('getUID')->willReturn('alice');
+		$alice->method('getDisplayName')->willReturn('Alice');
+		$bob = $this->createMock(IUser::class);
+		$bob->method('getUID')->willReturn('bob');
+		$bob->method('getDisplayName')->willReturn('Bob');
+
+		$activeGroup = $this->createMock(IGroup::class);
+		$activeGroup->method('getGID')->willReturn('active');
+		$sopranosGroup = $this->createMock(IGroup::class);
+		$sopranosGroup->method('getGID')->willReturn('sopranos');
+		$sopranosGroup->method('getUsers')->willReturn([$alice]);
+		$altosGroup = $this->createMock(IGroup::class);
+		$altosGroup->method('getGID')->willReturn('altos');
+		$altosGroup->method('getUsers')->willReturn([$bob]);
+
+		$this->groupManager->method('get')->willReturnMap([
+			['sopranos', $sopranosGroup],
+			['altos', $altosGroup],
+		]);
+		$this->groupManager->method('getUserGroups')->willReturnCallback(
+			fn (IUser $user) => $user->getUID() === 'alice'
+				? [$activeGroup, $sopranosGroup]
+				: [$activeGroup, $altosGroup]
+		);
+		$this->userManager->method('get')->willReturnMap([['alice', $alice]]);
+
+		$this->visibilityService->method('getTargetAttendees')
+			->willReturn(['alice' => $alice, 'bob' => $bob]);
+
+		$summary = $this->service->getResponseSummary($appointmentId);
+
+		// Both instrument sections render; the restriction group gets none.
+		$this->assertSame(['sopranos', 'altos'], array_keys($summary['by_group']));
+		$this->assertSame(1, $summary['by_group']['sopranos']['yes']);
+		$this->assertSame('Alice', $summary['by_group']['sopranos']['responses'][0]['userName']);
+		$this->assertSame(1, $summary['by_group']['altos']['no_response']);
+		$this->assertSame('bob', $summary['by_group']['altos']['non_responding_users'][0]['userId']);
+		// Nobody is unaffiliated, so Others stays empty.
+		$this->assertSame(0, $summary['others']['yes']);
+		$this->assertSame([], $summary['others']['responses']);
+		$this->assertSame([], $summary['others']['non_responding_users']);
+		$this->assertSame(1, $summary['yes']);
+		$this->assertSame(1, $summary['no_response']);
+	}
+
+	/**
+	 * Team analog of issue #199: restricting an appointment to one team must
+	 * not hide the whitelisted teams' sections from the summary.
+	 */
+	public function testGetResponseSummaryKeepsWhitelistedTeamSectionsWhenVisibilityRestricted(): void {
+		$appointmentId = 9;
+		$appointment = new Appointment();
+		$appointment->setId($appointmentId);
+		$appointment->setVisibleUsers('[]');
+		$appointment->setVisibleGroups('[]');
+		$appointment->setVisibleTeams(json_encode(['team-a']));
+
+		$response = new AttendanceResponse();
+		$response->setId(1);
+		$response->setAppointmentId($appointmentId);
+		$response->setUserId('carol');
+		$response->setResponse('yes');
+
+		$this->appointmentMapper->method('find')->with($appointmentId)->willReturn($appointment);
+		$this->responseMapper->method('findByAppointment')->with($appointmentId)->willReturn([$response]);
+
+		$this->configService->method('getWhitelistedGroups')->willReturn([]);
+		$this->configService->method('getWhitelistedTeams')->willReturn(['team-b']);
+
+		$this->visibilityService->method('getVisibilitySettings')
+			->willReturn(['users' => [], 'groups' => [], 'teams' => ['team-a']]);
+		$this->visibilityService->method('hasRestrictedVisibility')->willReturn(true);
+		$this->visibilityService->method('isUserTargetAttendee')->willReturn(true);
+		$this->visibilityService->method('getTeamMembers')->with('team-b')->willReturn(['carol']);
+		$this->visibilityService->method('getTeamInfo')->with('team-b')
+			->willReturn(['id' => 'team-b', 'label' => 'Team B', 'type' => 'team']);
+
+		$carol = $this->createMock(IUser::class);
+		$carol->method('getUID')->willReturn('carol');
+		$carol->method('getDisplayName')->willReturn('Carol');
+
+		$this->userManager->method('get')->willReturnMap([['carol', $carol]]);
+		$this->groupManager->method('getUserGroups')->willReturn([]);
+		$this->groupManager->method('search')->with('')->willReturn([]);
+
+		$this->visibilityService->method('getTargetAttendees')
+			->willReturn(['carol' => $carol]);
+
+		$summary = $this->service->getResponseSummary($appointmentId);
+
+		$this->assertSame(['team-b'], array_keys($summary['by_team']));
+		$this->assertSame('Team B', $summary['by_team']['team-b']['displayName']);
+		$this->assertSame(1, $summary['by_team']['team-b']['yes']);
+		$this->assertSame('Carol', $summary['by_team']['team-b']['responses'][0]['userName']);
+		$this->assertSame(0, $summary['others']['yes']);
+		$this->assertSame([], $summary['others']['responses']);
+		$this->assertSame(1, $summary['yes']);
+	}
+
+	/**
+	 * Without a whitelist there is no configured grouping, so a restricted
+	 * appointment keeps grouping by its restriction groups — the audience's
+	 * other group memberships must not fan out into sections.
+	 */
+	public function testGetResponseSummaryWithoutWhitelistKeepsGroupingByRestrictionGroups(): void {
+		$appointmentId = 10;
+		$appointment = new Appointment();
+		$appointment->setId($appointmentId);
+		$appointment->setVisibleUsers('[]');
+		$appointment->setVisibleGroups(json_encode(['board']));
+		$appointment->setVisibleTeams('[]');
+
+		$response = new AttendanceResponse();
+		$response->setId(1);
+		$response->setAppointmentId($appointmentId);
+		$response->setUserId('dave');
+		$response->setResponse('yes');
+
+		$this->appointmentMapper->method('find')->with($appointmentId)->willReturn($appointment);
+		$this->responseMapper->method('findByAppointment')->with($appointmentId)->willReturn([$response]);
+
+		$this->configService->method('getWhitelistedGroups')->willReturn([]);
+		$this->configService->method('getWhitelistedTeams')->willReturn([]);
+
+		$this->visibilityService->method('getVisibilitySettings')
+			->willReturn(['users' => [], 'groups' => ['board'], 'teams' => []]);
+		$this->visibilityService->method('hasRestrictedVisibility')->willReturn(true);
+		$this->visibilityService->method('isUserTargetAttendee')->willReturn(true);
+
+		$dave = $this->createMock(IUser::class);
+		$dave->method('getUID')->willReturn('dave');
+		$dave->method('getDisplayName')->willReturn('Dave');
+
+		$boardGroup = $this->createMock(IGroup::class);
+		$boardGroup->method('getGID')->willReturn('board');
+		$boardGroup->method('getUsers')->willReturn([$dave]);
+		$staffGroup = $this->createMock(IGroup::class);
+		$staffGroup->method('getGID')->willReturn('staff');
+		$staffGroup->method('getUsers')->willReturn([$dave]);
+
+		$this->groupManager->method('search')->with('')->willReturn([$boardGroup, $staffGroup]);
+		$this->groupManager->method('getUserGroups')->willReturn([$boardGroup, $staffGroup]);
+		$this->userManager->method('get')->willReturnMap([['dave', $dave]]);
+
+		$this->visibilityService->method('getTargetAttendees')
+			->willReturn(['dave' => $dave]);
+
+		$summary = $this->service->getResponseSummary($appointmentId);
+
+		$this->assertSame(['board'], array_keys($summary['by_group']));
+		$this->assertSame(1, $summary['by_group']['board']['yes']);
+		$this->assertSame(0, $summary['others']['yes']);
+		$this->assertSame([], $summary['others']['responses']);
+	}
 }


### PR DESCRIPTION
Fixes #199

## Problem

Restricting an appointment's access (e.g. to a status group like "Active") made the answer overview stop grouping by the configured summary groups — every answer collapsed into "Others".

## Root cause

`ResponseSummaryService::isGroupAllowedCached()` / `isTeamAllowedCached()` required a whitelisted section to *also* be one of the appointment's visibility-restriction groups/teams. That conflates two orthogonal settings: visibility restrictions define **who** may see and respond, while the admin whitelist defines **how** answers are displayed. "Restrict by status, group by instrument" — the exact use case in #199 — was therefore impossible.

## Fix

- With a whitelist configured, it alone decides the summary sections; restrictions keep narrowing only the audience (`getTargetAttendees()` / `isUserTargetAttendee()` are untouched).
- Without a whitelist, a group-restricted appointment still groups by its restriction groups (existing behavior, now pinned by a test).
- Sections nobody in the audience belongs to are still dropped by `filterEmptyGroups()`, so restricted appointments don't render irrelevant sections.
- The team check became always-true under this rule (`by_team` only ever iterates whitelisted teams), so `isTeamAllowedCached()` is removed; the whitelisted-teams loops are typed `list<string>` instead of relying on that call for psalm's string refinement. The psalm baseline loses the 8 entries whose code no longer exists.

This also makes the summary consistent with the check-in view and the export, which already group purely by the whitelist.

## Compatibility

The response shape is unchanged (same keys, corrected contents), so older mobile clients are unaffected and no new capability flag is needed.

## Tests

- Regression test for the #199 scenario (restrict by status group, group by instruments) — fails on the previous code.
- Team analog (restrict to one team, whitelist another) — fails on the previous code.
- A test pinning the preserved no-whitelist behavior.
- `./scripts/check.sh` fully green (eslint, stylelint, php-cs-fixer, psalm, 379 unit tests, vite build, l10n checks, OpenAPI spec check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019FFNeKvAeAX9nK3SeV3EE2

---
_Generated by [Claude Code](https://claude.ai/code/session_019FFNeKvAeAX9nK3SeV3EE2)_