### PR TITLE
feat(org-calendar): link back to the appointment in the event description

### DIFF
--- a/lib/Listener/CalendarObjectUpdateListener.php
+++ b/lib/Listener/CalendarObjectUpdateListener.php
@@ -88,8 +88,8 @@ class CalendarObjectUpdateListener implements IEventListener {
 			$appointment->setName($summary);
 		}
 		if ($description !== '') {
-			// The app-generated response summary block is calendar-only content
-			$appointment->setDescription(strip_tags(OrgCalendarSyncService::stripResponseSummary($description)));
+			// The app-generated block is calendar-only content
+			$appointment->setDescription(strip_tags(OrgCalendarSyncService::stripAppendedBlock($description)));
 		}
 
 		$dtstart = $vevent->DTSTART ? $vevent->DTSTART->getDateTime() : null;
@@ -167,7 +167,7 @@ class CalendarObjectUpdateListener implements IEventListener {
 						$appointment->setName($summary);
 					}
 					if ($description !== '') {
-						$appointment->setDescription(strip_tags(OrgCalendarSyncService::stripResponseSummary($description)));
+						$appointment->setDescription(strip_tags(OrgCalendarSyncService::stripAppendedBlock($description)));
 					}
 					$appointment->setUpdatedAt(gmdate('Y-m-d H:i:s'));
 					$this->appointmentMapper->update($appointment);

--- a/lib/Service/IcalService.php
+++ b/lib/Service/IcalService.php
@@ -13,6 +13,7 @@ use OCA\Attendance\Db\IcalToken;
 use OCA\Attendance\Db\IcalTokenMapper;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\IConfig;
+use OCP\IL10N;
 use OCP\IURLGenerator;
 use OCP\L10N\IFactory as IL10NFactory;
 use OCP\Security\ISecureRandom;
