### PR TITLE
Derive the e2e container name instead of hardcoding it

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lint": "eslint src",
     "stylelint": "stylelint \"src/**/*.{vue,scss,css}\"",
     "test:e2e:server": "node tests/e2e/setup/server.js",
-    "test:e2e:server-cleanup": "docker rm -f nextcloud-e2e-test-server_attendance 2>/dev/null || true && docker volume rm -f apps_writable 2>/dev/null || true",
+    "test:e2e:server-cleanup": "node tests/e2e/setup/server-cleanup.js",
     "test:e2e": "npm run test:e2e:server && npm run test:e2e:run",
     "test:e2e:run": "playwright test",
     "test:e2e:ui": "playwright test --ui",

--- a/tests/e2e/15-close-inquiry-permissions.spec.js
+++ b/tests/e2e/15-close-inquiry-permissions.spec.js
@@ -11,6 +11,7 @@ import {
 	reloadWebWorkers,
 	PERMISSIVE_PERMISSIONS,
 } from './fixtures/nextcloud.js'
+import { CONTAINER_NAME } from './setup/container.js'
 
 // Set permission_manage_appointments via the same web SAPI that serves the
 // actual reopen call — occ runs in CLI mode and APCu lives in a separate
@@ -56,7 +57,7 @@ test.describe('Attendance App - Close inquiry permissions (sequential)', () => {
 		// or sibling test cannot mask the negative case.
 		await setManageAppointmentsRoles(request, ['admin'])
 		const checkPerm = execSync(
-			`docker exec -u www-data nextcloud-e2e-test-server_attendance php occ config:app:get attendance permission_manage_appointments`,
+			`docker exec -u www-data ${CONTAINER_NAME} php occ config:app:get attendance permission_manage_appointments`,
 			{ stdio: 'pipe' },
 		).toString().trim()
 		console.log('[debug] permission_manage_appointments =', checkPerm)

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -130,6 +130,14 @@ The tests use the `@nextcloud/e2e-test-server` package which provides a pre-conf
 - **Installed apps:**
   - Attendance app (from current directory)
 
+### Container name
+
+`@nextcloud/e2e-test-server` names the container after the basename of the
+project directory, so it is `nextcloud-e2e-test-server_attendance` in the main
+checkout but `nextcloud-e2e-test-server_<worktree>` in a git worktree. Anything
+that shells out to `docker` therefore takes the name from
+`setup/container.js`, which asks the package for it — never hardcode it.
+
 ## Writing Tests
 
 ### Test Structure

--- a/tests/e2e/fixtures/nextcloud.js
+++ b/tests/e2e/fixtures/nextcloud.js
@@ -3,6 +3,7 @@ import { existsSync, mkdirSync, readFileSync } from 'fs'
 import { execSync } from 'node:child_process'
 import { dirname, join } from 'path'
 import { fileURLToPath } from 'url'
+import { CONTAINER_NAME } from '../setup/container.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const AUTH_DIR = join(__dirname, '..', '.auth')
@@ -440,7 +441,7 @@ export async function resetAdminSettings(request) {
  */
 export async function reloadWebWorkers() {
 	execSync(
-		'docker exec nextcloud-e2e-test-server_attendance apachectl graceful',
+		`docker exec ${CONTAINER_NAME} apachectl graceful`,
 		{ stdio: 'pipe' },
 	)
 	// Give Apache a moment to cycle workers.

--- a/tests/e2e/setup/container.js
+++ b/tests/e2e/setup/container.js
@@ -1,0 +1,9 @@
+import { getContainerName } from '@nextcloud/e2e-test-server'
+
+/**
+ * Name of the Docker container running the test server. It is derived from the
+ * basename of the project directory, so a git worktree gets a different one
+ * than the main checkout — asking the package that named it, instead of
+ * hardcoding `…_attendance`, keeps `docker exec` working in both.
+ */
+export const CONTAINER_NAME = getContainerName()

--- a/tests/e2e/setup/server-cleanup.js
+++ b/tests/e2e/setup/server-cleanup.js
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+
+import { execFileSync } from 'node:child_process'
+import { CONTAINER_NAME } from './container.js'
+
+/**
+ * Drop the test server container and the `apps_writable` volume, so the next
+ * `npm run test:e2e` builds a completely fresh instance. Either may already be
+ * gone — that is not an error.
+ */
+function dockerRemove(...args) {
+	try {
+		execFileSync('docker', args, { stdio: 'pipe' })
+	} catch {
+		// Already removed, or Docker is not running.
+	}
+}
+
+dockerRemove('rm', '-f', CONTAINER_NAME)
+dockerRemove('volume', 'rm', '-f', 'apps_writable')
+
+console.log(`Removed container ${CONTAINER_NAME} and volume apps_writable`)


### PR DESCRIPTION
## Problem

`@nextcloud/e2e-test-server` names its Docker container after the basename of the project directory, so `nextcloud-e2e-test-server_attendance` only holds when the checkout folder happens to be called `attendance`. In a git worktree (e.g. `.claude/worktrees/awesome-kalam-eb95ca`) it is named after the worktree instead, and all three places that shelled out to `docker` with the hardcoded name missed it:

- `reloadWebWorkers()` threw `No such container`, which aborted the `beforeAll` hooks of `15-close-inquiry-permissions`, `28-create-permission`, `29-organizer-visibility` and `32-statistics` — those tests failed at 0ms.
- `test:e2e:server-cleanup` dropped only the `apps_writable` volume and left a stale container behind.

CI is green because the main checkout's folder is called `attendance`, so the mismatch never shows up there.

## Change

New `tests/e2e/setup/container.js` is the single place the name comes from. Rather than reimplementing the derivation, it asks the package itself:

```js
import { getContainerName } from '@nextcloud/e2e-test-server'
export const CONTAINER_NAME = getContainerName()
```

`getContainerName()` is a regular export of the package (`dist/docker.d.ts`) and does `nextcloud-e2e-test-server_${basename(process.cwd()).replace(' ', '')}` — including the space-stripping a hand-written copy would likely miss. If the naming scheme changes upstream, the callers follow automatically.

The three call sites now use it:

- `tests/e2e/fixtures/nextcloud.js` — `docker exec ${CONTAINER_NAME} apachectl graceful`
- `tests/e2e/15-close-inquiry-permissions.spec.js` — same for the `occ config:app:get` debug call
- `package.json` — `test:e2e:server-cleanup` becomes `node tests/e2e/setup/server-cleanup.js`, a small script that removes the container and the `apps_writable` volume via `execFileSync` and reports what it removed. The `2>/dev/null || true` shell juggling goes away with it.

A short section in `tests/e2e/README.md` records why the name must not be hardcoded again.

## Testing

Run from a worktree at `.claude/worktrees/awesome-kalam-eb95ca`, where the container was actually named `nextcloud-e2e-test-server_awesome-kalam-eb95ca`:

- **Failure reproduced first:** reverting only the fixture to the hardcoded name makes `beforeAll` fail at `reloadWebWorkers` (`nextcloud.js:443`), with the remaining tests reported as "did not run" — exactly the reported symptom.
- **With the fix:** `15-close-inquiry-permissions`, `28-create-permission`, `29-organizer-visibility` and `32-statistics` → **17 passed (1.9m)**, exit 0.
- `npm run test:e2e:server-cleanup` from the worktree now removes the worktree-named container (previously it survived); afterwards no containers and no volumes remain.

`./scripts/check.sh` → **All checks passed** (eslint, stylelint, php-cs-fixer, psalm, phpunit, vite build, both l10n checks, openapi spec).

The rest of the suite was not run end-to-end here: the `calendar` app could not be installed in this sandbox ("not found on the appstore" for the NC 36 dev server), which fails specs 12/13/27 independently of this change. The four specs above do not need it.

No app code is touched — this is test tooling only, so there is no impact on the Flutter client or the API surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CZzGVDp4XnKFD6zhECUod1

---
_Generated by [Claude Code](https://claude.ai/code/session_01CZzGVDp4XnKFD6zhECUod1)_