@@ -153,8 +154,8 @@ class IcalService {
 		$output .= "VERSION:2.0\r\n";
 		$output .= "PRODID:-//Nextcloud//Attendance App//EN\r\n";
 		$output .= "CALSCALE:GREGORIAN\r\n";
-		$output .= 'NAME:' . $this->escapeIcalText($calendarName) . "\r\n";
-		$output .= 'X-WR-CALNAME:' . $this->escapeIcalText($calendarName) . "\r\n";
+		$output .= 'NAME:' . self::escapeIcalText($calendarName) . "\r\n";
+		$output .= 'X-WR-CALNAME:' . self::escapeIcalText($calendarName) . "\r\n";
 		$output .= "REFRESH-INTERVAL;VALUE=DURATION:PT15M\r\n";
 		$output .= "X-PUBLISHED-TTL:PT15M\r\n";
 
@@ -202,7 +203,7 @@ class IcalService {
 		Appointment $appointment,
 		$response,
 		string $userId,
-		$l,
+		IL10N $l,
 		string $domain,
 		array $reminderTriggers = [],
 	): string {
@@ -311,7 +312,7 @@ class IcalService {
 		}
 
 		// Add link to respond
-		$descriptionParts[] = $l->t('View or change your response') . ":\n" . $this->getAppointmentUrl($appointment->getId());
+		$descriptionParts[] = $this->appointmentLinkLine($l, $appointment->getId());
 
 		$description = implode("\n\n", $descriptionParts);
 
@@ -353,15 +354,15 @@ class IcalService {
 		$output .= 'SEQUENCE:' . $sequence . "\r\n";
 		$output .= 'DTSTART:' . $startDt->format('Ymd\THis\Z') . "\r\n";
 		$output .= 'DTEND:' . $endDt->format('Ymd\THis\Z') . "\r\n";
-		$output .= 'SUMMARY:' . $this->escapeIcalText($summary) . "\r\n";
-		$output .= 'DESCRIPTION:' . $this->escapeIcalText($description) . "\r\n";
+		$output .= 'SUMMARY:' . self::escapeIcalText($summary) . "\r\n";
+		$output .= 'DESCRIPTION:' . self::escapeIcalText($description) . "\r\n";
 		$location = $appointment->getLocation();
 		if ($location !== null) {
-			$output .= 'LOCATION:' . $this->escapeIcalText($location) . "\r\n";
+			$output .= 'LOCATION:' . self::escapeIcalText($location) . "\r\n";
 		}
 		$categoryName = $this->resolveCategoryName($appointment->getCategoryId());
 		if ($categoryName !== null) {
-			$output .= 'CATEGORIES:' . $this->escapeIcalText($categoryName) . "\r\n";
+			$output .= 'CATEGORIES:' . self::escapeIcalText($categoryName) . "\r\n";
 		}
 		$output .= 'URL:' . $appointmentUrl . "\r\n";
 		$output .= 'STATUS:' . $status . "\r\n";
@@ -378,7 +379,7 @@ class IcalService {
 				$output .= "BEGIN:VALARM\r\n";
 				$output .= 'TRIGGER:-' . $trigger . "\r\n";
 				$output .= "ACTION:DISPLAY\r\n";
-				$output .= 'DESCRIPTION:' . $this->escapeIcalText($appointment->getName()) . "\r\n";
+				$output .= 'DESCRIPTION:' . self::escapeIcalText($appointment->getName()) . "\r\n";
 				$output .= "END:VALARM\r\n";
 			}
 		}
@@ -411,9 +412,23 @@ class IcalService {
 	}
 
 	/**
-	 * Escape text for iCal format (RFC 5545)
+	 * Labelled deep link, as it appears at the end of a calendar event's
+	 * description. Shared with the organization calendar so both spell the same
+	 * source string — a reword here must not fork into a second one to translate.
+	 *
+	 * @param IL10N $l The language the event is written in
 	 */
-	public function escapeIcalText(string $text): string {
+	public function appointmentLinkLine(IL10N $l, int $appointmentId): string {
+		return $l->t('View or change your response') . ":\n" . $this->getAppointmentUrl($appointmentId);
+	}
+
+	/**
+	 * Escape text for iCal format (RFC 5545)
+	 *
+	 * Static for the same reason as unfoldIcalContent() below: a pure transform
+	 * tests must not have to restate in a stub.
+	 */
+	public static function escapeIcalText(string $text): string {
 		// Escape backslashes first, then other special chars
 		$text = str_replace('\\', '\\\\', $text);
 		$text = str_replace(';', '\\;', $text);

--- a/lib/Service/OrgCalendarSyncService.php
+++ b/lib/Service/OrgCalendarSyncService.php
@@ -111,7 +111,7 @@ class OrgCalendarSyncService {
 		}
 
 		if (isset($orgCalendar['summary'])) {
-			// Backfill in both directions: switching off has to take the block
+			// Backfill in both directions: switching off has to take the summary
 			// out of the events that already carry it, not just stop adding it.
 			$changed = $changed || $this->configService->isOrgCalendarSummaryEnabled() !== $orgCalendar['summary'];
 			$this->configService->setOrgCalendarSummaryEnabled($orgCalendar['summary']);
@@ -440,7 +440,7 @@ class OrgCalendarSyncService {
 
 	/**
 	 * The VEVENT properties the app owns, as full unfolded lines.
-	 * A null value means the property must be absent (e.g. empty description).
+	 * A null value means the property must be absent (e.g. an unset location).
 	 *
 	 * @return array<string, ?string> property name => line
 	 */
@@ -458,13 +458,13 @@ class OrgCalendarSyncService {
 			'LAST-MODIFIED' => 'LAST-MODIFIED:' . $lastModified->format('Ymd\THis\Z'),
 			'DTSTART' => 'DTSTART:' . $start->format('Ymd\THis\Z'),
 			'DTEND' => 'DTEND:' . $end->format('Ymd\THis\Z'),
-			'SUMMARY' => 'SUMMARY:' . $this->icalService->escapeIcalText($appointment->getName()),
-			'DESCRIPTION' => 'DESCRIPTION:' . $this->icalService->escapeIcalText($this->buildDescription($appointment)),
+			'SUMMARY' => 'SUMMARY:' . IcalService::escapeIcalText($appointment->getName()),
+			'DESCRIPTION' => 'DESCRIPTION:' . IcalService::escapeIcalText($this->buildDescription($appointment)),
 			'LOCATION' => $location !== null
-				? 'LOCATION:' . $this->icalService->escapeIcalText($location)
+				? 'LOCATION:' . IcalService::escapeIcalText($location)
 				: null,
 			'CATEGORIES' => $categoryName !== null
-				? 'CATEGORIES:' . $this->icalService->escapeIcalText($categoryName)
+				? 'CATEGORIES:' . IcalService::escapeIcalText($categoryName)
 				: null,
 			'STATUS' => 'STATUS:' . ($appointment->isCancelled() ? 'CANCELLED' : 'CONFIRMED'),
 		];
@@ -488,28 +488,21 @@ class OrgCalendarSyncService {
 	/**
 	 * Event DESCRIPTION = plain appointment description, plus the app block
 	 * behind the BLOCK_SEPARATOR marker: the response summary when anybody
-	 * responded (the "who is coming" visibility agreed in issue #71) and a link
-	 * into the app, where an attendee can read the details and answer (#205).
+	 * responded (issue #71) and a link into the app to answer (issue #205).
 	 *
-	 * The link is deliberately outside the summary switch: that switch buys
-	 * quiet by keeping a write per answer out of the calendar, and the link
-	 * never changes, so it costs nothing to carry.
+	 * Only the summary sits behind the summary switch — the link never changes,
+	 * so carrying it costs no extra write.
 	 */
 	private function buildDescription(Appointment $appointment): string {
 		$description = trim($appointment->getDescription() ?? '');
-
-		$block = [];
-		if ($this->configService->isOrgCalendarSummaryEnabled()) {
-			$summary = $this->buildResponseSummary($appointment);
-			if ($summary !== null) {
-				$block[] = $summary;
-			}
-		}
-		$block[] = $this->getL10N()->t('View or change your response') . ":\n"
-			. $this->icalService->getAppointmentUrl($appointment->getId());
+		$summary = $this->configService->isOrgCalendarSummaryEnabled()
+			? $this->buildResponseSummary($appointment)
+			: null;
 
 		return ($description !== '' ? $description . "\n\n" : '')
-			. self::BLOCK_SEPARATOR . "\n" . implode("\n", $block);
+			. self::BLOCK_SEPARATOR . "\n"
+			. ($summary !== null ? $summary . "\n" : '')
+			. $this->icalService->appointmentLinkLine($this->getL10N(), $appointment->getId());
 	}
 
 	/**

--- a/lib/Service/OrgCalendarSyncService.php
+++ b/lib/Service/OrgCalendarSyncService.php
@@ -26,8 +26,8 @@ use Psr\Log\LoggerInterface;
  * columns the import flow uses. The listener writes through the mapper (not this
  * service), so no push/echo loop can form; the listener echo of our own writes
  * is idempotent because the pushed DESCRIPTION is the plain appointment
- * description plus the response summary block, which the listener strips again
- * via stripResponseSummary() before writing back.
+ * description plus the app-generated block, which the listener strips again
+ * via stripAppendedBlock() before writing back.
  *
  * Object CRUD uses OCA\DAV\CalDAV\CalDavBackend because OCP offers no public
  * update/delete API for calendar objects (nextcloud/server#20154):
@@ -44,13 +44,14 @@ class OrgCalendarSyncService {
 
 	/**
 	 * Separator line between the appointment description and the app-generated
-	 * response summary inside the event DESCRIPTION. Doubles as the suppression
-	 * marker: CalendarObjectUpdateListener strips everything from this line on
-	 * before syncing a calendar-side description back into the appointment, so
-	 * the summary never leaks into the appointment description (echo loop).
+	 * block (response summary and deep link) inside the event DESCRIPTION.
+	 * Doubles as the suppression marker: CalendarObjectUpdateListener strips
+	 * everything from this line on before syncing a calendar-side description
+	 * back into the appointment, so the block never leaks into the appointment
+	 * description (echo loop).
 	 * Must stay untranslated — stripping has to work in every language.
 	 */
-	public const SUMMARY_SEPARATOR = '--- Attendance ---';
+	public const BLOCK_SEPARATOR = '--- Attendance ---';
 
 	/**
 	 * Properties managedProperties() derives from the appointment's updatedAt,
@@ -334,8 +335,9 @@ class OrgCalendarSyncService {
 	 * Build the full VCALENDAR document for a new appointment event.
 	 *
 	 * DESCRIPTION carries only content derived from the appointment (plus the
-	 * summary block the listener strips again), so the listener echo of our
-	 * own writes is a no-op. The deep link goes into URL instead.
+	 * app block the listener strips again), so the listener echo of our own
+	 * writes is a no-op. URL carries the same deep link for the clients that
+	 * surface that property.
 	 */
 	public function buildIcs(Appointment $appointment, string $uid): string {
 		$utc = new \DateTimeZone('UTC');
@@ -448,7 +450,6 @@ class OrgCalendarSyncService {
 		$end = new \DateTime($appointment->getEndDatetime(), $utc);
 		$lastModified = new \DateTime($appointment->getUpdatedAt() ?: 'now', $utc);
 
-		$description = $this->buildDescription($appointment);
 		$location = $appointment->getLocation();
 		$categoryName = $this->resolveCategoryName($appointment->getCategoryId());
 
@@ -458,9 +459,7 @@ class OrgCalendarSyncService {
 			'DTSTART' => 'DTSTART:' . $start->format('Ymd\THis\Z'),
 			'DTEND' => 'DTEND:' . $end->format('Ymd\THis\Z'),
 			'SUMMARY' => 'SUMMARY:' . $this->icalService->escapeIcalText($appointment->getName()),
-			'DESCRIPTION' => $description !== ''
-				? 'DESCRIPTION:' . $this->icalService->escapeIcalText($description)
-				: null,
+			'DESCRIPTION' => 'DESCRIPTION:' . $this->icalService->escapeIcalText($this->buildDescription($appointment)),
 			'LOCATION' => $location !== null
 				? 'LOCATION:' . $this->icalService->escapeIcalText($location)
 				: null,
@@ -487,30 +486,34 @@ class OrgCalendarSyncService {
 	}
 
 	/**
-	 * Event DESCRIPTION = plain appointment description, plus — when anybody
-	 * responded — the response summary behind the SUMMARY_SEPARATOR marker
-	 * (the "who is coming" visibility agreed in issue #71).
+	 * Event DESCRIPTION = plain appointment description, plus the app block
+	 * behind the BLOCK_SEPARATOR marker: the response summary when anybody
+	 * responded (the "who is coming" visibility agreed in issue #71) and a link
+	 * into the app, where an attendee can read the details and answer (#205).
+	 *
+	 * The link is deliberately outside the summary switch: that switch buys
+	 * quiet by keeping a write per answer out of the calendar, and the link
+	 * never changes, so it costs nothing to carry.
 	 */
 	private function buildDescription(Appointment $appointment): string {
 		$description = trim($appointment->getDescription() ?? '');
 
-		if (!$this->configService->isOrgCalendarSummaryEnabled()) {
-			return $description;
+		$block = [];
+		if ($this->configService->isOrgCalendarSummaryEnabled()) {
+			$summary = $this->buildResponseSummary($appointment);
+			if ($summary !== null) {
+				$block[] = $summary;
+			}
 		}
+		$block[] = $this->getL10N()->t('View or change your response') . ":\n"
+			. $this->icalService->getAppointmentUrl($appointment->getId());
 
-		$summary = $this->buildResponseSummary($appointment);
-		if ($summary !== null) {
-			$description = ($description !== '' ? $description . "\n\n" : '')
-				. self::SUMMARY_SEPARATOR . "\n" . $summary;
-		}
-
-		return $description;
+		return ($description !== '' ? $description . "\n\n" : '')
+			. self::BLOCK_SEPARATOR . "\n" . implode("\n", $block);
 	}
 
 	/**
 	 * One-line response summary, e.g. "12 attending, 3 declined, 2 maybe".
-	 * Uses the instance default language — the calendar is shared org-wide,
-	 * so the text must not depend on whoever responded last.
 	 *
 	 * @return string|null Null when nobody responded yet
 	 */
@@ -520,26 +523,35 @@ class OrgCalendarSyncService {
 			return null;
 		}
 
-		if ($this->l10n === null) {
-			$lang = $this->config->getSystemValueString('default_language', 'en');
-			$this->l10n = $this->l10nFactory->get('attendance', $lang);
-		}
+		$l10n = $this->getL10N();
 
 		return implode(', ', [
-			$this->l10n->n('%n attending', '%n attending', $counts['yes'] ?? 0),
-			$this->l10n->n('%n declined', '%n declined', $counts['no'] ?? 0),
-			$this->l10n->n('%n maybe', '%n maybe', $counts['maybe'] ?? 0),
+			$l10n->n('%n attending', '%n attending', $counts['yes'] ?? 0),
+			$l10n->n('%n declined', '%n declined', $counts['no'] ?? 0),
+			$l10n->n('%n maybe', '%n maybe', $counts['maybe'] ?? 0),
 		]);
 	}
 
 	/**
-	 * Remove the app-generated response summary block from a calendar-side
-	 * description. Used by CalendarObjectUpdateListener before syncing a
-	 * description back into the appointment, so our own summary (which always
-	 * sits at the end) never becomes part of the appointment description.
+	 * Instance default language — the calendar is shared org-wide, so its text
+	 * must not depend on whoever triggered the write.
 	 */
-	public static function stripResponseSummary(string $description): string {
-		$pos = strpos($description, self::SUMMARY_SEPARATOR);
+	private function getL10N(): IL10N {
+		if ($this->l10n === null) {
+			$lang = $this->config->getSystemValueString('default_language', 'en');
+			$this->l10n = $this->l10nFactory->get('attendance', $lang);
+		}
+		return $this->l10n;
+	}
+
+	/**
+	 * Remove the app-generated block from a calendar-side description. Used by
+	 * CalendarObjectUpdateListener before syncing a description back into the
+	 * appointment, so our own summary and link (which always sit at the end)
+	 * never become part of the appointment description.
+	 */
+	public static function stripAppendedBlock(string $description): string {
+		$pos = strpos($description, self::BLOCK_SEPARATOR);
 		if ($pos === false) {
 			return $description;
 		}

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1792,7 +1792,6 @@
       <code><![CDATA[getUserValue]]></code>
     </DeprecatedMethod>
     <MissingParamType>
-      <code><![CDATA[$l]]></code>
       <code><![CDATA[$response]]></code>
     </MissingParamType>
     <MixedArgument>
@@ -1802,7 +1801,6 @@
     </MixedArgument>
     <MixedArgumentTypeCoercion>
       <code><![CDATA[$attachmentLines]]></code>
-      <code><![CDATA[$descriptionParts]]></code>
     </MixedArgumentTypeCoercion>
     <MixedArrayOffset>
       <code><![CDATA[$attachmentUrls[$attachment->getFileId()]]]></code>
@@ -1816,13 +1814,9 @@
       <code><![CDATA[$attachment]]></code>
       <code><![CDATA[$attachment]]></code>
       <code><![CDATA[$attachmentLines[]]]></code>
-      <code><![CDATA[$descriptionParts[]]]></code>
       <code><![CDATA[$instanceName]]></code>
       <code><![CDATA[$responseComment]]></code>
-      <code><![CDATA[$responseLabel]]></code>
       <code><![CDATA[$responseState]]></code>
-      <code><![CDATA[$statusLabel]]></code>
-      <code><![CDATA[$statusLabel]]></code>
     </MixedAssignment>
     <MixedMethodCall>
       <code><![CDATA[getComment]]></code>
@@ -1834,32 +1828,11 @@
       <code><![CDATA[getRespondedAt]]></code>
       <code><![CDATA[getRespondedAt]]></code>
       <code><![CDATA[getResponse]]></code>
-      <code><![CDATA[t]]></code>
-      <code><![CDATA[t]]></code>
-      <code><![CDATA[t]]></code>
-      <code><![CDATA[t]]></code>
-      <code><![CDATA[t]]></code>
-      <code><![CDATA[t]]></code>
-      <code><![CDATA[t]]></code>
-      <code><![CDATA[t]]></code>
-      <code><![CDATA[t]]></code>
-      <code><![CDATA[t]]></code>
-      <code><![CDATA[t]]></code>
-      <code><![CDATA[t]]></code>
     </MixedMethodCall>
     <MixedOperand>
       <code><![CDATA[$attachment->getFileId()]]></code>
       <code><![CDATA[$instanceName]]></code>
-      <code><![CDATA[$l->t('Attachments')]]></code>
-      <code><![CDATA[$l->t('Cancelled')]]></code>
-      <code><![CDATA[$l->t('Me')]]></code>
-      <code><![CDATA[$l->t('Me')]]></code>
-      <code><![CDATA[$l->t('View or change your response')]]></code>
-      <code><![CDATA[$l->t('Your response')]]></code>
       <code><![CDATA[$responseComment]]></code>
-      <code><![CDATA[$responseLabel]]></code>
-      <code><![CDATA[$responseLabel]]></code>
-      <code><![CDATA[$statusLabel]]></code>
     </MixedOperand>
     <PossiblyFalseArgument>
       <code><![CDATA[$domain]]></code>

--- a/tests/e2e/27-org-calendar.spec.js
+++ b/tests/e2e/27-org-calendar.spec.js
@@ -1,4 +1,5 @@
 import {
+	BASE_URL,
 	cancelAppointmentViaAPI,
 	createAppointmentViaAPI,
 	deleteAppointmentViaAPI,
@@ -205,7 +206,7 @@ test.describe('Attendance App - Organization calendar', () => {
 	})
 
 	test.describe('Calendar to app sync of pushed events', () => {
-		test('calendar edit syncs back without leaking the summary block', async ({ request }) => {
+		test('calendar edit syncs back without leaking the app block', async ({ request }) => {
 			await saveAdminSettings(request, { calendarSync: { enabled: true } })
 
 			const appointment = await createAppointmentViaAPI(request, {
@@ -216,15 +217,16 @@ test.describe('Attendance App - Organization calendar', () => {
 			await respondToAppointmentViaAPI(request, appointment.id, { response: 'yes' })
 
 			// Edit the pushed event in the calendar: new title, and a description
-			// that still contains the app-generated summary block (as it would
-			// after editing the text above the marker in the Calendar app)
+			// that still carries the whole app block (as it would after editing
+			// the text above the marker in the Calendar app)
 			const start = new Date(Date.now() + 21 * 24 * 60 * 60 * 1000)
 			start.setHours(10, 0, 0, 0)
 			const end = new Date(start.getTime() + 60 * 60 * 1000)
 			await updateCalendarEvent(request, {
 				uid: appointment.calendarEventUid,
 				summary: 'Org Roundtrip Edited',
-				description: 'Edited text\\n\\n--- Attendance ---\\n1 attending\\, 0 declined\\, 0 maybe',
+				description: 'Edited text\\n\\n--- Attendance ---\\n1 attending\\, 0 declined\\, 0 maybe'
+					+ `\\nView or change your response:\\n${BASE_URL}/apps/attendance/#/appointment/${appointment.id}`,
 				dtstart: toICalDate(start),
 				dtend: toICalDate(end),
 				calendarName: CALENDAR_NAME,
@@ -233,7 +235,7 @@ test.describe('Attendance App - Organization calendar', () => {
 			const appointments = await listAppointmentsViaAPI(request, { showPast: false })
 			const synced = appointments.find((a) => a.id === appointment.id)
 			expect(synced.name).toBe('Org Roundtrip Edited')
-			// The summary block was stripped before writing back
+			// The whole app block was stripped before writing back
 			expect(synced.description).toBe('Edited text')
 
 			await deleteAppointmentViaAPI(request, appointment.id)

--- a/tests/e2e/27-org-calendar.spec.js
+++ b/tests/e2e/27-org-calendar.spec.js
@@ -86,6 +86,8 @@ test.describe('Attendance App - Organization calendar', () => {
 			expect(ics).toBeTruthy()
 			expect(ics).toContain('SUMMARY:Org Push Create')
 			expect(ics).toContain('DESCRIPTION:Rehearsal in the club house')
+			expect(ics).toContain('--- Attendance ---')
+			expect(ics).toContain(`/apps/attendance/#/appointment/${appointment.id}`)
 			expect(ics).toContain('STATUS:CONFIRMED')
 
 			await deleteAppointmentViaAPI(request, appointment.id)

--- a/tests/e2e/fixtures/nextcloud.js
+++ b/tests/e2e/fixtures/nextcloud.js
@@ -7,7 +7,7 @@ import { CONTAINER_NAME } from '../setup/container.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const AUTH_DIR = join(__dirname, '..', '.auth')
-const BASE_URL = process.env.NEXTCLOUD_URL || 'http://localhost:8080'
+export const BASE_URL = process.env.NEXTCLOUD_URL || 'http://localhost:8080'
 // Nextcloud app API POST requests need /index.php to avoid redirect issues.
 // OCS provisioning API may or may not need /index.php depending on mod_rewrite config.
 const API_BASE = `${BASE_URL}/index.php`

--- a/tests/unit/Service/OrgCalendarSyncServiceTest.php
+++ b/tests/unit/Service/OrgCalendarSyncServiceTest.php
@@ -142,6 +142,9 @@ class OrgCalendarSyncServiceTest extends TestCase {
 	private FakeCalDavBackend $backend;
 	private TestableOrgCalendarSyncService $service;
 
+	/** Deep link line the app block ends with, as it appears in the escaped ICS */
+	private const LINK_LINE = 'View or change your response:\nhttps://cloud.example.com/apps/attendance/#/appointment/5';
+
 	protected function setUp(): void {
 		$this->calendarService = $this->createMock(CalendarService::class);
 		$this->appointmentMapper = $this->createMock(AppointmentMapper::class);
@@ -152,7 +155,11 @@ class OrgCalendarSyncServiceTest extends TestCase {
 		$this->categoryMapper = $this->createMock(CategoryMapper::class);
 		$this->backend = new FakeCalDavBackend();
 
-		$this->icalService->method('escapeIcalText')->willReturnArgument(0);
+		// Only the newline part of the real escaping is reproduced — it is what
+		// keeps a multi-line DESCRIPTION on one ICS content line.
+		$this->icalService->method('escapeIcalText')->willReturnCallback(
+			fn (string $text) => str_replace(["\r\n", "\r", "\n"], '\\n', $text),
+		);
 		$this->icalService->method('foldIcalContent')->willReturnArgument(0);
 		$this->icalService->method('getAppointmentUrl')
 			->willReturnCallback(fn (int $id) => 'https://cloud.example.com/apps/attendance/#/appointment/' . $id);
@@ -164,6 +171,7 @@ class OrgCalendarSyncServiceTest extends TestCase {
 		);
 
 		$l10n = $this->createMock(IL10N::class);
+		$l10n->method('t')->willReturnArgument(0);
 		$l10n->method('n')->willReturnCallback(
 			fn (string $singular, string $plural, int $count) => str_replace('%n', (string)$count, $count === 1 ? $singular : $plural),
 		);
@@ -371,7 +379,7 @@ class OrgCalendarSyncServiceTest extends TestCase {
 		$this->assertStringNotContainsString('SUMMARY:Old title', $ics);
 	}
 
-	public function testPatchRemovesDescriptionWhenCleared(): void {
+	public function testPatchDropsClearedDescriptionTextButKeepsTheBlock(): void {
 		$this->configureEnabled();
 		$appointment = $this->buildAppointment();
 		$appointment->setDescription('');
@@ -388,7 +396,12 @@ class OrgCalendarSyncServiceTest extends TestCase {
 		];
 
 		$this->assertTrue($this->service->syncAppointment($appointment));
-		$this->assertStringNotContainsString('DESCRIPTION:', $this->backend->updated[0][2]);
+		$ics = $this->backend->updated[0][2];
+		$this->assertStringNotContainsString('Old text', $ics);
+		$this->assertStringContainsString(
+			'DESCRIPTION:' . OrgCalendarSyncService::BLOCK_SEPARATOR . '\n' . self::LINK_LINE,
+			$ics,
+		);
 	}
 
 	public function testPatchRemovesLocationWhenNotSet(): void {
@@ -453,23 +466,52 @@ class OrgCalendarSyncServiceTest extends TestCase {
 		$ics = $this->backend->created[0][2];
 
 		$this->assertStringContainsString(
-			"DESCRIPTION:Bring instruments\n\n"
-			. OrgCalendarSyncService::SUMMARY_SEPARATOR
-			. "\n2 attending, 1 declined, 1 maybe",
+			'DESCRIPTION:Bring instruments\n\n'
+			. OrgCalendarSyncService::BLOCK_SEPARATOR
+			. '\n2 attending, 1 declined, 1 maybe\n' . self::LINK_LINE,
 			$ics,
 		);
 	}
 
-	public function testNoSummaryBlockWithoutResponses(): void {
+	public function testBlockCarriesTheLinkWithoutResponses(): void {
 		$this->configureEnabled();
 		$appointment = $this->buildAppointment();
 		$this->appointmentMapper->method('update')->willReturnArgument(0);
 		$this->responseSummary = ['yes' => 0, 'no' => 0, 'maybe' => 0];
 
 		$this->assertTrue($this->service->syncAppointment($appointment));
-		$this->assertStringNotContainsString(OrgCalendarSyncService::SUMMARY_SEPARATOR, $this->backend->created[0][2]);
+		$ics = $this->backend->created[0][2];
+
+		$this->assertStringContainsString(
+			'DESCRIPTION:Bring instruments\n\n'
+			. OrgCalendarSyncService::BLOCK_SEPARATOR . '\n' . self::LINK_LINE,
+			$ics,
+		);
+		$this->assertStringNotContainsString('attending', $ics);
 	}
 
+	/**
+	 * An appointment without a description starts straight with the block —
+	 * no leading blank line.
+	 */
+	public function testBlockIsTheWholeDescriptionWhenTheAppointmentHasNone(): void {
+		$this->configureEnabled();
+		$appointment = $this->buildAppointment();
+		$appointment->setDescription('');
+		$this->appointmentMapper->method('update')->willReturnArgument(0);
+
+		$this->assertTrue($this->service->syncAppointment($appointment));
+
+		$this->assertStringContainsString(
+			'DESCRIPTION:' . OrgCalendarSyncService::BLOCK_SEPARATOR . '\n' . self::LINK_LINE,
+			$this->backend->created[0][2],
+		);
+	}
+
+	/**
+	 * The summary switch buys quiet from the per-answer write; the link never
+	 * changes, so switching the summary off must not take it away.
+	 */
 	public function testSummaryOmittedWhenTheAdminSwitchedItOff(): void {
 		$this->configureEnabled(false);
 		$appointment = $this->buildAppointment();
@@ -479,8 +521,12 @@ class OrgCalendarSyncServiceTest extends TestCase {
 		$this->assertTrue($this->service->syncAppointment($appointment));
 
 		$ics = $this->backend->created[0][2];
-		$this->assertStringNotContainsString(OrgCalendarSyncService::SUMMARY_SEPARATOR, $ics);
-		$this->assertStringContainsString('DESCRIPTION:Bring instruments', $ics);
+		$this->assertStringNotContainsString('attending', $ics);
+		$this->assertStringContainsString(
+			'DESCRIPTION:Bring instruments\n\n'
+			. OrgCalendarSyncService::BLOCK_SEPARATOR . '\n' . self::LINK_LINE,
+			$ics,
+		);
 	}
 
 	/**
@@ -555,16 +601,19 @@ class OrgCalendarSyncServiceTest extends TestCase {
 		$this->assertFalse($this->service->matchesIgnoringTimestamps($folded, $other));
 	}
 
-	public function testStripResponseSummary(): void {
-		$description = "Bring instruments\n\n" . OrgCalendarSyncService::SUMMARY_SEPARATOR . "\n2 attending, 1 declined, 1 maybe";
-		$this->assertSame('Bring instruments', OrgCalendarSyncService::stripResponseSummary($description));
+	public function testStripAppendedBlock(): void {
+		$block = OrgCalendarSyncService::BLOCK_SEPARATOR
+			. "\n2 attending, 1 declined, 1 maybe"
+			. "\nView or change your response:"
+			. "\nhttps://cloud.example.com/apps/attendance/#/appointment/5";
 
-		// Description that is only a summary block collapses to empty
-		$onlySummary = OrgCalendarSyncService::SUMMARY_SEPARATOR . "\n2 attending, 0 declined, 0 maybe";
-		$this->assertSame('', OrgCalendarSyncService::stripResponseSummary($onlySummary));
+		$this->assertSame('Bring instruments', OrgCalendarSyncService::stripAppendedBlock("Bring instruments\n\n" . $block));
+
+		// Description that is only the block collapses to empty
+		$this->assertSame('', OrgCalendarSyncService::stripAppendedBlock($block));
 
 		// No marker → unchanged
-		$this->assertSame('Plain text', OrgCalendarSyncService::stripResponseSummary('Plain text'));
+		$this->assertSame('Plain text', OrgCalendarSyncService::stripAppendedBlock('Plain text'));
 	}
 
 	public function testSyncAllUpcomingSkipsImportedAppointments(): void {

--- a/tests/unit/Service/OrgCalendarSyncServiceTest.php
+++ b/tests/unit/Service/OrgCalendarSyncServiceTest.php
@@ -142,8 +142,8 @@ class OrgCalendarSyncServiceTest extends TestCase {
 	private FakeCalDavBackend $backend;
 	private TestableOrgCalendarSyncService $service;
 
-	/** Deep link line the app block ends with, as it appears in the escaped ICS */
-	private const LINK_LINE = 'View or change your response:\nhttps://cloud.example.com/apps/attendance/#/appointment/5';
+	/** Deep link line the app block ends with, unescaped */
+	private const LINK_LINE = "View or change your response:\nhttps://cloud.example.com/apps/attendance/#/appointment/5";
 
 	protected function setUp(): void {
 		$this->calendarService = $this->createMock(CalendarService::class);
@@ -155,14 +155,12 @@ class OrgCalendarSyncServiceTest extends TestCase {
 		$this->categoryMapper = $this->createMock(CategoryMapper::class);
 		$this->backend = new FakeCalDavBackend();
 
-		// Only the newline part of the real escaping is reproduced — it is what
-		// keeps a multi-line DESCRIPTION on one ICS content line.
-		$this->icalService->method('escapeIcalText')->willReturnCallback(
-			fn (string $text) => str_replace(["\r\n", "\r", "\n"], '\\n', $text),
-		);
 		$this->icalService->method('foldIcalContent')->willReturnArgument(0);
 		$this->icalService->method('getAppointmentUrl')
 			->willReturnCallback(fn (int $id) => 'https://cloud.example.com/apps/attendance/#/appointment/' . $id);
+		$this->icalService->method('appointmentLinkLine')->willReturnCallback(
+			fn (IL10N $l, int $id) => "View or change your response:\nhttps://cloud.example.com/apps/attendance/#/appointment/$id",
+		);
 
 		$this->urlGenerator->method('getAbsoluteURL')->willReturn('https://cloud.example.com/');
 
@@ -171,7 +169,6 @@ class OrgCalendarSyncServiceTest extends TestCase {
 		);
 
 		$l10n = $this->createMock(IL10N::class);
-		$l10n->method('t')->willReturnArgument(0);
 		$l10n->method('n')->willReturnCallback(
 			fn (string $singular, string $plural, int $count) => str_replace('%n', (string)$count, $count === 1 ? $singular : $plural),
 		);
@@ -399,7 +396,7 @@ class OrgCalendarSyncServiceTest extends TestCase {
 		$ics = $this->backend->updated[0][2];
 		$this->assertStringNotContainsString('Old text', $ics);
 		$this->assertStringContainsString(
-			'DESCRIPTION:' . OrgCalendarSyncService::BLOCK_SEPARATOR . '\n' . self::LINK_LINE,
+			'DESCRIPTION:' . IcalService::escapeIcalText(OrgCalendarSyncService::BLOCK_SEPARATOR . "\n" . self::LINK_LINE),
 			$ics,
 		);
 	}
@@ -456,77 +453,86 @@ class OrgCalendarSyncServiceTest extends TestCase {
 		$this->assertStringNotContainsString('CATEGORIES:', $this->backend->updated[0][2]);
 	}
 
-	public function testResponseSummaryIsAppendedBehindMarker(): void {
-		$this->configureEnabled();
-		$appointment = $this->buildAppointment();
-		$this->appointmentMapper->method('update')->willReturnArgument(0);
-		$this->responseSummary = ['yes' => 2, 'no' => 1, 'maybe' => 1];
+	/**
+	 * @return array<string, array{0: string, 1: bool, 2: array<string, int>, 3: string}>
+	 */
+	public static function descriptionProvider(): array {
+		$marker = OrgCalendarSyncService::BLOCK_SEPARATOR;
+		$link = self::LINK_LINE;
 
-		$this->assertTrue($this->service->syncAppointment($appointment));
-		$ics = $this->backend->created[0][2];
-
-		$this->assertStringContainsString(
-			'DESCRIPTION:Bring instruments\n\n'
-			. OrgCalendarSyncService::BLOCK_SEPARATOR
-			. '\n2 attending, 1 declined, 1 maybe\n' . self::LINK_LINE,
-			$ics,
-		);
-	}
-
-	public function testBlockCarriesTheLinkWithoutResponses(): void {
-		$this->configureEnabled();
-		$appointment = $this->buildAppointment();
-		$this->appointmentMapper->method('update')->willReturnArgument(0);
-		$this->responseSummary = ['yes' => 0, 'no' => 0, 'maybe' => 0];
-
-		$this->assertTrue($this->service->syncAppointment($appointment));
-		$ics = $this->backend->created[0][2];
-
-		$this->assertStringContainsString(
-			'DESCRIPTION:Bring instruments\n\n'
-			. OrgCalendarSyncService::BLOCK_SEPARATOR . '\n' . self::LINK_LINE,
-			$ics,
-		);
-		$this->assertStringNotContainsString('attending', $ics);
+		return [
+			'summary and link behind the marker' => [
+				'Bring instruments', true, ['yes' => 2, 'no' => 1, 'maybe' => 1],
+				"Bring instruments\n\n$marker\n2 attending, 1 declined, 1 maybe\n$link",
+			],
+			'link alone while nobody has responded' => [
+				'Bring instruments', true, ['yes' => 0, 'no' => 0, 'maybe' => 0],
+				"Bring instruments\n\n$marker\n$link",
+			],
+			// The switch buys quiet from the per-answer write; the link never changes
+			'link survives the summary switch' => [
+				'Bring instruments', false, ['yes' => 2, 'no' => 1, 'maybe' => 1],
+				"Bring instruments\n\n$marker\n$link",
+			],
+			'block is the whole description' => [
+				'', true, [], "$marker\n$link",
+			],
+		];
 	}
 
 	/**
-	 * An appointment without a description starts straight with the block —
-	 * no leading blank line.
+	 * @dataProvider descriptionProvider
+	 *
+	 * @param array<string, int> $counts
 	 */
-	public function testBlockIsTheWholeDescriptionWhenTheAppointmentHasNone(): void {
-		$this->configureEnabled();
+	public function testEventDescription(string $appointmentDescription, bool $summaryEnabled, array $counts, string $expected): void {
+		$this->configureEnabled($summaryEnabled);
 		$appointment = $this->buildAppointment();
-		$appointment->setDescription('');
+		$appointment->setDescription($appointmentDescription);
 		$this->appointmentMapper->method('update')->willReturnArgument(0);
+		$this->responseSummary = $counts;
 
 		$this->assertTrue($this->service->syncAppointment($appointment));
 
 		$this->assertStringContainsString(
-			'DESCRIPTION:' . OrgCalendarSyncService::BLOCK_SEPARATOR . '\n' . self::LINK_LINE,
+			'DESCRIPTION:' . IcalService::escapeIcalText($expected) . "\r\n",
 			$this->backend->created[0][2],
 		);
 	}
 
 	/**
-	 * The summary switch buys quiet from the per-answer write; the link never
-	 * changes, so switching the summary off must not take it away.
+	 * The marker earns its keep only if the strip is the exact inverse of what
+	 * the sync appends — assert the round trip rather than two hand-written
+	 * halves that can drift apart.
 	 */
-	public function testSummaryOmittedWhenTheAdminSwitchedItOff(): void {
-		$this->configureEnabled(false);
+	public function testEverythingTheSyncAppendsIsStrippedAgain(): void {
+		$this->configureEnabled();
 		$appointment = $this->buildAppointment();
 		$this->appointmentMapper->method('update')->willReturnArgument(0);
 		$this->responseSummary = ['yes' => 2, 'no' => 1, 'maybe' => 1];
 
 		$this->assertTrue($this->service->syncAppointment($appointment));
 
-		$ics = $this->backend->created[0][2];
-		$this->assertStringNotContainsString('attending', $ics);
-		$this->assertStringContainsString(
-			'DESCRIPTION:Bring instruments\n\n'
-			. OrgCalendarSyncService::BLOCK_SEPARATOR . '\n' . self::LINK_LINE,
-			$ics,
-		);
+		$written = $this->descriptionOf($this->backend->created[0][2]);
+		$this->assertSame('Bring instruments', OrgCalendarSyncService::stripAppendedBlock($written));
+	}
+
+	/**
+	 * The DESCRIPTION of a written event, unescaped back to plain text — the
+	 * shape Sabre hands the listener.
+	 */
+	private function descriptionOf(string $ics): string {
+		foreach (IcalService::unfoldIcalContent($ics) as $line) {
+			if (IcalService::icalPropertyName($line) === 'DESCRIPTION') {
+				$escaped = substr($line, strlen('DESCRIPTION:'));
+				return preg_replace_callback(
+					'/\\\\(.)/',
+					fn (array $m) => $m[1] === 'n' ? "\n" : $m[1],
+					$escaped,
+				) ?? $escaped;
+			}
+		}
+		$this->fail('no DESCRIPTION in the written event');
 	}
 
 	/**
@@ -603,9 +609,7 @@ class OrgCalendarSyncServiceTest extends TestCase {
 
 	public function testStripAppendedBlock(): void {
 		$block = OrgCalendarSyncService::BLOCK_SEPARATOR
-			. "\n2 attending, 1 declined, 1 maybe"
-			. "\nView or change your response:"
-			. "\nhttps://cloud.example.com/apps/attendance/#/appointment/5";
+			. "\n2 attending, 1 declined, 1 maybe\n" . self::LINK_LINE;
 
 		$this->assertSame('Bring instruments', OrgCalendarSyncService::stripAppendedBlock("Bring instruments\n\n" . $block));
 


### PR DESCRIPTION
The deep link was only in the VEVENT URL property, which the Calendar app
does not surface, so the "--- Attendance ---" block told people how many
were coming but gave them no way to answer without hunting for the app.

The link now sits at the end of that block, reusing the "View or change
your response" wording of the personal iCal feed. It stays outside the
response-summary switch: that switch exists to keep a calendar write per
answer out of the activity stream, and the link never changes.

Because the block is now always present, DESCRIPTION is too — clearing an
appointment's description leaves the block rather than dropping the
property. Renamed SUMMARY_SEPARATOR/stripResponseSummary to
BLOCK_SEPARATOR/stripAppendedBlock so the names still say what the marker
covers; stripping is unchanged, so the calendar-to-app echo stays a no-op.

Existing events pick the link up on the next sync of the appointment or
via the admin's "Sync upcoming appointments now" button — no forced mass
write on upgrade.

Closes #205