### PR TITLE
feat: optional "Maybe" answer and attendance limit with waitlist

### DIFF
--- a/l10n/de.js
+++ b/l10n/de.js
@@ -975,6 +975,10 @@ OC.L10N.register(
     "Move {name} up" : "{name} nach oben verschieben",
     "Move {name} down" : "{name} nach unten verschieben",
     "Sections appear in this order. Drag an entry or use the arrows to move it." : "Die Abschnitte erscheinen in dieser Reihenfolge. Ziehe einen Eintrag oder verschiebe ihn mit den Pfeilen.",
-    "Using Attendance with a group? One license for the whole group costs less than {count} personal licenses." : "Du nutzt Attendance mit einer Gruppe? Eine Lizenz für die ganze Gruppe kostet weniger als {count} persönliche Lizenzen."
+    "Using Attendance with a group? One license for the whole group costs less than {count} personal licenses." : "Du nutzt Attendance mit einer Gruppe? Eine Lizenz für die ganze Gruppe kostet weniger als {count} persönliche Lizenzen.",
+    "Answer options" : "Antwortmöglichkeiten",
+    "Offer “Maybe” as an answer" : "„Vielleicht“ als Antwort anbieten",
+    "What every appointment offers unless its organizer decides otherwise." : "Gilt für jeden Termin, bei dem der Organisator es nicht anders festlegt.",
+    "Without “Maybe” people are left with a clear yes or no." : "Ohne „Vielleicht“ bleibt nur eine klare Zu- oder Absage."
 },
 "nplurals=2; plural=(n != 1);");

--- a/l10n/de.js
+++ b/l10n/de.js
@@ -979,6 +979,22 @@ OC.L10N.register(
     "Answer options" : "Antwortmöglichkeiten",
     "Offer “Maybe” as an answer" : "„Vielleicht“ als Antwort anbieten",
     "What every appointment offers unless its organizer decides otherwise." : "Gilt für jeden Termin, bei dem der Organisator es nicht anders festlegt.",
-    "Without “Maybe” people are left with a clear yes or no." : "Ohne „Vielleicht“ bleibt nur eine klare Zu- oder Absage."
+    "Without “Maybe” people are left with a clear yes or no." : "Ohne „Vielleicht“ bleibt nur eine klare Zu- oder Absage.",
+    "A spot came free for %1$s on %2$s" : "Ein Platz ist frei geworden: %1$s am %2$s",
+    "Attendance limit" : "Teilnahmelimit",
+    "Join waitlist" : "Auf die Warteliste",
+    "Maximum attendees" : "Maximale Teilnehmerzahl",
+    "No spot came free for %1$s on %2$s" : "Es ist kein Platz frei geworden: %1$s am %2$s",
+    "Offer a waitlist when full" : "Warteliste anbieten, wenn der Termin voll ist",
+    "Once that many people have said yes the appointment is full. Leave empty for no limit." : "Sobald so viele zugesagt haben, ist der Termin voll. Leer lassen für unbegrenzt.",
+    "Someone moved off the waitlist into a free spot" : "Jemand ist von der Warteliste auf einen frei gewordenen Platz nachgerückt",
+    "The appointment stayed full, so you no longer need to keep the date free. Thanks for answering." : "Der Termin ist voll geblieben, du musst dir den Tag nicht mehr freihalten. Danke für deine Antwort.",
+    "This appointment is full." : "Dieser Termin ist voll.",
+    "This appointment is full. Join the waitlist to take the next free spot." : "Dieser Termin ist voll. Geh auf die Warteliste, um den nächsten frei werdenden Platz zu bekommen.",
+    "Waitlist" : "Warteliste",
+    "You are number {position} on the waitlist" : "Du bist Nummer {position} auf der Warteliste",
+    "You are on the waitlist" : "Du bist auf der Warteliste",
+    "You were on the waitlist and are in now. Please plan to be there." : "Du warst auf der Warteliste und bist jetzt dabei. Bitte halte dir den Termin frei.",
+    "{subject} moved off the waitlist into a free spot" : "{subject} ist von der Warteliste auf einen frei gewordenen Platz nachgerückt"
 },
 "nplurals=2; plural=(n != 1);");

--- a/l10n/de.json
+++ b/l10n/de.json
@@ -973,6 +973,10 @@
     "Move {name} up" : "{name} nach oben verschieben",
     "Move {name} down" : "{name} nach unten verschieben",
     "Sections appear in this order. Drag an entry or use the arrows to move it." : "Die Abschnitte erscheinen in dieser Reihenfolge. Ziehe einen Eintrag oder verschiebe ihn mit den Pfeilen.",
-    "Using Attendance with a group? One license for the whole group costs less than {count} personal licenses." : "Du nutzt Attendance mit einer Gruppe? Eine Lizenz für die ganze Gruppe kostet weniger als {count} persönliche Lizenzen."
+    "Using Attendance with a group? One license for the whole group costs less than {count} personal licenses." : "Du nutzt Attendance mit einer Gruppe? Eine Lizenz für die ganze Gruppe kostet weniger als {count} persönliche Lizenzen.",
+    "Answer options" : "Antwortmöglichkeiten",
+    "Offer “Maybe” as an answer" : "„Vielleicht“ als Antwort anbieten",
+    "What every appointment offers unless its organizer decides otherwise." : "Gilt für jeden Termin, bei dem der Organisator es nicht anders festlegt.",
+    "Without “Maybe” people are left with a clear yes or no." : "Ohne „Vielleicht“ bleibt nur eine klare Zu- oder Absage."
 },"pluralForm" :"nplurals=2; plural=(n != 1);"
 }

--- a/l10n/de.json
+++ b/l10n/de.json
@@ -977,6 +977,22 @@
     "Answer options" : "Antwortmöglichkeiten",
     "Offer “Maybe” as an answer" : "„Vielleicht“ als Antwort anbieten",
     "What every appointment offers unless its organizer decides otherwise." : "Gilt für jeden Termin, bei dem der Organisator es nicht anders festlegt.",
-    "Without “Maybe” people are left with a clear yes or no." : "Ohne „Vielleicht“ bleibt nur eine klare Zu- oder Absage."
+    "Without “Maybe” people are left with a clear yes or no." : "Ohne „Vielleicht“ bleibt nur eine klare Zu- oder Absage.",
+    "A spot came free for %1$s on %2$s" : "Ein Platz ist frei geworden: %1$s am %2$s",
+    "Attendance limit" : "Teilnahmelimit",
+    "Join waitlist" : "Auf die Warteliste",
+    "Maximum attendees" : "Maximale Teilnehmerzahl",
+    "No spot came free for %1$s on %2$s" : "Es ist kein Platz frei geworden: %1$s am %2$s",
+    "Offer a waitlist when full" : "Warteliste anbieten, wenn der Termin voll ist",
+    "Once that many people have said yes the appointment is full. Leave empty for no limit." : "Sobald so viele zugesagt haben, ist der Termin voll. Leer lassen für unbegrenzt.",
+    "Someone moved off the waitlist into a free spot" : "Jemand ist von der Warteliste auf einen frei gewordenen Platz nachgerückt",
+    "The appointment stayed full, so you no longer need to keep the date free. Thanks for answering." : "Der Termin ist voll geblieben, du musst dir den Tag nicht mehr freihalten. Danke für deine Antwort.",
+    "This appointment is full." : "Dieser Termin ist voll.",
+    "This appointment is full. Join the waitlist to take the next free spot." : "Dieser Termin ist voll. Geh auf die Warteliste, um den nächsten frei werdenden Platz zu bekommen.",
+    "Waitlist" : "Warteliste",
+    "You are number {position} on the waitlist" : "Du bist Nummer {position} auf der Warteliste",
+    "You are on the waitlist" : "Du bist auf der Warteliste",
+    "You were on the waitlist and are in now. Please plan to be there." : "Du warst auf der Warteliste und bist jetzt dabei. Bitte halte dir den Termin frei.",
+    "{subject} moved off the waitlist into a free spot" : "{subject} ist von der Warteliste auf einen frei gewordenen Platz nachgerückt"
 },"pluralForm" :"nplurals=2; plural=(n != 1);"
 }

--- a/l10n/de_DE.js
+++ b/l10n/de_DE.js
@@ -975,6 +975,10 @@ OC.L10N.register(
     "Move {name} up" : "{name} nach oben verschieben",
     "Move {name} down" : "{name} nach unten verschieben",
     "Sections appear in this order. Drag an entry or use the arrows to move it." : "Die Abschnitte erscheinen in dieser Reihenfolge. Ziehen Sie einen Eintrag oder verschieben Sie ihn mit den Pfeilen.",
-    "Using Attendance with a group? One license for the whole group costs less than {count} personal licenses." : "Sie nutzen Attendance mit einer Gruppe? Eine Lizenz für die ganze Gruppe kostet weniger als {count} persönliche Lizenzen."
+    "Using Attendance with a group? One license for the whole group costs less than {count} personal licenses." : "Sie nutzen Attendance mit einer Gruppe? Eine Lizenz für die ganze Gruppe kostet weniger als {count} persönliche Lizenzen.",
+    "Answer options" : "Antwortmöglichkeiten",
+    "Offer “Maybe” as an answer" : "„Vielleicht“ als Antwort anbieten",
+    "What every appointment offers unless its organizer decides otherwise." : "Gilt für jeden Termin, bei dem der Organisator es nicht anders festlegt.",
+    "Without “Maybe” people are left with a clear yes or no." : "Ohne „Vielleicht“ bleibt nur eine klare Zu- oder Absage."
 },
 "nplurals=2; plural=(n != 1);");

--- a/l10n/de_DE.js
+++ b/l10n/de_DE.js
@@ -979,6 +979,22 @@ OC.L10N.register(
     "Answer options" : "Antwortmöglichkeiten",
     "Offer “Maybe” as an answer" : "„Vielleicht“ als Antwort anbieten",
     "What every appointment offers unless its organizer decides otherwise." : "Gilt für jeden Termin, bei dem der Organisator es nicht anders festlegt.",
-    "Without “Maybe” people are left with a clear yes or no." : "Ohne „Vielleicht“ bleibt nur eine klare Zu- oder Absage."
+    "Without “Maybe” people are left with a clear yes or no." : "Ohne „Vielleicht“ bleibt nur eine klare Zu- oder Absage.",
+    "A spot came free for %1$s on %2$s" : "Ein Platz ist frei geworden: %1$s am %2$s",
+    "Attendance limit" : "Teilnahmelimit",
+    "Join waitlist" : "Auf die Warteliste",
+    "Maximum attendees" : "Maximale Teilnehmerzahl",
+    "No spot came free for %1$s on %2$s" : "Es ist kein Platz frei geworden: %1$s am %2$s",
+    "Offer a waitlist when full" : "Warteliste anbieten, wenn der Termin voll ist",
+    "Once that many people have said yes the appointment is full. Leave empty for no limit." : "Sobald so viele zugesagt haben, ist der Termin voll. Leer lassen für unbegrenzt.",
+    "Someone moved off the waitlist into a free spot" : "Jemand ist von der Warteliste auf einen frei gewordenen Platz nachgerückt",
+    "The appointment stayed full, so you no longer need to keep the date free. Thanks for answering." : "Der Termin ist voll geblieben, Sie müssen sich den Tag nicht mehr freihalten. Danke für Ihre Antwort.",
+    "This appointment is full." : "Dieser Termin ist voll.",
+    "This appointment is full. Join the waitlist to take the next free spot." : "Dieser Termin ist voll. Gehen Sie auf die Warteliste, um den nächsten frei werdenden Platz zu bekommen.",
+    "Waitlist" : "Warteliste",
+    "You are number {position} on the waitlist" : "Sie sind Nummer {position} auf der Warteliste",
+    "You are on the waitlist" : "Sie sind auf der Warteliste",
+    "You were on the waitlist and are in now. Please plan to be there." : "Sie waren auf der Warteliste und sind jetzt dabei. Bitte halten Sie sich den Termin frei.",
+    "{subject} moved off the waitlist into a free spot" : "{subject} ist von der Warteliste auf einen frei gewordenen Platz nachgerückt"
 },
 "nplurals=2; plural=(n != 1);");

--- a/l10n/de_DE.json
+++ b/l10n/de_DE.json
@@ -977,6 +977,22 @@
     "Answer options" : "Antwortmöglichkeiten",
     "Offer “Maybe” as an answer" : "„Vielleicht“ als Antwort anbieten",
     "What every appointment offers unless its organizer decides otherwise." : "Gilt für jeden Termin, bei dem der Organisator es nicht anders festlegt.",
-    "Without “Maybe” people are left with a clear yes or no." : "Ohne „Vielleicht“ bleibt nur eine klare Zu- oder Absage."
+    "Without “Maybe” people are left with a clear yes or no." : "Ohne „Vielleicht“ bleibt nur eine klare Zu- oder Absage.",
+    "A spot came free for %1$s on %2$s" : "Ein Platz ist frei geworden: %1$s am %2$s",
+    "Attendance limit" : "Teilnahmelimit",
+    "Join waitlist" : "Auf die Warteliste",
+    "Maximum attendees" : "Maximale Teilnehmerzahl",
+    "No spot came free for %1$s on %2$s" : "Es ist kein Platz frei geworden: %1$s am %2$s",
+    "Offer a waitlist when full" : "Warteliste anbieten, wenn der Termin voll ist",
+    "Once that many people have said yes the appointment is full. Leave empty for no limit." : "Sobald so viele zugesagt haben, ist der Termin voll. Leer lassen für unbegrenzt.",
+    "Someone moved off the waitlist into a free spot" : "Jemand ist von der Warteliste auf einen frei gewordenen Platz nachgerückt",
+    "The appointment stayed full, so you no longer need to keep the date free. Thanks for answering." : "Der Termin ist voll geblieben, Sie müssen sich den Tag nicht mehr freihalten. Danke für Ihre Antwort.",
+    "This appointment is full." : "Dieser Termin ist voll.",
+    "This appointment is full. Join the waitlist to take the next free spot." : "Dieser Termin ist voll. Gehen Sie auf die Warteliste, um den nächsten frei werdenden Platz zu bekommen.",
+    "Waitlist" : "Warteliste",
+    "You are number {position} on the waitlist" : "Sie sind Nummer {position} auf der Warteliste",
+    "You are on the waitlist" : "Sie sind auf der Warteliste",
+    "You were on the waitlist and are in now. Please plan to be there." : "Sie waren auf der Warteliste und sind jetzt dabei. Bitte halten Sie sich den Termin frei.",
+    "{subject} moved off the waitlist into a free spot" : "{subject} ist von der Warteliste auf einen frei gewordenen Platz nachgerückt"
 },"pluralForm" :"nplurals=2; plural=(n != 1);"
 }

--- a/l10n/de_DE.json
+++ b/l10n/de_DE.json
@@ -973,6 +973,10 @@
     "Move {name} up" : "{name} nach oben verschieben",
     "Move {name} down" : "{name} nach unten verschieben",
     "Sections appear in this order. Drag an entry or use the arrows to move it." : "Die Abschnitte erscheinen in dieser Reihenfolge. Ziehen Sie einen Eintrag oder verschieben Sie ihn mit den Pfeilen.",
-    "Using Attendance with a group? One license for the whole group costs less than {count} personal licenses." : "Sie nutzen Attendance mit einer Gruppe? Eine Lizenz für die ganze Gruppe kostet weniger als {count} persönliche Lizenzen."
+    "Using Attendance with a group? One license for the whole group costs less than {count} personal licenses." : "Sie nutzen Attendance mit einer Gruppe? Eine Lizenz für die ganze Gruppe kostet weniger als {count} persönliche Lizenzen.",
+    "Answer options" : "Antwortmöglichkeiten",
+    "Offer “Maybe” as an answer" : "„Vielleicht“ als Antwort anbieten",
+    "What every appointment offers unless its organizer decides otherwise." : "Gilt für jeden Termin, bei dem der Organisator es nicht anders festlegt.",
+    "Without “Maybe” people are left with a clear yes or no." : "Ohne „Vielleicht“ bleibt nur eine klare Zu- oder Absage."
 },"pluralForm" :"nplurals=2; plural=(n != 1);"
 }

--- a/lib/Audit/Verb.php
+++ b/lib/Audit/Verb.php
@@ -13,6 +13,8 @@ final class Verb {
 	public const RESPONSE_CHANGED = 'response.changed';
 	public const RESPONSE_RESCINDED = 'response.rescinded';
 	public const RESPONSE_COMMENT_UPDATED = 'response.comment_updated';
+	/** A freed spot let somebody in off the waitlist. Nobody clicked anything. */
+	public const WAITLIST_PROMOTED = 'waitlist.promoted';
 
 	public const CHECKIN_RECORDED = 'checkin.recorded';
 	public const CHECKIN_CHANGED = 'checkin.changed';
@@ -29,6 +31,7 @@ final class Verb {
 		self::RESPONSE_CHANGED,
 		self::RESPONSE_RESCINDED,
 		self::RESPONSE_COMMENT_UPDATED,
+		self::WAITLIST_PROMOTED,
 	];
 
 	public const ALL_CHECKIN = [
@@ -50,6 +53,7 @@ final class Verb {
 		self::RESPONSE_CHANGED,
 		self::RESPONSE_RESCINDED,
 		self::RESPONSE_COMMENT_UPDATED,
+		self::WAITLIST_PROMOTED,
 		self::CHECKIN_RECORDED,
 		self::CHECKIN_CHANGED,
 		self::APPOINTMENT_CREATED,

--- a/lib/Controller/AdminController.php
+++ b/lib/Controller/AdminController.php
@@ -160,6 +160,7 @@ class AdminController extends Controller {
 					'pushEnabled' => $this->configService->isPushEnabled(),
 					'mobileAppBannerEnabled' => $this->configService->isMobileAppBannerEnabled(),
 					'bookingEnabled' => $this->configService->isBookingEnabled(),
+					'allowMaybe' => $this->configService->isMaybeAllowed(),
 					'selfCheckinWindowMinutes' => $this->configService->getSelfCheckinWindowMinutes(),
 					'guestsApp' => [
 						'enabled' => $this->guestService->isGuestsAppEnabled(),
@@ -197,6 +198,7 @@ class AdminController extends Controller {
 	 * @param ?bool $pushEnabled Whether push notifications are enabled
 	 * @param ?bool $mobileAppBannerEnabled Whether the mobile app promotion banner is enabled
 	 * @param ?bool $bookingEnabled Whether the booking / planning feature is enabled
+	 * @param ?bool $allowMaybe Whether appointments offer "Maybe" where they have no override of their own
 	 * @param ?int $selfCheckinWindowMinutes Minutes before appointment start that self-check-in opens
 	 * @param ?bool $onboardingCompleted Whether the setup wizard has been walked to its end
 	 * @return DataResponse<Http::STATUS_OK, array<string, mixed>, array{}>|DataResponse<Http::STATUS_UNAUTHORIZED, array{error: string}, array{}>|DataResponse<Http::STATUS_FORBIDDEN, array{error: string}, array{}>|DataResponse<Http::STATUS_INTERNAL_SERVER_ERROR, array{error: string}, array{}>
@@ -215,6 +217,7 @@ class AdminController extends Controller {
 		?bool $pushEnabled = null,
 		?bool $mobileAppBannerEnabled = null,
 		?bool $bookingEnabled = null,
+		?bool $allowMaybe = null,
 		?int $selfCheckinWindowMinutes = null,
 		?bool $onboardingCompleted = null,
 	): DataResponse {
@@ -291,6 +294,10 @@ class AdminController extends Controller {
 
 			if ($bookingEnabled !== null) {
 				$this->configService->setBookingEnabled($bookingEnabled);
+			}
+
+			if ($allowMaybe !== null) {
+				$this->configService->setMaybeAllowed($allowMaybe);
 			}
 
 			if ($selfCheckinWindowMinutes !== null) {

--- a/lib/Controller/AppointmentController.php
+++ b/lib/Controller/AppointmentController.php
@@ -189,6 +189,7 @@ class AppointmentController extends Controller {
 	 * @param ?string $location Free-text location
 	 * @param ?int $categoryId Category ID
 	 * @param bool $createTalkRoom Open a Talk conversation with the scheduled people when the inquiry closes
+	 * @param ?bool $allowMaybe Offer "Maybe" as an answer; null follows the instance-wide default
 	 * @return DataResponse<Http::STATUS_CREATED, AttendanceAppointmentData, array{}>|DataResponse<Http::STATUS_BAD_REQUEST, array{error: string}, array{}>|DataResponse<Http::STATUS_UNAUTHORIZED, array{error: string}, array{}>|DataResponse<Http::STATUS_FORBIDDEN, array{error: string}, array{}>
 	 */
 	#[NoAdminRequired]
@@ -211,6 +212,7 @@ class AppointmentController extends Controller {
 		?string $location = null,
 		?int $categoryId = null,
 		bool $createTalkRoom = false,
+		?bool $allowMaybe = null,
 	): DataResponse {
 		$user = $this->userSession->getUser();
 		if (!$user) {
@@ -243,11 +245,12 @@ class AppointmentController extends Controller {
 				$location,
 				$categoryId,
 				$createTalkRoom,
+				$allowMaybe,
 			);
 
 			$this->addAttachmentsToAppointment($appointment->getId(), $attachments, $user->getUID());
 
-			return new DataResponse($appointment, Http::STATUS_CREATED);
+			return new DataResponse($this->appointmentService->serializeAppointment($appointment), Http::STATUS_CREATED);
 		} catch (\Exception $e) {
 			return new DataResponse(['error' => $e->getMessage()], 400);
 		}
@@ -302,6 +305,8 @@ class AppointmentController extends Controller {
 					$organizers === [] ? null : $organizers,
 					$data['location'] ?? null,
 					$data['categoryId'] ?? null,
+					false,
+					$data['allowMaybe'] ?? null,
 				);
 				$createdIds[] = $appointment->getId();
 				if ($firstAppointment === null) {
@@ -359,6 +364,7 @@ class AppointmentController extends Controller {
 	 * @param ?string $location Free-text location, applied identically to every affected sibling when scope is future/all
 	 * @param ?int $categoryId Category, applied identically to every affected sibling when scope is future/all
 	 * @param ?bool $createTalkRoom Open a Talk conversation when the inquiry closes, or null to leave unchanged
+	 * @param ?bool $allowMaybe Offer "Maybe" as an answer, or null to leave unchanged; applied identically to every affected sibling when scope is future/all
 	 * @return DataResponse<Http::STATUS_OK, AttendanceAppointmentData|list<AttendanceAppointmentData>, array{}>|DataResponse<Http::STATUS_BAD_REQUEST, array{error: string}, array{}>|DataResponse<Http::STATUS_UNAUTHORIZED, array{error: string}, array{}>|DataResponse<Http::STATUS_FORBIDDEN, array{error: string}, array{}>|DataResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>
 	 */
 	#[NoAdminRequired]
@@ -380,6 +386,7 @@ class AppointmentController extends Controller {
 		?string $location = null,
 		?int $categoryId = null,
 		?bool $createTalkRoom = null,
+		?bool $allowMaybe = null,
 	): DataResponse {
 		$user = $this->userSession->getUser();
 		if (!$user) {
@@ -399,6 +406,7 @@ class AppointmentController extends Controller {
 					$id, $scope, $name, $description, $startDatetime, $endDatetime,
 					$user->getUID(), $visibleUsers, $visibleGroups, $visibleTeams,
 					$deadlineUpdate, $organizers, $location, $categoryId, $createTalkRoom,
+					$allowMaybe,
 				);
 
 				// Sync attachments across all affected appointments
@@ -406,7 +414,10 @@ class AppointmentController extends Controller {
 					$this->syncAttachments($updated->getId(), $attachments, $user->getUID());
 				}
 
-				return new DataResponse($updatedAppointments);
+				return new DataResponse(array_map(
+					fn ($updated) => $this->appointmentService->serializeAppointment($updated),
+					$updatedAppointments,
+				));
 			}
 
 			// scope === 'single': detach from series if part of one, then update normally
@@ -415,20 +426,22 @@ class AppointmentController extends Controller {
 					$id, 'single', $name, $description, $startDatetime, $endDatetime,
 					$user->getUID(), $visibleUsers, $visibleGroups, $visibleTeams,
 					$deadlineUpdate, $organizers, $location, $categoryId, $createTalkRoom,
+					$allowMaybe,
 				);
 				$this->syncAttachments($id, $attachments, $user->getUID());
-				return new DataResponse($updatedAppointments[0]);
+				return new DataResponse($this->appointmentService->serializeAppointment($updatedAppointments[0]));
 			}
 
 			$appointment = $this->appointmentService->updateAppointment(
 				$id, $name, $description, $startDatetime, $endDatetime,
 				$user->getUID(), $visibleUsers, $visibleGroups, $visibleTeams,
 				$deadlineUpdate, $organizers, $location, $categoryId, $createTalkRoom,
+				$allowMaybe,
 			);
 
 			$this->syncAttachments($id, $attachments, $user->getUID());
 
-			return new DataResponse($appointment);
+			return new DataResponse($this->appointmentService->serializeAppointment($appointment));
 		} catch (\Exception $e) {
 			return new DataResponse(['error' => $e->getMessage()], 400);
 		}
@@ -460,7 +473,7 @@ class AppointmentController extends Controller {
 		}
 
 		$updated = $this->appointmentService->closeAppointment($id);
-		return new DataResponse($updated);
+		return new DataResponse($this->appointmentService->serializeAppointment($updated));
 	}
 
 	/**
@@ -484,7 +497,7 @@ class AppointmentController extends Controller {
 		}
 
 		$updated = $this->appointmentService->reopenAppointment($id);
-		return new DataResponse($updated);
+		return new DataResponse($this->appointmentService->serializeAppointment($updated));
 	}
 
 	/**
@@ -593,7 +606,7 @@ class AppointmentController extends Controller {
 		}
 
 		$updated = $this->appointmentService->cancelAppointment($id, $user->getUID());
-		return new DataResponse($updated);
+		return new DataResponse($this->appointmentService->serializeAppointment($updated));
 	}
 
 	/**
@@ -617,7 +630,7 @@ class AppointmentController extends Controller {
 		}
 
 		$updated = $this->appointmentService->uncancelAppointment($id, $user->getUID());
-		return new DataResponse($updated);
+		return new DataResponse($this->appointmentService->serializeAppointment($updated));
 	}
 
 	/**
@@ -1023,6 +1036,13 @@ class AppointmentController extends Controller {
 			// must hide the filter rather than send it blind.
 			'scheduledFilter' => true,
 			'remindMaybe' => true,
+			// Server understands the allowMaybe field on an appointment and
+			// rejects a "maybe" the appointment does not offer. Clients that do
+			// not see this flag keep showing all three buttons.
+			'responseOptions' => true,
+			// What an appointment offers when it has no opinion of its own.
+			// The appointment editor starts its switch here.
+			'allowMaybeDefault' => $this->configService->isMaybeAllowed(),
 			// Older servers reject response=null. Mobile clients gate the
 			// withdraw-response affordance on this flag.
 			'responseToggle' => true,

--- a/lib/Controller/AppointmentController.php
+++ b/lib/Controller/AppointmentController.php
@@ -190,6 +190,8 @@ class AppointmentController extends Controller {
 	 * @param ?int $categoryId Category ID
 	 * @param bool $createTalkRoom Open a Talk conversation with the scheduled people when the inquiry closes
 	 * @param ?bool $allowMaybe Offer "Maybe" as an answer; null follows the instance-wide default
+	 * @param ?int $maxAttendees Attendance limit; null or zero means no limit
+	 * @param bool $waitlistEnabled Whether a full appointment offers a place in line
 	 * @return DataResponse<Http::STATUS_CREATED, AttendanceAppointmentData, array{}>|DataResponse<Http::STATUS_BAD_REQUEST, array{error: string}, array{}>|DataResponse<Http::STATUS_UNAUTHORIZED, array{error: string}, array{}>|DataResponse<Http::STATUS_FORBIDDEN, array{error: string}, array{}>
 	 */
 	#[NoAdminRequired]
@@ -213,6 +215,8 @@ class AppointmentController extends Controller {
 		?int $categoryId = null,
 		bool $createTalkRoom = false,
 		?bool $allowMaybe = null,
+		?int $maxAttendees = null,
+		bool $waitlistEnabled = true,
 	): DataResponse {
 		$user = $this->userSession->getUser();
 		if (!$user) {
@@ -246,6 +250,8 @@ class AppointmentController extends Controller {
 				$categoryId,
 				$createTalkRoom,
 				$allowMaybe,
+				$maxAttendees,
+				$waitlistEnabled,
 			);
 
 			$this->addAttachmentsToAppointment($appointment->getId(), $attachments, $user->getUID());
@@ -307,6 +313,8 @@ class AppointmentController extends Controller {
 					$data['categoryId'] ?? null,
 					false,
 					$data['allowMaybe'] ?? null,
+					$data['maxAttendees'] ?? null,
+					$data['waitlistEnabled'] ?? true,
 				);
 				$createdIds[] = $appointment->getId();
 				if ($firstAppointment === null) {
@@ -365,6 +373,8 @@ class AppointmentController extends Controller {
 	 * @param ?int $categoryId Category, applied identically to every affected sibling when scope is future/all
 	 * @param ?bool $createTalkRoom Open a Talk conversation when the inquiry closes, or null to leave unchanged
 	 * @param ?bool $allowMaybe Offer "Maybe" as an answer, or null to leave unchanged; applied identically to every affected sibling when scope is future/all
+	 * @param ?int $maxAttendees Attendance limit; null or zero clears it, applied identically to every affected sibling when scope is future/all
+	 * @param ?bool $waitlistEnabled Whether a full appointment offers a place in line, or null to leave unchanged
 	 * @return DataResponse<Http::STATUS_OK, AttendanceAppointmentData|list<AttendanceAppointmentData>, array{}>|DataResponse<Http::STATUS_BAD_REQUEST, array{error: string}, array{}>|DataResponse<Http::STATUS_UNAUTHORIZED, array{error: string}, array{}>|DataResponse<Http::STATUS_FORBIDDEN, array{error: string}, array{}>|DataResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>
 	 */
 	#[NoAdminRequired]
@@ -387,6 +397,8 @@ class AppointmentController extends Controller {
 		?int $categoryId = null,
 		?bool $createTalkRoom = null,
 		?bool $allowMaybe = null,
+		?int $maxAttendees = null,
+		?bool $waitlistEnabled = null,
 	): DataResponse {
 		$user = $this->userSession->getUser();
 		if (!$user) {
@@ -406,7 +418,7 @@ class AppointmentController extends Controller {
 					$id, $scope, $name, $description, $startDatetime, $endDatetime,
 					$user->getUID(), $visibleUsers, $visibleGroups, $visibleTeams,
 					$deadlineUpdate, $organizers, $location, $categoryId, $createTalkRoom,
-					$allowMaybe,
+					$allowMaybe, $maxAttendees, $waitlistEnabled,
 				);
 
 				// Sync attachments across all affected appointments
@@ -426,7 +438,7 @@ class AppointmentController extends Controller {
 					$id, 'single', $name, $description, $startDatetime, $endDatetime,
 					$user->getUID(), $visibleUsers, $visibleGroups, $visibleTeams,
 					$deadlineUpdate, $organizers, $location, $categoryId, $createTalkRoom,
-					$allowMaybe,
+					$allowMaybe, $maxAttendees, $waitlistEnabled,
 				);
 				$this->syncAttachments($id, $attachments, $user->getUID());
 				return new DataResponse($this->appointmentService->serializeAppointment($updatedAppointments[0]));
@@ -436,7 +448,7 @@ class AppointmentController extends Controller {
 				$id, $name, $description, $startDatetime, $endDatetime,
 				$user->getUID(), $visibleUsers, $visibleGroups, $visibleTeams,
 				$deadlineUpdate, $organizers, $location, $categoryId, $createTalkRoom,
-				$allowMaybe,
+				$allowMaybe, $maxAttendees, $waitlistEnabled,
 			);
 
 			$this->syncAttachments($id, $attachments, $user->getUID());
@@ -815,12 +827,13 @@ class AppointmentController extends Controller {
 	 * @param int $id Appointment ID
 	 * @param ?string $response Response value: yes, no, maybe — or null to withdraw an existing response
 	 * @param string $comment Optional comment
+	 * @param bool $acceptWaitlist Take a place in line when the appointment is already full, instead of being turned away
 	 * @return DataResponse<Http::STATUS_OK, AttendanceResponseData, array{}>|DataResponse<Http::STATUS_BAD_REQUEST, array{error: string}, array{}>|DataResponse<Http::STATUS_UNAUTHORIZED, array{error: string}, array{}>
 	 */
 	#[NoAdminRequired]
 	#[NoCSRFRequired]
 	#[OpenAPI]
-	public function respond(int $id, ?string $response, string $comment = ''): DataResponse {
+	public function respond(int $id, ?string $response, string $comment = '', bool $acceptWaitlist = false): DataResponse {
 		$user = $this->userSession->getUser();
 		if (!$user) {
 			return new DataResponse(['error' => 'User not authenticated'], 401);
@@ -831,9 +844,13 @@ class AppointmentController extends Controller {
 				$id,
 				$user->getUID(),
 				$response,
-				$comment
+				$comment,
+				$acceptWaitlist
 			);
-			return new DataResponse($attendanceResponse);
+			return new DataResponse($this->appointmentService->serializeResponse(
+				$attendanceResponse,
+				$this->appointmentService->getAppointment($id),
+			));
 		} catch (\Exception $e) {
 			return new DataResponse(['error' => $e->getMessage()], 400);
 		}
@@ -875,7 +892,7 @@ class AppointmentController extends Controller {
 				$response,
 				$user->getUID()
 			);
-			return new DataResponse($attendanceResponse);
+			return new DataResponse($this->appointmentService->serializeResponse($attendanceResponse, $appointment));
 		} catch (\Exception $e) {
 			return new DataResponse(['error' => $e->getMessage()], 400);
 		}
@@ -1043,6 +1060,11 @@ class AppointmentController extends Controller {
 			// What an appointment offers when it has no opinion of its own.
 			// The appointment editor starts its switch here.
 			'allowMaybeDefault' => $this->configService->isMaybeAllowed(),
+			// Server understands maxAttendees/waitlistEnabled on an appointment,
+			// reports occupancy and isFull, and takes acceptWaitlist on respond.
+			// Clients without this flag show a plain "Yes" that a full
+			// appointment answers with 400.
+			'attendanceLimit' => true,
 			// Older servers reject response=null. Mobile clients gate the
 			// withdraw-response affordance on this flag.
 			'responseToggle' => true,

--- a/lib/Db/Appointment.php
+++ b/lib/Db/Appointment.php
@@ -59,6 +59,10 @@ use OCP\AppFramework\Db\Entity;
  * @method void setTalkRoomToken(?string $talkRoomToken)
  * @method bool|null getAllowMaybe()
  * @method void setAllowMaybe(?bool $allowMaybe)
+ * @method int|null getMaxAttendees()
+ * @method void setMaxAttendees(?int $maxAttendees)
+ * @method bool getWaitlistEnabled()
+ * @method void setWaitlistEnabled(bool $waitlistEnabled)
  */
 class Appointment extends Entity implements JsonSerializable {
 	use DatetimeFormatTrait;
@@ -87,6 +91,8 @@ class Appointment extends Entity implements JsonSerializable {
 	protected $createTalkRoom = false;
 	protected $talkRoomToken = null;
 	protected $allowMaybe = null;
+	protected $maxAttendees = null;
+	protected $waitlistEnabled = true;
 
 	public function __construct() {
 		$this->addType('id', 'integer');
@@ -115,6 +121,8 @@ class Appointment extends Entity implements JsonSerializable {
 		$this->addType('createTalkRoom', 'boolean');
 		$this->addType('talkRoomToken', 'string');
 		$this->addType('allowMaybe', 'boolean');
+		$this->addType('maxAttendees', 'integer');
+		$this->addType('waitlistEnabled', 'boolean');
 	}
 
 	public function jsonSerialize(): array {
@@ -148,6 +156,8 @@ class Appointment extends Entity implements JsonSerializable {
 			// Tri-state in the column, resolved against the instance default
 			// before it reaches a client — see AppointmentService::serializeAppointment().
 			'allowMaybe' => $this->getAllowMaybe(),
+			'maxAttendees' => $this->getMaxAttendees(),
+			'waitlistEnabled' => $this->getWaitlistEnabled(),
 		];
 	}
 

--- a/lib/Db/Appointment.php
+++ b/lib/Db/Appointment.php
@@ -57,6 +57,8 @@ use OCP\AppFramework\Db\Entity;
  * @method void setCreateTalkRoom(bool $createTalkRoom)
  * @method string|null getTalkRoomToken()
  * @method void setTalkRoomToken(?string $talkRoomToken)
+ * @method bool|null getAllowMaybe()
+ * @method void setAllowMaybe(?bool $allowMaybe)
  */
 class Appointment extends Entity implements JsonSerializable {
 	use DatetimeFormatTrait;
@@ -84,6 +86,7 @@ class Appointment extends Entity implements JsonSerializable {
 	protected $categoryId = null;
 	protected $createTalkRoom = false;
 	protected $talkRoomToken = null;
+	protected $allowMaybe = null;
 
 	public function __construct() {
 		$this->addType('id', 'integer');
@@ -111,6 +114,7 @@ class Appointment extends Entity implements JsonSerializable {
 		$this->addType('categoryId', 'integer');
 		$this->addType('createTalkRoom', 'boolean');
 		$this->addType('talkRoomToken', 'string');
+		$this->addType('allowMaybe', 'boolean');
 	}
 
 	public function jsonSerialize(): array {
@@ -141,6 +145,9 @@ class Appointment extends Entity implements JsonSerializable {
 			'categoryId' => $this->getCategoryId(),
 			'createTalkRoom' => $this->getCreateTalkRoom(),
 			'talkRoomToken' => $this->getTalkRoomToken(),
+			// Tri-state in the column, resolved against the instance default
+			// before it reaches a client — see AppointmentService::serializeAppointment().
+			'allowMaybe' => $this->getAllowMaybe(),
 		];
 	}
 

--- a/lib/Db/AttendanceResponse.php
+++ b/lib/Db/AttendanceResponse.php
@@ -38,6 +38,12 @@ use OCP\AppFramework\Db\Entity;
  * @method void setBookingNotifiedStatus(?string $bookingNotifiedStatus)
  * @method string|null getBookingNotifiedAt()
  * @method void setBookingNotifiedAt(?string $bookingNotifiedAt)
+ * @method string|null getSpotClaimedAt()
+ * @method void setSpotClaimedAt(?string $spotClaimedAt)
+ * @method string|null getWaitlistNotifiedStatus()
+ * @method void setWaitlistNotifiedStatus(?string $waitlistNotifiedStatus)
+ * @method string|null getWaitlistNotifiedAt()
+ * @method void setWaitlistNotifiedAt(?string $waitlistNotifiedAt)
  */
 class AttendanceResponse extends Entity implements JsonSerializable {
 	use DatetimeFormatTrait;
@@ -55,6 +61,9 @@ class AttendanceResponse extends Entity implements JsonSerializable {
 	protected $bookingStatus = null;
 	protected $bookingNotifiedStatus = null;
 	protected $bookingNotifiedAt = null;
+	protected $spotClaimedAt = null;
+	protected $waitlistNotifiedStatus = null;
+	protected $waitlistNotifiedAt = null;
 
 	public function __construct() {
 		$this->addType('id', 'integer');
@@ -72,6 +81,9 @@ class AttendanceResponse extends Entity implements JsonSerializable {
 		$this->addType('bookingStatus', 'string');
 		$this->addType('bookingNotifiedStatus', 'string');
 		$this->addType('bookingNotifiedAt', 'string');
+		$this->addType('spotClaimedAt', 'string');
+		$this->addType('waitlistNotifiedStatus', 'string');
+		$this->addType('waitlistNotifiedAt', 'string');
 	}
 
 	public function jsonSerialize(): array {

--- a/lib/Db/AttendanceResponseMapper.php
+++ b/lib/Db/AttendanceResponseMapper.php
@@ -74,6 +74,34 @@ class AttendanceResponseMapper extends QBMapper {
 	}
 
 	/**
+	 * The yes-responses of one appointment in the order they claimed their spot.
+	 *
+	 * This is the attendance queue an capacity limit slices: the first
+	 * max_attendees hold a place, the rest are waiting. spot_claimed_at is set
+	 * whenever a response becomes a yes and cleared when it stops being one, so
+	 * every row here has one — Version000024 seeded the rows that predate it.
+	 * Two claims within the same second fall back to insertion order.
+	 *
+	 * @return list<AttendanceResponse>
+	 */
+	public function findClaimedSpots(int $appointmentId): array {
+		$qb = $this->db->getQueryBuilder();
+
+		$qb->select('*')
+			->from($this->getTableName())
+			->where(
+				$qb->expr()->eq('appointment_id', $qb->createNamedParameter($appointmentId, IQueryBuilder::PARAM_INT))
+			)
+			->andWhere(
+				$qb->expr()->eq('response', $qb->createNamedParameter('yes'))
+			)
+			->orderBy('spot_claimed_at', 'ASC')
+			->addOrderBy('id', 'ASC');
+
+		return $this->findEntities($qb);
+	}
+
+	/**
 	 * The few columns the statistics evaluate, for a set of appointments, in
 	 * one query. Deliberately not entities: at the 1000-appointment cap this
 	 * can be hundreds of thousands of rows, and hydrating all 15 columns of

--- a/lib/Migration/Version000023Date20260903120000.php
+++ b/lib/Migration/Version000023Date20260903120000.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\Attendance\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * Per-appointment override for the "Maybe" answer.
+ *
+ * Tri-state on purpose: NULL follows the instance-wide default, so flipping
+ * that setting reaches every appointment nobody has decided about. Nullable
+ * and additive, so older mobile clients keep working.
+ */
+final class Version000023Date20260903120000 extends SimpleMigrationStep {
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 */
+	#[\Override]
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+		if (!$schema->hasTable('att_appointments')) {
+			return null;
+		}
+
+		$table = $schema->getTable('att_appointments');
+
+		if (!$table->hasColumn('allow_maybe')) {
+			$table->addColumn('allow_maybe', 'boolean', [
+				'notnull' => false,
+				'default' => null,
+			]);
+		}
+
+		return $schema;
+	}
+}

--- a/lib/Migration/Version000024Date20260903130000.php
+++ b/lib/Migration/Version000024Date20260903130000.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\Attendance\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\IDBConnection;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * Attendance limit with an optional waitlist.
+ *
+ * Who holds a spot is derived, not stored: the yes-responses ordered by
+ * spot_claimed_at, the first max_attendees of them in, the rest waiting. That
+ * keeps the queue from drifting away from the answers it is built out of, and
+ * makes promotion a consequence of somebody leaving rather than a write of its
+ * own. spot_claimed_at is set when a response becomes a yes and cleared when it
+ * stops being one, so re-answering yes goes to the back of the queue.
+ *
+ * All columns nullable and additive, so older mobile clients keep working.
+ */
+final class Version000024Date20260903130000 extends SimpleMigrationStep {
+	public function __construct(
+		private IDBConnection $db,
+	) {
+	}
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 */
+	#[\Override]
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		if ($schema->hasTable('att_appointments')) {
+			$table = $schema->getTable('att_appointments');
+
+			if (!$table->hasColumn('max_attendees')) {
+				$table->addColumn('max_attendees', 'integer', [
+					'notnull' => false,
+					'default' => null,
+				]);
+			}
+
+			if (!$table->hasColumn('waitlist_enabled')) {
+				$table->addColumn('waitlist_enabled', 'boolean', [
+					'notnull' => false,
+					'default' => true,
+				]);
+			}
+		}
+
+		if ($schema->hasTable('att_responses')) {
+			$table = $schema->getTable('att_responses');
+
+			if (!$table->hasColumn('spot_claimed_at')) {
+				$table->addColumn('spot_claimed_at', 'datetime', [
+					'notnull' => false,
+					'default' => null,
+				]);
+			}
+
+			// Same shape as booking_notified_*: a spot that frees up and fills
+			// again must not notify the same person twice.
+			if (!$table->hasColumn('waitlist_notified_status')) {
+				$table->addColumn('waitlist_notified_status', 'string', [
+					'notnull' => false,
+					'length' => 32,
+				]);
+			}
+
+			if (!$table->hasColumn('waitlist_notified_at')) {
+				$table->addColumn('waitlist_notified_at', 'datetime', [
+					'notnull' => false,
+					'default' => null,
+				]);
+			}
+		}
+
+		return $schema;
+	}
+
+	/**
+	 * Existing yes-responses need an ordering key, or an organizer who sets a
+	 * limit on a running appointment would find everybody tied for last place.
+	 * When they answered is the fairest thing on record.
+	 *
+	 * Guarded on IS NULL, so a re-run after a failed update is a no-op and a
+	 * later claim is never overwritten.
+	 */
+	#[\Override]
+	public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void {
+		$schema = $schemaClosure();
+		if (!$schema->hasTable('att_responses')) {
+			return;
+		}
+
+		$qb = $this->db->getQueryBuilder();
+		$qb->update('att_responses')
+			->set('spot_claimed_at', $qb->createFunction('responded_at'))
+			->where($qb->expr()->eq('response', $qb->createNamedParameter('yes')))
+			->andWhere($qb->expr()->isNull('spot_claimed_at'));
+
+		$updated = $qb->executeStatement();
+		$output->info("Seeded {$updated} existing yes-responses with a spot-claim time.");
+	}
+}

--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace OCA\Attendance\Notification;
 
+use OCA\Attendance\Db\AppointmentMapper;
 use OCA\Attendance\Db\AttendanceResponseMapper;
 use OCA\Attendance\Service\QuickResponseTokenService;
+use OCA\Attendance\Service\ResponsePolicyService;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\IConfig;
 use OCP\IURLGenerator;
@@ -23,6 +25,8 @@ class Notifier implements INotifier {
 	private QuickResponseTokenService $tokenService;
 	private IConfig $config;
 	private AttendanceResponseMapper $responseMapper;
+	private AppointmentMapper $appointmentMapper;
+	private ResponsePolicyService $responsePolicyService;
 	private IUserManager $userManager;
 
 	public function __construct(
@@ -32,12 +36,16 @@ class Notifier implements INotifier {
 		IConfig $config,
 		AttendanceResponseMapper $responseMapper,
 		IUserManager $userManager,
+		AppointmentMapper $appointmentMapper,
+		ResponsePolicyService $responsePolicyService,
 	) {
 		$this->l10nFactory = $l10nFactory;
 		$this->urlGenerator = $urlGenerator;
 		$this->tokenService = $tokenService;
 		$this->config = $config;
 		$this->responseMapper = $responseMapper;
+		$this->appointmentMapper = $appointmentMapper;
+		$this->responsePolicyService = $responsePolicyService;
 		$this->userManager = $userManager;
 	}
 
@@ -438,6 +446,21 @@ class Notifier implements INotifier {
 	}
 
 	/**
+	 * Whether this appointment still offers "Maybe". A notification can outlive
+	 * the appointment it points at, and an unknown one keeps all three buttons
+	 * rather than silently dropping one.
+	 */
+	private function isMaybeOffered(int $appointmentId): bool {
+		try {
+			return $this->responsePolicyService->isMaybeAllowed(
+				$this->appointmentMapper->find($appointmentId),
+			);
+		} catch (\Throwable $e) {
+			return true;
+		}
+	}
+
+	/**
 	 * Add quick response action buttons to a notification.
 	 *
 	 * @param INotification $notification The notification to add actions to
@@ -463,16 +486,19 @@ class Notifier implements INotifier {
 			->setPrimary(false);
 		$notification->addParsedAction($noAction);
 
-		// Maybe action (added second, displays middle)
-		$maybeAction = $notification->createAction();
-		$maybeAction->setLabel('maybe')
-			->setParsedLabel($l->t('Maybe'))
-			->setLink(
-				$this->tokenService->generateQuickResponseUrl($userId, $appointmentId, 'maybe'),
-				IAction::TYPE_WEB
-			)
-			->setPrimary(false);
-		$notification->addParsedAction($maybeAction);
+		// Maybe action (added second, displays middle). Left out where the
+		// appointment does not offer it — the link would only ever 400.
+		if ($this->isMaybeOffered($appointmentId)) {
+			$maybeAction = $notification->createAction();
+			$maybeAction->setLabel('maybe')
+				->setParsedLabel($l->t('Maybe'))
+				->setLink(
+					$this->tokenService->generateQuickResponseUrl($userId, $appointmentId, 'maybe'),
+					IAction::TYPE_WEB
+				)
+				->setPrimary(false);
+			$notification->addParsedAction($maybeAction);
+		}
 
 		// Yes action (added last, displays first/left)
 		$yesAction = $notification->createAction();

--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -241,6 +241,37 @@ class Notifier implements INotifier {
 					$this->urlGenerator->imagePath('attendance', 'app-dark.svg')
 				));
 				return $notification;
+			case 'waitlist_promoted':
+			case 'waitlist_not_promoted':
+				$parameters = $notification->getSubjectParameters();
+				$appointmentName = (string)($parameters['name'] ?? 'Unknown');
+				$appointmentDate = $this->formatDateForUser(
+					(string)($parameters['startDatetime'] ?? $parameters['date'] ?? ''),
+					$notification->getUser()
+				);
+				if ($notification->getSubject() === 'waitlist_promoted') {
+					$notification->setParsedSubject(
+						// TRANSLATORS Push notification subject: the appointment was full when the person answered, a spot has now come free and they have it. %1$s is the appointment name, %2$s the date.
+						$l->t('A spot came free for %1$s on %2$s', [$appointmentName, $appointmentDate])
+					);
+					$notification->setParsedMessage(
+						// TRANSLATORS Push notification body, shown under a subject that already says a spot came free. Nobody clicked anything to make this happen — the person was waiting and moved up — so say plainly that they are in now. Sample German: "Du warst auf der Warteliste und bist jetzt dabei. Bitte halte dir den Termin frei."
+						$l->t('You were on the waitlist and are in now. Please plan to be there.')
+					);
+				} else {
+					$notification->setParsedSubject(
+						// TRANSLATORS Push notification subject: the appointment closed while the person was still waiting for a spot. %1$s is the appointment name, %2$s the date.
+						$l->t('No spot came free for %1$s on %2$s', [$appointmentName, $appointmentDate])
+					);
+					$notification->setParsedMessage(
+						// TRANSLATORS Push notification body, shown under a subject that already says no spot came free. The point is to release the person from holding the date — without this they keep the evening free for nothing. The app speaks as "we", the people organizing. Sample German: "Der Termin ist voll geblieben, du musst dir den Tag nicht mehr freihalten. Danke für deine Antwort."
+						$l->t('The appointment stayed full, so you no longer need to keep the date free. Thanks for answering.')
+					);
+				}
+				$notification->setIcon($this->urlGenerator->getAbsoluteURL(
+					$this->urlGenerator->imagePath('attendance', 'app-dark.svg')
+				));
+				return $notification;
 			case 'response_submitted':
 			case 'response_changed':
 			case 'response_rescinded':

--- a/lib/ResponseDefinitions.php
+++ b/lib/ResponseDefinitions.php
@@ -31,6 +31,7 @@ namespace OCA\Attendance;
  *   categoryId: ?int,
  *   createTalkRoom: bool,
  *   talkRoomToken: ?string,
+ *   allowMaybe: bool,
  * }
  * @psalm-type AttendanceMyPermissions = array{
  *   isOrganizer: bool,
@@ -145,6 +146,7 @@ namespace OCA\Attendance;
  *   responseDeadline?: string,
  *   location?: string,
  *   categoryId?: int,
+ *   allowMaybe?: bool,
  * }
  * @psalm-type AttendanceCategoryData = array{
  *   id: int,
@@ -178,6 +180,8 @@ namespace OCA\Attendance;
  *   bookingEnabled: bool,
  *   scheduledFilter: bool,
  *   remindMaybe: bool,
+ *   responseOptions: bool,
+ *   allowMaybeDefault: bool,
  *   responseToggle: bool,
  *   guestInvitation: bool,
  *   auditLog: bool,
@@ -258,6 +262,7 @@ namespace OCA\Attendance;
  *   pushEnabled: bool,
  *   mobileAppBannerEnabled: bool,
  *   bookingEnabled: bool,
+ *   allowMaybe: bool,
  *   selfCheckinWindowMinutes: int,
  *   guestsApp: AttendanceGuestsAppStatus,
  * }

--- a/lib/ResponseDefinitions.php
+++ b/lib/ResponseDefinitions.php
@@ -32,6 +32,10 @@ namespace OCA\Attendance;
  *   createTalkRoom: bool,
  *   talkRoomToken: ?string,
  *   allowMaybe: bool,
+ *   maxAttendees: ?int,
+ *   waitlistEnabled: bool,
+ *   occupancy: int,
+ *   isFull: bool,
  * }
  * @psalm-type AttendanceMyPermissions = array{
  *   isOrganizer: bool,
@@ -56,6 +60,8 @@ namespace OCA\Attendance;
  *   responseSource: ?string,
  *   checkinSource: ?string,
  *   bookingStatus: ?string,
+ *   waitlisted: bool,
+ *   waitlistPosition: ?int,
  * }
  * @psalm-type AttendanceResponseWithUser = array{
  *   id: int,
@@ -75,6 +81,7 @@ namespace OCA\Attendance;
  *   userName: string,
  *   userGroups: list<string>,
  *   isGuest: bool,
+ *   waitlisted: bool,
  * }
  * @psalm-type AttendanceGuestsAppStatus = array{
  *   enabled: bool,
@@ -147,6 +154,8 @@ namespace OCA\Attendance;
  *   location?: string,
  *   categoryId?: int,
  *   allowMaybe?: bool,
+ *   maxAttendees?: int,
+ *   waitlistEnabled?: bool,
  * }
  * @psalm-type AttendanceCategoryData = array{
  *   id: int,
@@ -182,6 +191,7 @@ namespace OCA\Attendance;
  *   remindMaybe: bool,
  *   responseOptions: bool,
  *   allowMaybeDefault: bool,
+ *   attendanceLimit: bool,
  *   responseToggle: bool,
  *   guestInvitation: bool,
  *   auditLog: bool,

--- a/lib/Service/AppointmentSerializer.php
+++ b/lib/Service/AppointmentSerializer.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\Attendance\Service;
+
+use OCA\Attendance\Db\Appointment;
+
+/**
+ * The appointment payload every client sees.
+ *
+ * The entity cannot build it alone: whether "Maybe" is offered depends on the
+ * instance default and on whether the appointment has a limit, and occupancy is
+ * derived from the queue. Both the appointment endpoints and the check-in view
+ * hand out this shape, so it lives here rather than in either of them.
+ */
+class AppointmentSerializer {
+	public function __construct(
+		private ResponsePolicyService $responsePolicyService,
+		private CapacityService $capacityService,
+	) {
+	}
+
+	/**
+	 * @return array<string, mixed>
+	 */
+	public function serialize(Appointment $appointment): array {
+		/** @var array<string, mixed> $data */
+		$data = $appointment->jsonSerialize();
+		$data['allowMaybe'] = $this->responsePolicyService->isMaybeAllowed($appointment);
+		// Only an appointment with a limit pays for the queue query, which is
+		// why every reader asks limitOf() first. Without one there is nothing to
+		// count and nothing that can be full.
+		$hasLimit = $this->capacityService->limitOf($appointment) !== null;
+		$data['occupancy'] = $hasLimit ? $this->capacityService->occupancy($appointment) : 0;
+		$data['isFull'] = $hasLimit && $this->capacityService->isFull($appointment);
+		return $data;
+	}
+}

--- a/lib/Service/AppointmentService.php
+++ b/lib/Service/AppointmentService.php
@@ -52,6 +52,7 @@ class AppointmentService {
 	private OrgCalendarSyncService $orgCalendarSyncService;
 	private CategoryMapper $categoryMapper;
 	private TalkRoomService $talkRoomService;
+	private ResponsePolicyService $responsePolicyService;
 	/** @var array<string, bool> per-request cache for isOrganizerAnywhere() */
 	private array $organizerAnywhereCache = [];
 
@@ -74,6 +75,7 @@ class AppointmentService {
 		OrgCalendarSyncService $orgCalendarSyncService,
 		CategoryMapper $categoryMapper,
 		TalkRoomService $talkRoomService,
+		ResponsePolicyService $responsePolicyService,
 	) {
 		$this->appointmentMapper = $appointmentMapper;
 		$this->responseMapper = $responseMapper;
@@ -93,6 +95,7 @@ class AppointmentService {
 		$this->orgCalendarSyncService = $orgCalendarSyncService;
 		$this->categoryMapper = $categoryMapper;
 		$this->talkRoomService = $talkRoomService;
+		$this->responsePolicyService = $responsePolicyService;
 	}
 
 	/**
@@ -117,6 +120,7 @@ class AppointmentService {
 		?string $location = null,
 		?int $categoryId = null,
 		bool $createTalkRoom = false,
+		?bool $allowMaybe = null,
 	): Appointment {
 		$this->validateDateRange($startDatetime, $endDatetime);
 
@@ -147,6 +151,9 @@ class AppointmentService {
 		$appointment->setSeriesPosition($seriesPosition);
 		$appointment->setSendNotification($sendNotification);
 		$appointment->setCreateTalkRoom($createTalkRoom);
+		// NULL is a real state here: the appointment has no opinion on "Maybe"
+		// and follows whatever the instance default says, now and later.
+		$appointment->setAllowMaybe($allowMaybe);
 		$appointment->setResponseDeadline($deadlineFormatted);
 		// The creator freely chooses the initial organizer list; when the client
 		// sends nothing, the creator becomes the sole organizer.
@@ -201,6 +208,7 @@ class AppointmentService {
 		?string $location = null,
 		?int $categoryId = null,
 		?bool $createTalkRoom = null,
+		?bool $allowMaybe = null,
 	): Appointment {
 		$appointment = $this->appointmentMapper->find($id);
 
@@ -242,6 +250,13 @@ class AppointmentService {
 
 		if ($createTalkRoom !== null) {
 			$appointment->setCreateTalkRoom($createTalkRoom);
+		}
+
+		// Unlike the column, the parameter has no tri-state: null means the
+		// caller left the field alone. Deciding is one-way — an appointment that
+		// has an answer keeps it rather than falling back to the default.
+		if ($allowMaybe !== null) {
+			$appointment->setAllowMaybe($allowMaybe);
 		}
 
 		$updated = $this->appointmentMapper->update($appointment);
@@ -617,6 +632,7 @@ class AppointmentService {
 	 * @param ?list<string> $organizers New organizer list, or null to leave unchanged
 	 * @param ?string $location Location, applied identically to every affected sibling
 	 * @param ?int $categoryId Category, applied identically to every affected sibling
+	 * @param ?bool $allowMaybe Whether "Maybe" is offered, applied identically to every affected sibling; null leaves it alone
 	 * @return list<Appointment> Updated appointments
 	 */
 	public function updateSeriesAppointments(
@@ -635,6 +651,7 @@ class AppointmentService {
 		?string $location = null,
 		?int $categoryId = null,
 		?bool $createTalkRoom = null,
+		?bool $allowMaybe = null,
 	): array {
 		$deadlineUpdate ??= DeadlineUpdate::unchanged();
 		$reference = $this->appointmentMapper->find($referenceId);
@@ -648,6 +665,7 @@ class AppointmentService {
 				$referenceId, $name, $description, $startDatetime, $endDatetime,
 				$userId, $visibleUsers, $visibleGroups, $visibleTeams,
 				$deadlineUpdate, $organizers, $location, $categoryId, $createTalkRoom,
+				$allowMaybe,
 			);
 			return [$updated];
 		}
@@ -659,6 +677,7 @@ class AppointmentService {
 				$referenceId, $name, $description, $startDatetime, $endDatetime,
 				$userId, $visibleUsers, $visibleGroups, $visibleTeams,
 				$deadlineUpdate, $organizers, $location, $categoryId, $createTalkRoom,
+				$allowMaybe,
 			);
 			return [$updated];
 		}
@@ -720,6 +739,9 @@ class AppointmentService {
 			$sibling->setCategoryId($categoryIdValue);
 			if ($createTalkRoom !== null) {
 				$sibling->setCreateTalkRoom($createTalkRoom);
+			}
+			if ($allowMaybe !== null) {
+				$sibling->setAllowMaybe($allowMaybe);
 			}
 
 			// Apply time deltas
@@ -949,7 +971,7 @@ class AppointmentService {
 			$includeResponseCounts,
 		);
 
-		$appointmentData = $appointment->jsonSerialize();
+		$appointmentData = $this->serializeAppointment($appointment);
 		$appointmentData = $this->enrichVisibilityData($appointmentData);
 		$appointmentData = $this->enrichSeriesCount($appointmentData, $appointment);
 		// Only expose userResponse when the user actually answered yes/no/maybe.
@@ -1217,6 +1239,10 @@ class AppointmentService {
 	): AttendanceResponse {
 		$appointmentId = $appointment->getId();
 
+		// Same guard ResponseService::submitResponse() runs for quick-response
+		// links, so neither path can accept an answer the other rejects.
+		$this->responsePolicyService->assertResponseAllowed($appointment, $response);
+
 		if ($appointment->isClosed()) {
 			throw new \RuntimeException('This appointment is closed and no longer accepts responses.');
 		}
@@ -1481,7 +1507,7 @@ class AppointmentService {
 				$includeResponseCounts,
 			);
 
-			$appointmentData = $appointment->jsonSerialize();
+			$appointmentData = $this->serializeAppointment($appointment);
 			$appointmentData = $this->enrichVisibilityData($appointmentData);
 			$appointmentData = $this->enrichSeriesCount($appointmentData, $appointment);
 			$appointmentData['userResponse'] = $this->serializeUserResponse($userResponse);
@@ -1523,7 +1549,7 @@ class AppointmentService {
 				continue;
 			}
 
-			$appointmentData = $appointment->jsonSerialize();
+			$appointmentData = $this->serializeAppointment($appointment);
 			$appointmentData = $this->enrichVisibilityData($appointmentData);
 			$userResponse = $this->getUserResponse($appointment->getId(), $userId);
 			$appointmentData['userResponse'] = $this->serializeUserResponse($userResponse);
@@ -1808,6 +1834,20 @@ class AppointmentService {
 		}
 
 		return array_unique($userIds);
+	}
+
+	/**
+	 * The appointment as a client sees it. The entity cannot resolve allowMaybe
+	 * on its own — the tri-state column has to be read against the instance
+	 * default — so payloads go through here instead of jsonSerialize().
+	 *
+	 * @return array<string, mixed>
+	 */
+	public function serializeAppointment(Appointment $appointment): array {
+		/** @var array<string, mixed> $data */
+		$data = $appointment->jsonSerialize();
+		$data['allowMaybe'] = $this->responsePolicyService->isMaybeAllowed($appointment);
+		return $data;
 	}
 
 	/**

--- a/lib/Service/AppointmentService.php
+++ b/lib/Service/AppointmentService.php
@@ -53,6 +53,8 @@ class AppointmentService {
 	private CategoryMapper $categoryMapper;
 	private TalkRoomService $talkRoomService;
 	private ResponsePolicyService $responsePolicyService;
+	private CapacityService $capacityService;
+	private AppointmentSerializer $appointmentSerializer;
 	/** @var array<string, bool> per-request cache for isOrganizerAnywhere() */
 	private array $organizerAnywhereCache = [];
 
@@ -76,6 +78,8 @@ class AppointmentService {
 		CategoryMapper $categoryMapper,
 		TalkRoomService $talkRoomService,
 		ResponsePolicyService $responsePolicyService,
+		CapacityService $capacityService,
+		AppointmentSerializer $appointmentSerializer,
 	) {
 		$this->appointmentMapper = $appointmentMapper;
 		$this->responseMapper = $responseMapper;
@@ -96,6 +100,8 @@ class AppointmentService {
 		$this->categoryMapper = $categoryMapper;
 		$this->talkRoomService = $talkRoomService;
 		$this->responsePolicyService = $responsePolicyService;
+		$this->capacityService = $capacityService;
+		$this->appointmentSerializer = $appointmentSerializer;
 	}
 
 	/**
@@ -121,6 +127,8 @@ class AppointmentService {
 		?int $categoryId = null,
 		bool $createTalkRoom = false,
 		?bool $allowMaybe = null,
+		?int $maxAttendees = null,
+		bool $waitlistEnabled = true,
 	): Appointment {
 		$this->validateDateRange($startDatetime, $endDatetime);
 
@@ -154,6 +162,8 @@ class AppointmentService {
 		// NULL is a real state here: the appointment has no opinion on "Maybe"
 		// and follows whatever the instance default says, now and later.
 		$appointment->setAllowMaybe($allowMaybe);
+		$appointment->setMaxAttendees($this->normalizeAttendeeLimit($maxAttendees));
+		$appointment->setWaitlistEnabled($waitlistEnabled);
 		$appointment->setResponseDeadline($deadlineFormatted);
 		// The creator freely chooses the initial organizer list; when the client
 		// sends nothing, the creator becomes the sole organizer.
@@ -209,6 +219,8 @@ class AppointmentService {
 		?int $categoryId = null,
 		?bool $createTalkRoom = null,
 		?bool $allowMaybe = null,
+		?int $maxAttendees = null,
+		?bool $waitlistEnabled = null,
 	): Appointment {
 		$appointment = $this->appointmentMapper->find($id);
 
@@ -259,7 +271,19 @@ class AppointmentService {
 			$appointment->setAllowMaybe($allowMaybe);
 		}
 
+		// Zero and null both mean "no limit", so the field clears itself; there
+		// is no separate way to say "leave it alone". Lowering it below what is
+		// already taken is allowed and demotes nobody — the appointment simply
+		// sits over capacity until people drop out.
+		$appointment->setMaxAttendees($this->normalizeAttendeeLimit($maxAttendees));
+		if ($waitlistEnabled !== null) {
+			$appointment->setWaitlistEnabled($waitlistEnabled);
+		}
+
 		$updated = $this->appointmentMapper->update($appointment);
+
+		// A raised limit lets the next people in line through.
+		$this->capacityService->syncWaitlistNotifications($updated);
 
 		$this->notifyAboutUpdate($before, $updated, $this->commitAppointmentChange($before, $updated), $userId);
 
@@ -497,6 +521,10 @@ class AppointmentService {
 		// (only diffs against the last communicated state).
 		$this->bookingService->notifyOnClose($updated);
 
+		// Anyone still in line keeps the date free for a spot that is no longer
+		// coming. Same fire-once marker as the promotions.
+		$this->capacityService->notifyNotPromoted($updated);
+
 		$this->talkRoomService->openOrSync($updated);
 
 		return $updated;
@@ -633,6 +661,8 @@ class AppointmentService {
 	 * @param ?string $location Location, applied identically to every affected sibling
 	 * @param ?int $categoryId Category, applied identically to every affected sibling
 	 * @param ?bool $allowMaybe Whether "Maybe" is offered, applied identically to every affected sibling; null leaves it alone
+	 * @param ?int $maxAttendees Attendance limit, applied identically to every affected sibling; null clears it
+	 * @param ?bool $waitlistEnabled Whether a full sibling offers a waitlist; null leaves it alone
 	 * @return list<Appointment> Updated appointments
 	 */
 	public function updateSeriesAppointments(
@@ -652,6 +682,8 @@ class AppointmentService {
 		?int $categoryId = null,
 		?bool $createTalkRoom = null,
 		?bool $allowMaybe = null,
+		?int $maxAttendees = null,
+		?bool $waitlistEnabled = null,
 	): array {
 		$deadlineUpdate ??= DeadlineUpdate::unchanged();
 		$reference = $this->appointmentMapper->find($referenceId);
@@ -665,7 +697,7 @@ class AppointmentService {
 				$referenceId, $name, $description, $startDatetime, $endDatetime,
 				$userId, $visibleUsers, $visibleGroups, $visibleTeams,
 				$deadlineUpdate, $organizers, $location, $categoryId, $createTalkRoom,
-				$allowMaybe,
+				$allowMaybe, $maxAttendees, $waitlistEnabled,
 			);
 			return [$updated];
 		}
@@ -677,7 +709,7 @@ class AppointmentService {
 				$referenceId, $name, $description, $startDatetime, $endDatetime,
 				$userId, $visibleUsers, $visibleGroups, $visibleTeams,
 				$deadlineUpdate, $organizers, $location, $categoryId, $createTalkRoom,
-				$allowMaybe,
+				$allowMaybe, $maxAttendees, $waitlistEnabled,
 			);
 			return [$updated];
 		}
@@ -743,6 +775,10 @@ class AppointmentService {
 			if ($allowMaybe !== null) {
 				$sibling->setAllowMaybe($allowMaybe);
 			}
+			$sibling->setMaxAttendees($this->normalizeAttendeeLimit($maxAttendees));
+			if ($waitlistEnabled !== null) {
+				$sibling->setWaitlistEnabled($waitlistEnabled);
+			}
 
 			// Apply time deltas
 			$siblingStart = new \DateTime($sibling->getStartDatetime(), new \DateTimeZone('UTC'));
@@ -774,6 +810,7 @@ class AppointmentService {
 			}
 
 			$updatedSibling = $this->appointmentMapper->update($sibling);
+			$this->capacityService->syncWaitlistNotifications($updatedSibling);
 			$edits[] = [
 				'before' => $before,
 				'after' => $updatedSibling,
@@ -978,7 +1015,7 @@ class AppointmentService {
 		// A row with response=NULL exists when an admin checked the user in
 		// before they ever responded; treat that as "no response" (matches list endpoint).
 		$userResponse = $this->getUserResponse($appointment->getId(), $userId);
-		$appointmentData['userResponse'] = $this->serializeUserResponse($userResponse);
+		$appointmentData['userResponse'] = $this->serializeUserResponse($userResponse, $appointment);
 		$responseSummary = $this->buildResponseSummaryFor($myPermissions, $appointment->getId());
 		if ($responseSummary !== null) {
 			$appointmentData['responseSummary'] = $responseSummary;
@@ -1070,13 +1107,28 @@ class AppointmentService {
 	 *
 	 * @return array<string, mixed>|null
 	 */
-	private function serializeUserResponse(?AttendanceResponse $userResponse): ?array {
+	private function serializeUserResponse(?AttendanceResponse $userResponse, ?Appointment $appointment = null): ?array {
 		if ($userResponse === null || $userResponse->getResponse() === null) {
 			return null;
 		}
-		$data = $userResponse->jsonSerialize();
-		$data['bookingStatus'] = $this->bookingService->effectiveBookingStatus($userResponse);
-		return $data;
+		return $this->serializeResponse($userResponse, $appointment);
+	}
+
+	/**
+	 * A response as a client sees it: the row, the scheduling verdict, and
+	 * whether this yes holds a spot or a place in line. The standing is derived,
+	 * so it moves on its own as other people change their answers.
+	 *
+	 * @return array<string, mixed>
+	 */
+	public function serializeResponse(AttendanceResponse $response, ?Appointment $appointment = null): array {
+		/** @var array<string, mixed> $data */
+		$data = $response->jsonSerialize();
+		$data['bookingStatus'] = $this->bookingService->effectiveBookingStatus($response);
+		$standing = $appointment === null
+			? ['waitlisted' => false, 'waitlistPosition' => null]
+			: $this->capacityService->standingOf($appointment, $response->getUserId());
+		return $data + $standing;
 	}
 
 	/**
@@ -1148,6 +1200,7 @@ class AppointmentService {
 		string $userId,
 		?string $response,
 		string $comment = '',
+		bool $acceptWaitlist = false,
 	): AttendanceResponse {
 		$this->validateResponseValue($response);
 
@@ -1165,6 +1218,7 @@ class AppointmentService {
 			null,
 			\OCA\Attendance\Audit\Verb::SOURCE_CLIENT,
 			null,
+			$acceptWaitlist,
 		);
 	}
 
@@ -1227,6 +1281,8 @@ class AppointmentService {
 	 *                         can't survive the response that gave it context)
 	 * @param ?string $responseSource value for response_source, or null to leave it untouched
 	 * @param ?string $actorUserId audit actor when acting on someone else's behalf
+	 * @param bool $acceptWaitlist take a place in line when the appointment is
+	 *                             already full, rather than being turned away
 	 */
 	private function applyResponse(
 		Appointment $appointment,
@@ -1236,12 +1292,9 @@ class AppointmentService {
 		?string $responseSource,
 		string $auditSource,
 		?string $actorUserId,
+		bool $acceptWaitlist = false,
 	): AttendanceResponse {
 		$appointmentId = $appointment->getId();
-
-		// Same guard ResponseService::submitResponse() runs for quick-response
-		// links, so neither path can accept an answer the other rejects.
-		$this->responsePolicyService->assertResponseAllowed($appointment, $response);
 
 		if ($appointment->isClosed()) {
 			throw new \RuntimeException('This appointment is closed and no longer accepts responses.');
@@ -1254,18 +1307,32 @@ class AppointmentService {
 			throw new \RuntimeException('This appointment was cancelled and no longer accepts responses.');
 		}
 
+		$existingResponse = null;
+		try {
+			$existingResponse = $this->responseMapper->findByAppointmentAndUser($appointmentId, $userId);
+		} catch (DoesNotExistException $e) {
+			// First answer from this person.
+		}
+
+		$beforeResponse = $existingResponse?->getResponse();
+		$beforeComment = $existingResponse === null ? '' : (string)$existingResponse->getComment();
+
+		// Same guards ResponseService::submitResponse() runs for quick-response
+		// links, so neither path can accept an answer the other rejects. An
+		// organizer answering for somebody else may exceed a limit.
+		$this->responsePolicyService->assertResponseAllowed(
+			$appointment,
+			$response,
+			$beforeResponse,
+			$acceptWaitlist,
+			$actorUserId !== null,
+		);
+
 		if ($response === null) {
 			$comment = '';
 		}
 
-		$beforeResponse = null;
-		$beforeComment = '';
-
-		try {
-			$existingResponse = $this->responseMapper->findByAppointmentAndUser($appointmentId, $userId);
-			$beforeResponse = $existingResponse->getResponse();
-			$beforeComment = (string)$existingResponse->getComment();
-
+		if ($existingResponse !== null) {
 			// Withdrawing an already-withdrawn (or never-set) response is a no-op:
 			// don't churn responded_at or notification state on repeated clicks.
 			if ($response === null && $beforeResponse === null) {
@@ -1279,8 +1346,9 @@ class AppointmentService {
 			if ($responseSource !== null) {
 				$existingResponse->setResponseSource($responseSource);
 			}
+			$this->capacityService->applySpotClaim($existingResponse, $beforeResponse, $response);
 			$result = $this->responseMapper->update($existingResponse);
-		} catch (DoesNotExistException $e) {
+		} else {
 			// No row to withdraw from — return a transient placeholder rather
 			// than inserting a junk row that filters would have to skip later.
 			if ($response === null) {
@@ -1300,8 +1368,13 @@ class AppointmentService {
 			if ($responseSource !== null) {
 				$attendanceResponse->setResponseSource($responseSource);
 			}
+			$this->capacityService->applySpotClaim($attendanceResponse, null, $response);
 			$result = $this->responseMapper->insert($attendanceResponse);
 		}
+
+		// The queue moved: a withdrawn yes frees a spot for whoever is next, a
+		// fresh one may have taken the last.
+		$this->capacityService->syncWaitlistNotifications($appointment);
 
 		$this->auditEventService->recordResponseChange(
 			$appointmentId,
@@ -1510,7 +1583,7 @@ class AppointmentService {
 			$appointmentData = $this->serializeAppointment($appointment);
 			$appointmentData = $this->enrichVisibilityData($appointmentData);
 			$appointmentData = $this->enrichSeriesCount($appointmentData, $appointment);
-			$appointmentData['userResponse'] = $this->serializeUserResponse($userResponse);
+			$appointmentData['userResponse'] = $this->serializeUserResponse($userResponse, $appointment);
 			$responseSummary = $this->buildResponseSummaryFor($myPermissions, $appointment->getId());
 			if ($responseSummary !== null) {
 				$appointmentData['responseSummary'] = $responseSummary;
@@ -1552,7 +1625,7 @@ class AppointmentService {
 			$appointmentData = $this->serializeAppointment($appointment);
 			$appointmentData = $this->enrichVisibilityData($appointmentData);
 			$userResponse = $this->getUserResponse($appointment->getId(), $userId);
-			$appointmentData['userResponse'] = $this->serializeUserResponse($userResponse);
+			$appointmentData['userResponse'] = $this->serializeUserResponse($userResponse, $appointment);
 			$appointmentData['attachments'] = $this->attachmentService->getAttachments($appointment->getId());
 			$appointmentData = $this->hideTalkRoomFromOutsiders(
 				$appointmentData,
@@ -1844,10 +1917,15 @@ class AppointmentService {
 	 * @return array<string, mixed>
 	 */
 	public function serializeAppointment(Appointment $appointment): array {
-		/** @var array<string, mixed> $data */
-		$data = $appointment->jsonSerialize();
-		$data['allowMaybe'] = $this->responsePolicyService->isMaybeAllowed($appointment);
-		return $data;
+		return $this->appointmentSerializer->serialize($appointment);
+	}
+
+	/**
+	 * A limit of zero or less is how a client says "no limit"; the column keeps
+	 * NULL for that so every reader has one way to ask.
+	 */
+	private function normalizeAttendeeLimit(?int $maxAttendees): ?int {
+		return $maxAttendees === null || $maxAttendees <= 0 ? null : $maxAttendees;
 	}
 
 	/**

--- a/lib/Service/CapacityService.php
+++ b/lib/Service/CapacityService.php
@@ -1,0 +1,242 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\Attendance\Service;
+
+use OCA\Attendance\Audit\Verb;
+use OCA\Attendance\Db\Appointment;
+use OCA\Attendance\Db\AttendanceResponse;
+use OCA\Attendance\Db\AttendanceResponseMapper;
+
+/**
+ * An appointment's attendance limit and the queue behind it.
+ *
+ * Nothing here is stored as membership. Who holds a spot is derived from the
+ * yes-responses ordered by spot_claimed_at: the first max_attendees are in, the
+ * rest are waiting. A spot that frees up therefore promotes the next person as
+ * a consequence of the ordering, with no write and nothing to keep in step.
+ *
+ * Orthogonal to BookingService, which is the organizer planning people in by
+ * hand. Capacity is self-service and per-appointment; booking is organizer-
+ * authored and switched on instance-wide. Where both are in use, booking
+ * operates within the capacity.
+ */
+class CapacityService {
+	/** The person is waiting for a spot. Set when they join, never notified. */
+	public const NOTIFIED_WAITLISTED = 'waitlisted';
+	/** They were told a spot came free. */
+	public const NOTIFIED_PROMOTED = 'promoted';
+	/** They were told at close that no spot came free. */
+	public const NOTIFIED_NOT_PROMOTED = 'not_promoted';
+
+	public function __construct(
+		private AttendanceResponseMapper $responseMapper,
+		private NotificationService $notificationService,
+		private AuditEventService $auditEventService,
+	) {
+	}
+
+	/**
+	 * The attendance limit, or null when the appointment does not have one.
+	 * Null is also the feature's off switch: without a limit nothing below
+	 * runs a query.
+	 */
+	public function limitOf(Appointment $appointment): ?int {
+		$limit = $appointment->getMaxAttendees();
+		return $limit === null || $limit <= 0 ? null : $limit;
+	}
+
+	/**
+	 * Whether people who arrive at a full appointment may queue for a spot.
+	 * Meaningless without a limit, so false there.
+	 */
+	public function isWaitlistEnabled(Appointment $appointment): bool {
+		return $this->limitOf($appointment) !== null && $appointment->getWaitlistEnabled();
+	}
+
+	/**
+	 * Everyone who answered yes, in queue order.
+	 *
+	 * @return list<AttendanceResponse>
+	 */
+	public function queue(Appointment $appointment): array {
+		return $this->responseMapper->findClaimedSpots($appointment->getId());
+	}
+
+	/**
+	 * How many people answered yes. Can exceed the limit: an organizer may
+	 * answer on somebody's behalf past it, and lowering a limit never takes a
+	 * spot back from a person who already had one.
+	 */
+	public function occupancy(Appointment $appointment): int {
+		if ($this->limitOf($appointment) === null) {
+			return 0;
+		}
+		return count($this->queue($appointment));
+	}
+
+	/**
+	 * Whether a further self-service yes would have to wait.
+	 */
+	public function isFull(Appointment $appointment): bool {
+		$limit = $this->limitOf($appointment);
+		return $limit !== null && $this->occupancy($appointment) >= $limit;
+	}
+
+	/**
+	 * Split the queue into the people holding a spot and the people waiting.
+	 *
+	 * @param list<AttendanceResponse>|null $queue pre-loaded queue, to save a query
+	 * @return array{confirmed: list<AttendanceResponse>, waiting: list<AttendanceResponse>}
+	 */
+	public function split(Appointment $appointment, ?array $queue = null): array {
+		$limit = $this->limitOf($appointment);
+		$queue ??= $this->queue($appointment);
+		if ($limit === null) {
+			return ['confirmed' => $queue, 'waiting' => []];
+		}
+		return [
+			'confirmed' => array_slice($queue, 0, $limit),
+			'waiting' => array_slice($queue, $limit),
+		];
+	}
+
+	/**
+	 * A person's standing in the queue: whether they are waiting, and their
+	 * place in line counted from 1. Both null-ish for an appointment without a
+	 * limit, so callers can hand the result straight to a payload.
+	 *
+	 * @return array{waitlisted: bool, waitlistPosition: ?int}
+	 */
+	public function standingOf(Appointment $appointment, string $userId): array {
+		if ($this->limitOf($appointment) === null) {
+			return ['waitlisted' => false, 'waitlistPosition' => null];
+		}
+
+		$waiting = $this->split($appointment)['waiting'];
+		foreach ($waiting as $index => $response) {
+			if ($response->getUserId() === $userId) {
+				return ['waitlisted' => true, 'waitlistPosition' => $index + 1];
+			}
+		}
+
+		return ['waitlisted' => false, 'waitlistPosition' => null];
+	}
+
+	/**
+	 * Whether this person's yes currently holds a spot rather than a place in
+	 * line. True for everyone who answered yes when there is no limit.
+	 */
+	public function holdsSpot(Appointment $appointment, string $userId): bool {
+		if ($this->limitOf($appointment) === null) {
+			return true;
+		}
+		foreach ($this->split($appointment)['confirmed'] as $response) {
+			if ($response->getUserId() === $userId) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Keep the queue's ordering key in step with an answer that is about to be
+	 * written. Claiming a spot stamps the time; giving one up clears it, so
+	 * answering yes again later joins the back of the queue rather than
+	 * reclaiming the old place. Re-saving a yes — a changed comment, the same
+	 * answer twice — leaves the stamp alone.
+	 *
+	 * @param ?string $before the answer on record, null when there is none
+	 * @param ?string $after the answer being written, null when withdrawing
+	 */
+	public function applySpotClaim(AttendanceResponse $response, ?string $before, ?string $after): void {
+		if ($after === 'yes') {
+			if ($before !== 'yes' || $response->getSpotClaimedAt() === null) {
+				$response->setSpotClaimedAt(gmdate('Y-m-d H:i:s'));
+			}
+			return;
+		}
+
+		$response->setSpotClaimedAt(null);
+		// Leaving the queue drops what they were last told, so re-joining can
+		// notify them again.
+		$response->setWaitlistNotifiedStatus(null);
+		$response->setWaitlistNotifiedAt(null);
+	}
+
+	/**
+	 * Bring the queue's notification markers in step and tell anyone a freed
+	 * spot has just let in.
+	 *
+	 * Membership is derived, so a person can drift in and out of the limit as
+	 * others change their answers. The marker is what keeps that from becoming
+	 * a stream of notifications: it records the last thing they were told, and
+	 * only a change from waiting to holding a spot is worth telling them.
+	 * Joining the queue is marked but never announced — they just clicked the
+	 * button.
+	 */
+	public function syncWaitlistNotifications(Appointment $appointment): void {
+		if ($this->limitOf($appointment) === null) {
+			return;
+		}
+
+		$split = $this->split($appointment);
+
+		foreach ($split['confirmed'] as $response) {
+			$status = $response->getWaitlistNotifiedStatus();
+			if ($status !== self::NOTIFIED_WAITLISTED && $status !== self::NOTIFIED_NOT_PROMOTED) {
+				continue;
+			}
+			$this->markNotified($response, self::NOTIFIED_PROMOTED);
+			$this->notificationService->sendWaitlistNotification(
+				$appointment,
+				$response->getUserId(),
+				'waitlist_promoted',
+			);
+			// Nobody performed this change, which is exactly why it is worth
+			// recording: it answers "why am I suddenly in?".
+			$this->auditEventService->record(
+				Verb::WAITLIST_PROMOTED,
+				$appointment->getId(),
+				null,
+				$response->getUserId(),
+			);
+		}
+
+		foreach ($split['waiting'] as $response) {
+			if ($response->getWaitlistNotifiedStatus() === self::NOTIFIED_WAITLISTED) {
+				continue;
+			}
+			$this->markNotified($response, self::NOTIFIED_WAITLISTED);
+		}
+	}
+
+	/**
+	 * Close the loop for everyone still waiting when the inquiry ends. Without
+	 * it they keep the date free for a spot that is never coming.
+	 */
+	public function notifyNotPromoted(Appointment $appointment): void {
+		if ($this->limitOf($appointment) === null) {
+			return;
+		}
+
+		foreach ($this->split($appointment)['waiting'] as $response) {
+			if ($response->getWaitlistNotifiedStatus() === self::NOTIFIED_NOT_PROMOTED) {
+				continue;
+			}
+			$this->markNotified($response, self::NOTIFIED_NOT_PROMOTED);
+			$this->notificationService->sendWaitlistNotification(
+				$appointment,
+				$response->getUserId(),
+				'waitlist_not_promoted',
+			);
+		}
+	}
+
+	private function markNotified(AttendanceResponse $response, string $status): void {
+		$response->setWaitlistNotifiedStatus($status);
+		$response->setWaitlistNotifiedAt(gmdate('Y-m-d H:i:s'));
+		$this->responseMapper->update($response);
+	}
+}

--- a/lib/Service/CheckinService.php
+++ b/lib/Service/CheckinService.php
@@ -22,6 +22,8 @@ class CheckinService {
 	private IGroupManager $groupManager;
 	private GuestService $guestService;
 	private AuditEventService $auditEventService;
+	private CapacityService $capacityService;
+	private AppointmentSerializer $appointmentSerializer;
 
 	public function __construct(
 		AppointmentMapper $appointmentMapper,
@@ -31,6 +33,8 @@ class CheckinService {
 		IGroupManager $groupManager,
 		GuestService $guestService,
 		AuditEventService $auditEventService,
+		CapacityService $capacityService,
+		AppointmentSerializer $appointmentSerializer,
 	) {
 		$this->appointmentMapper = $appointmentMapper;
 		$this->responseMapper = $responseMapper;
@@ -39,6 +43,8 @@ class CheckinService {
 		$this->groupManager = $groupManager;
 		$this->guestService = $guestService;
 		$this->auditEventService = $auditEventService;
+		$this->capacityService = $capacityService;
+		$this->appointmentSerializer = $appointmentSerializer;
 	}
 
 	/**
@@ -138,13 +144,23 @@ class CheckinService {
 		// Build group list for filtering UI
 		$userGroups = $this->buildGroupList($whitelistedGroups);
 
+		// A place in line is not a place at the appointment. The list still
+		// carries everyone — an organizer has to be able to check in whoever
+		// actually turns up — but a waiting yes must not read as a confirmed one.
+		$confirmedIds = [];
+		if ($this->capacityService->limitOf($appointment) !== null) {
+			foreach ($this->capacityService->split($appointment)['confirmed'] as $row) {
+				$confirmedIds[$row->getUserId()] = true;
+			}
+		}
+
 		$users = array_map(
-			fn ($user) => $this->buildUserData($user, $userResponseMap, $whitelistedGroups),
+			fn ($user) => $this->buildUserData($user, $userResponseMap, $whitelistedGroups, $confirmedIds),
 			array_values($targetAttendees),
 		);
 
 		return [
-			'appointment' => $appointment->jsonSerialize(),
+			'appointment' => $this->appointmentSerializer->serialize($appointment),
 			'users' => $users,
 			'userGroups' => array_values($userGroups),
 		];
@@ -226,7 +242,7 @@ class CheckinService {
 	/**
 	 * Build data structure for a single user.
 	 */
-	private function buildUserData($user, array $userResponseMap, array $whitelistedGroups): array {
+	private function buildUserData($user, array $userResponseMap, array $whitelistedGroups, array $confirmedIds = []): array {
 		$userId = $user->getUID();
 		$userGroupIds = $this->groupManager->getUserGroupIds($user);
 
@@ -272,10 +288,12 @@ class CheckinService {
 			'checkinBy' => null,
 			'checkinAt' => null,
 			'checkinSource' => null,
+			'waitlisted' => false,
 		];
 
 		// Add response data if user has responded
 		if (isset($userResponseMap[$userId])) {
+			/** @var AttendanceResponse $response */
 			$response = $userResponseMap[$userId];
 			$responseData = $response->jsonSerialize();
 			$userData['response'] = $responseData['response'];
@@ -286,6 +304,9 @@ class CheckinService {
 			$userData['checkinBy'] = $responseData['checkinBy'];
 			$userData['checkinAt'] = $responseData['checkinAt'];
 			$userData['checkinSource'] = $responseData['checkinSource'];
+			$userData['waitlisted'] = $responseData['response'] === 'yes'
+				&& $confirmedIds !== []
+				&& !isset($confirmedIds[$userId]);
 		}
 
 		return $userData;

--- a/lib/Service/ConfigService.php
+++ b/lib/Service/ConfigService.php
@@ -342,6 +342,25 @@ class ConfigService {
 	}
 
 	/**
+	 * Whether appointments offer "Maybe" as an answer. A per-appointment
+	 * override wins; this is what an appointment without one follows.
+	 *
+	 * @return bool True if "Maybe" is offered
+	 */
+	public function isMaybeAllowed(): bool {
+		return $this->appConfig->getValueBool(self::APP_ID, 'allow_maybe', true);
+	}
+
+	/**
+	 * Set whether "Maybe" is offered where an appointment has no override.
+	 *
+	 * @param bool $allowed Whether "Maybe" should be offered
+	 */
+	public function setMaybeAllowed(bool $allowed): void {
+		$this->appConfig->setValueBool(self::APP_ID, 'allow_maybe', $allowed);
+	}
+
+	/**
 	 * Minutes before an appointment starts that self-check-in opens.
 	 * The window always closes at the appointment end.
 	 */

--- a/lib/Service/ExportService.php
+++ b/lib/Service/ExportService.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace OCA\Attendance\Service;
 
+use OCA\Attendance\Db\Appointment;
 use OCA\Attendance\Db\AppointmentMapper;
+use OCA\Attendance\Db\AttendanceResponse;
 use OCA\Attendance\Db\AttendanceResponseMapper;
 use OCP\Files\Folder;
 use OCP\Files\IRootFolder;
@@ -22,6 +24,7 @@ class ExportService {
 	private ConfigService $configService;
 	private OdsWriter $odsWriter;
 	private IL10N $l10n;
+	private CapacityService $capacityService;
 
 	public function __construct(
 		AppointmentMapper $appointmentMapper,
@@ -32,6 +35,7 @@ class ExportService {
 		ConfigService $configService,
 		OdsWriter $odsWriter,
 		IL10N $l10n,
+		CapacityService $capacityService,
 	) {
 		$this->appointmentMapper = $appointmentMapper;
 		$this->responseMapper = $responseMapper;
@@ -41,6 +45,7 @@ class ExportService {
 		$this->configService = $configService;
 		$this->odsWriter = $odsWriter;
 		$this->l10n = $l10n;
+		$this->capacityService = $capacityService;
 	}
 
 	/**
@@ -70,6 +75,10 @@ class ExportService {
 		// Collect all unique users who have responded or checked in
 		$allUserIds = [];
 		$appointmentResponses = [];
+		// Who actually holds a spot, per limited appointment. Resolved once here
+		// rather than per cell: this is a users x appointments matrix, and the
+		// queue is one query.
+		$confirmedIds = [];
 
 		foreach ($appointments as $appointment) {
 			$responses = $this->responseMapper->findByAppointment($appointment->getId());
@@ -79,6 +88,13 @@ class ExportService {
 				$respUserId = $response->getUserId();
 				$allUserIds[$respUserId] = true;
 				$appointmentResponses[$appointment->getId()][$respUserId] = $response;
+			}
+
+			if ($this->capacityService->limitOf($appointment) !== null) {
+				$confirmed = $this->capacityService->split($appointment)['confirmed'];
+				$confirmedIds[$appointment->getId()] = array_flip(
+					array_map(static fn ($row): string => $row->getUserId(), $confirmed),
+				);
 			}
 		}
 
@@ -118,7 +134,7 @@ class ExportService {
 			return strcmp($a['displayName'], $b['displayName']);
 		});
 
-		$odsContent = $this->odsWriter->write($this->getTableXml($appointments, $users, $appointmentResponses, $includeComments));
+		$odsContent = $this->odsWriter->write($this->getTableXml($appointments, $users, $appointmentResponses, $includeComments, $confirmedIds));
 
 		// Create the Attendance folder
 		try {
@@ -172,7 +188,13 @@ class ExportService {
 	/**
 	 * Render the export sheet. The document around it comes from OdsWriter.
 	 */
-	private function getTableXml(array $appointments, array $users, array $appointmentResponses, bool $includeComments = false): string {
+	/**
+	 * @param list<Appointment> $appointments
+	 * @param list<array{userId: string, displayName: string, group: string}> $users
+	 * @param array<int, array<string, AttendanceResponse>> $appointmentResponses
+	 * @param array<int, array<string, int>> $confirmedIds user IDs holding a spot, per limited appointment
+	 */
+	private function getTableXml(array $appointments, array $users, array $appointmentResponses, bool $includeComments = false, array $confirmedIds = []): string {
 		$xml = '
 			<table:table table:name="Attendance" table:print="false">';
 
@@ -290,10 +312,22 @@ class ExportService {
 			foreach ($appointments as $appointment) {
 				$response = $appointmentResponses[$appointment->getId()][$user['userId']] ?? null;
 
-				// RSVP column
+				// RSVP column. A yes that is only a place in line says so — this
+				// is the sheet an organizer takes to the door, and "Yes" for
+				// somebody without a spot would be wrong there. It borrows the
+				// amber "maybe" styling, which is free of ambiguity: an
+				// appointment with a limit never offers "Maybe".
 				$rsvpValue = $response ? $response->getResponse() : null;
-				$rsvp = $this->formatResponse($rsvpValue);
-				$rsvpStyle = $this->getResponseCellStyle($rsvpValue);
+				$waitlisted = $rsvpValue === 'yes'
+					&& isset($confirmedIds[$appointment->getId()])
+					&& !isset($confirmedIds[$appointment->getId()][$user['userId']]);
+				$rsvp = $waitlisted
+					// TRANSLATORS Cell value in the exported spreadsheet — the person answered yes but the appointment was full, so they are waiting for a spot (German "Warteliste").
+					? $this->l10n->t('Waitlist')
+					: $this->formatResponse($rsvpValue);
+				$rsvpStyle = $waitlisted
+					? OdsWriter::STYLE_MAYBE
+					: $this->getResponseCellStyle($rsvpValue);
 				$xml .= '
 					<table:table-cell table:style-name="' . $rsvpStyle . '" office:value-type="string">
 						<text:p>' . $rsvp . '</text:p>

--- a/lib/Service/IcalService.php
+++ b/lib/Service/IcalService.php
@@ -7,12 +7,14 @@ namespace OCA\Attendance\Service;
 use OCA\Attendance\Db\Appointment;
 use OCA\Attendance\Db\AppointmentAttachmentMapper;
 use OCA\Attendance\Db\AppointmentMapper;
+use OCA\Attendance\Db\AttendanceResponse;
 use OCA\Attendance\Db\AttendanceResponseMapper;
 use OCA\Attendance\Db\CategoryMapper;
 use OCA\Attendance\Db\IcalToken;
 use OCA\Attendance\Db\IcalTokenMapper;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\IConfig;
+use OCP\IL10N;
 use OCP\IURLGenerator;
 use OCP\L10N\IFactory as IL10NFactory;
 use OCP\Security\ISecureRandom;
@@ -33,6 +35,7 @@ class IcalService {
 	private IL10NFactory $l10nFactory;
 	private IConfig $config;
 	private CategoryMapper $categoryMapper;
+	private CapacityService $capacityService;
 
 	private const TOKEN_LENGTH = 64;
 	private const TOKEN_CHARS = 'abcdef0123456789';
@@ -50,6 +53,7 @@ class IcalService {
 		IL10NFactory $l10nFactory,
 		IConfig $config,
 		CategoryMapper $categoryMapper,
+		CapacityService $capacityService,
 	) {
 		$this->icalTokenMapper = $icalTokenMapper;
 		$this->appointmentMapper = $appointmentMapper;
@@ -63,6 +67,7 @@ class IcalService {
 		$this->l10nFactory = $l10nFactory;
 		$this->config = $config;
 		$this->categoryMapper = $categoryMapper;
+		$this->capacityService = $capacityService;
 	}
 
 	/**
@@ -200,9 +205,9 @@ class IcalService {
 	 */
 	private function generateVEvent(
 		Appointment $appointment,
-		$response,
+		?AttendanceResponse $response,
 		string $userId,
-		$l,
+		IL10N $l,
 		string $domain,
 		array $reminderTriggers = [],
 	): string {
@@ -259,6 +264,20 @@ class IcalService {
 			}
 			$summary = $appointment->getName()
 				. ' (' . $l->t('Me') . ': ' . $statusLabel . ')';
+		}
+
+		// A place in line is not a place at the appointment, so the slot stays
+		// free. Unlike the scheduling verdict above this needs no closed check:
+		// "you do not have a spot" is not a judgement the organizer has yet to
+		// make, it is where the person stands right now, and promotion flips it
+		// back on the next poll.
+		if ($responseState === 'yes'
+			&& $this->capacityService->limitOf($appointment) !== null
+			&& !$this->capacityService->holdsSpot($appointment, $userId)) {
+			$transp = 'TRANSPARENT';
+			// TRANSLATORS Status marker appended to the calendar event title — the appointment was full, so the person is waiting for a spot rather than holding one (German "Warteliste").
+			$summary = $appointment->getName()
+				. ' (' . $l->t('Me') . ': ' . $l->t('Waitlist') . ')';
 		}
 
 		// Cancelled appointments: the event will not take place. This is the one

--- a/lib/Service/NotificationService.php
+++ b/lib/Service/NotificationService.php
@@ -265,6 +265,53 @@ class NotificationService {
 	}
 
 	/**
+	 * Notify a single attendee about their place in an appointment's queue:
+	 * a spot came free and they are in ('waitlist_promoted'), or the inquiry
+	 * closed without one ('waitlist_not_promoted').
+	 *
+	 * Same shape as sendBookingNotification() — single recipient, deep-linked
+	 * to the appointment. CapacityService owns the fire-once marker, so this
+	 * only ever sends what it is told to.
+	 *
+	 * @param Appointment $appointment The appointment they queued for
+	 * @param string $userId The attendee to notify
+	 * @param string $subject 'waitlist_promoted' or 'waitlist_not_promoted'
+	 */
+	public function sendWaitlistNotification(Appointment $appointment, string $userId, string $subject): void {
+		if (!$this->isNotificationsAppEnabled()) {
+			return;
+		}
+
+		$appointmentUrl = $this->urlGenerator->linkToRouteAbsolute(
+			'attendance.page.appointment',
+			['id' => $appointment->getId()]
+		);
+
+		try {
+			$notification = $this->notificationManager->createNotification();
+			$notification->setApp('attendance')
+				->setUser($userId)
+				->setDateTime(new \DateTime())
+				->setObject('appointment', (string)$appointment->getId())
+				->setSubject($subject, [
+					'appointmentId' => $appointment->getId(),
+					'name' => $appointment->getName(),
+					'startDatetime' => $appointment->getStartDatetime(),
+				])
+				->setLink($appointmentUrl);
+
+			$this->notificationManager->notify($notification);
+		} catch (\Exception $e) {
+			$this->logger->error('Failed to send waitlist notification', [
+				'userId' => $userId,
+				'appointmentId' => $appointment->getId(),
+				'subject' => $subject,
+				'error' => $e->getMessage(),
+			]);
+		}
+	}
+
+	/**
 	 * Send an appointment reminder notification to a single user.
 	 * Uses the same notification format as ReminderJob but does NOT write to ReminderLogMapper.
 	 *

--- a/lib/Service/ResponsePolicyService.php
+++ b/lib/Service/ResponsePolicyService.php
@@ -20,6 +20,7 @@ class ResponsePolicyService {
 
 	public function __construct(
 		private ConfigService $configService,
+		private CapacityService $capacityService,
 	) {
 	}
 
@@ -28,14 +29,33 @@ class ResponsePolicyService {
 	 * NULL means the appointment has no opinion and follows the instance default.
 	 */
 	public function isMaybeAllowed(Appointment $appointment): bool {
+		// A limit and "Maybe" cannot coexist: a maybe would hold a spot away
+		// from somebody who would commit to it. The limit wins over both the
+		// appointment's own answer and the instance default.
+		if ($this->capacityService->limitOf($appointment) !== null) {
+			return false;
+		}
 		return $appointment->getAllowMaybe() ?? $this->configService->isMaybeAllowed();
 	}
 
 	/**
 	 * @param ?string $response the answer about to be stored, or null to withdraw
-	 * @throws \InvalidArgumentException if this appointment does not accept it
+	 * @param ?string $currentResponse the answer on record, null when there is none
+	 * @param bool $acceptWaitlist the person asked for a place in line if the
+	 *                             appointment turns out to be full
+	 * @param bool $onBehalf an organizer is answering for somebody else, which
+	 *                       may exceed the limit — they own the appointment and
+	 *                       real rosters have exceptions
+	 * @throws \InvalidArgumentException if this appointment does not accept the answer
+	 * @throws \RuntimeException if the appointment is full
 	 */
-	public function assertResponseAllowed(Appointment $appointment, ?string $response): void {
+	public function assertResponseAllowed(
+		Appointment $appointment,
+		?string $response,
+		?string $currentResponse = null,
+		bool $acceptWaitlist = false,
+		bool $onBehalf = false,
+	): void {
 		if ($response === null) {
 			return;
 		}
@@ -44,6 +64,22 @@ class ResponsePolicyService {
 		}
 		if ($response === 'maybe' && !$this->isMaybeAllowed($appointment)) {
 			throw new \InvalidArgumentException('This appointment does not accept "maybe" as an answer.');
+		}
+
+		// Only a fresh yes can run into the limit. Re-saving one — the same
+		// answer again, an edited comment — changes neither the queue nor its
+		// order, so it must not be turned away.
+		if ($response !== 'yes' || $currentResponse === 'yes' || $onBehalf) {
+			return;
+		}
+		if (!$this->capacityService->isFull($appointment)) {
+			return;
+		}
+		if (!$this->capacityService->isWaitlistEnabled($appointment)) {
+			throw new \RuntimeException('This appointment is full.');
+		}
+		if (!$acceptWaitlist) {
+			throw new \RuntimeException('This appointment is full. Join the waitlist to take the next free spot.');
 		}
 	}
 }

--- a/lib/Service/ResponsePolicyService.php
+++ b/lib/Service/ResponsePolicyService.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\Attendance\Service;
+
+use OCA\Attendance\Db\Appointment;
+
+/**
+ * The rules deciding which answers an appointment accepts.
+ *
+ * Two services persist responses: AppointmentService::applyResponse() for the
+ * web, mobile and on-behalf paths, ResponseService::submitResponse() for the
+ * quick-response links in notifications. Both ask here, so a rule cannot hold
+ * on one path and leak on the other.
+ */
+class ResponsePolicyService {
+	/** Every answer the storage layer understands, in display order. */
+	public const RESPONSES = ['yes', 'maybe', 'no'];
+
+	public function __construct(
+		private ConfigService $configService,
+	) {
+	}
+
+	/**
+	 * Whether this appointment offers "Maybe". The per-appointment column wins;
+	 * NULL means the appointment has no opinion and follows the instance default.
+	 */
+	public function isMaybeAllowed(Appointment $appointment): bool {
+		return $appointment->getAllowMaybe() ?? $this->configService->isMaybeAllowed();
+	}
+
+	/**
+	 * @param ?string $response the answer about to be stored, or null to withdraw
+	 * @throws \InvalidArgumentException if this appointment does not accept it
+	 */
+	public function assertResponseAllowed(Appointment $appointment, ?string $response): void {
+		if ($response === null) {
+			return;
+		}
+		if (!in_array($response, self::RESPONSES, true)) {
+			throw new \InvalidArgumentException('Invalid response. Must be yes, no, maybe, or null.');
+		}
+		if ($response === 'maybe' && !$this->isMaybeAllowed($appointment)) {
+			throw new \InvalidArgumentException('This appointment does not accept "maybe" as an answer.');
+		}
+	}
+}

--- a/lib/Service/ResponseService.php
+++ b/lib/Service/ResponseService.php
@@ -26,6 +26,7 @@ class ResponseService {
 	private AuditEventService $auditEventService;
 	private OrgCalendarSyncService $orgCalendarSyncService;
 	private TalkRoomService $talkRoomService;
+	private ResponsePolicyService $responsePolicyService;
 
 	public function __construct(
 		AppointmentMapper $appointmentMapper,
@@ -38,6 +39,7 @@ class ResponseService {
 		AuditEventService $auditEventService,
 		OrgCalendarSyncService $orgCalendarSyncService,
 		TalkRoomService $talkRoomService,
+		ResponsePolicyService $responsePolicyService,
 	) {
 		$this->appointmentMapper = $appointmentMapper;
 		$this->responseMapper = $responseMapper;
@@ -49,6 +51,7 @@ class ResponseService {
 		$this->auditEventService = $auditEventService;
 		$this->orgCalendarSyncService = $orgCalendarSyncService;
 		$this->talkRoomService = $talkRoomService;
+		$this->responsePolicyService = $responsePolicyService;
 	}
 
 	// Response source constants
@@ -74,12 +77,13 @@ class ResponseService {
 		string $comment = '',
 		string $source = self::SOURCE_APP,
 	): AttendanceResponse {
-		if (!in_array($response, ['yes', 'no', 'maybe'])) {
-			throw new \InvalidArgumentException('Invalid response. Must be yes, no, or maybe.');
-		}
-
 		// Check if appointment exists and is still open for responses
 		$appointment = $this->appointmentMapper->find($appointmentId);
+
+		// Same guard AppointmentService::applyResponse() runs, so a quick-response
+		// link cannot slip past a rule the app enforces.
+		$this->responsePolicyService->assertResponseAllowed($appointment, $response);
+
 		if ($appointment->isClosed()) {
 			throw new \RuntimeException('This appointment is closed and no longer accepts responses.');
 		}

--- a/lib/Service/ResponseService.php
+++ b/lib/Service/ResponseService.php
@@ -27,6 +27,7 @@ class ResponseService {
 	private OrgCalendarSyncService $orgCalendarSyncService;
 	private TalkRoomService $talkRoomService;
 	private ResponsePolicyService $responsePolicyService;
+	private CapacityService $capacityService;
 
 	public function __construct(
 		AppointmentMapper $appointmentMapper,
@@ -40,6 +41,7 @@ class ResponseService {
 		OrgCalendarSyncService $orgCalendarSyncService,
 		TalkRoomService $talkRoomService,
 		ResponsePolicyService $responsePolicyService,
+		CapacityService $capacityService,
 	) {
 		$this->appointmentMapper = $appointmentMapper;
 		$this->responseMapper = $responseMapper;
@@ -52,6 +54,7 @@ class ResponseService {
 		$this->orgCalendarSyncService = $orgCalendarSyncService;
 		$this->talkRoomService = $talkRoomService;
 		$this->responsePolicyService = $responsePolicyService;
+		$this->capacityService = $capacityService;
 	}
 
 	// Response source constants
@@ -80,10 +83,6 @@ class ResponseService {
 		// Check if appointment exists and is still open for responses
 		$appointment = $this->appointmentMapper->find($appointmentId);
 
-		// Same guard AppointmentService::applyResponse() runs, so a quick-response
-		// link cannot slip past a rule the app enforces.
-		$this->responsePolicyService->assertResponseAllowed($appointment, $response);
-
 		if ($appointment->isClosed()) {
 			throw new \RuntimeException('This appointment is closed and no longer accepts responses.');
 		}
@@ -91,22 +90,30 @@ class ResponseService {
 			throw new \RuntimeException('This appointment was cancelled and no longer accepts responses.');
 		}
 
-		$beforeResponse = null;
-		$beforeComment = '';
-
-		// Check if user already responded
+		$existingResponse = null;
 		try {
 			$existingResponse = $this->responseMapper->findByAppointmentAndUser($appointmentId, $userId);
-			$beforeResponse = $existingResponse->getResponse();
-			$beforeComment = (string)$existingResponse->getComment();
-			// Update existing response
+		} catch (DoesNotExistException $e) {
+			// First answer from this person.
+		}
+
+		$beforeResponse = $existingResponse?->getResponse();
+		$beforeComment = $existingResponse === null ? '' : (string)$existingResponse->getComment();
+
+		// Same guards AppointmentService::applyResponse() runs, so a quick-response
+		// link cannot slip past a rule the app enforces. A signed link carries no
+		// waitlist intent, so a full appointment turns it away with a message
+		// rather than queueing somebody who never asked to wait.
+		$this->responsePolicyService->assertResponseAllowed($appointment, $response, $beforeResponse);
+
+		if ($existingResponse !== null) {
 			$existingResponse->setResponse($response);
 			$existingResponse->setComment($comment);
 			$existingResponse->setRespondedAt(gmdate('Y-m-d H:i:s'));
 			$existingResponse->setResponseSource($source);
+			$this->capacityService->applySpotClaim($existingResponse, $beforeResponse, $response);
 			$result = $this->responseMapper->update($existingResponse);
-		} catch (DoesNotExistException $e) {
-			// Create new response
+		} else {
 			$attendanceResponse = new AttendanceResponse();
 			$attendanceResponse->setAppointmentId($appointmentId);
 			$attendanceResponse->setUserId($userId);
@@ -114,8 +121,12 @@ class ResponseService {
 			$attendanceResponse->setComment($comment);
 			$attendanceResponse->setRespondedAt(gmdate('Y-m-d H:i:s'));
 			$attendanceResponse->setResponseSource($source);
+			$this->capacityService->applySpotClaim($attendanceResponse, null, $response);
 			$result = $this->responseMapper->insert($attendanceResponse);
 		}
+
+		// Mirrors AppointmentService::applyResponse(): the queue moved.
+		$this->capacityService->syncWaitlistNotifications($appointment);
 
 		$auditSource = $source === self::SOURCE_QUICK_LINK
 			? \OCA\Attendance\Audit\Verb::SOURCE_QUICK_LINK

--- a/lib/Service/ResponseSummaryService.php
+++ b/lib/Service/ResponseSummaryService.php
@@ -6,8 +6,10 @@ namespace OCA\Attendance\Service;
 
 use OCA\Attendance\Db\Appointment;
 use OCA\Attendance\Db\AppointmentMapper;
+use OCA\Attendance\Db\AttendanceResponse;
 use OCA\Attendance\Db\AttendanceResponseMapper;
 use OCP\IGroupManager;
+use OCP\IUser;
 use OCP\IUserManager;
 
 /**
@@ -23,6 +25,7 @@ class ResponseSummaryService {
 	private IGroupManager $groupManager;
 	private IUserManager $userManager;
 	private GuestService $guestService;
+	private CapacityService $capacityService;
 
 	public function __construct(
 		AppointmentMapper $appointmentMapper,
@@ -32,6 +35,7 @@ class ResponseSummaryService {
 		IGroupManager $groupManager,
 		IUserManager $userManager,
 		GuestService $guestService,
+		CapacityService $capacityService,
 	) {
 		$this->appointmentMapper = $appointmentMapper;
 		$this->responseMapper = $responseMapper;
@@ -40,6 +44,7 @@ class ResponseSummaryService {
 		$this->groupManager = $groupManager;
 		$this->userManager = $userManager;
 		$this->guestService = $guestService;
+		$this->capacityService = $capacityService;
 	}
 
 	/**
@@ -212,6 +217,10 @@ class ResponseSummaryService {
 			// Appointment-specific visibility restrictions
 			'appointmentHasRestrictions' => $appointmentHasRestrictions,
 			'appointmentVisibleGroupsLower' => $appointmentVisibleGroupsLower,
+			// Who holds a spot rather than a place in line. Empty for an
+			// appointment without a limit, which is also how serializeResponse()
+			// knows there is no queue to report on.
+			'confirmedIds' => $this->confirmedIds($appointment),
 		];
 	}
 
@@ -277,7 +286,7 @@ class ResponseSummaryService {
 	 */
 	private function processResponse(
 		Appointment $appointment,
-		$response,
+		AttendanceResponse $response,
 		array &$summary,
 		array &$respondedUserIds,
 		array $cache,
@@ -302,6 +311,7 @@ class ResponseSummaryService {
 		$respondedUserIds[$userId] = $responseValue;
 
 		// Get user from cache
+		/** @var ?IUser $user */
 		$user = $cache['users'][$userId] ?? null;
 		$userInWhitelistedGroup = false;
 		$userInWhitelistedTeam = false;
@@ -315,7 +325,7 @@ class ResponseSummaryService {
 				// Check if group is allowed (using cache)
 				if ($this->isGroupVisibleAsSection($groupId, $cache)) {
 					$userInWhitelistedGroup = true;
-					$this->addResponseToGroup($summary, $groupId, $responseValue, $response, $user, $includeComments);
+					$this->addResponseToGroup($summary, $groupId, $responseValue, $response, $user, $includeComments, $cache);
 				}
 			}
 
@@ -333,7 +343,7 @@ class ResponseSummaryService {
 			// If user is not in any whitelisted group or team, add to "others"
 			if (!$userInWhitelistedGroup && !$userInWhitelistedTeam) {
 				$summary['others'][$responseValue]++;
-				$summary['others']['responses'][] = $this->serializeResponse($response, $user, $includeComments);
+				$summary['others']['responses'][] = $this->serializeResponse($response, $user, $includeComments, $cache);
 			}
 		}
 	}
@@ -343,14 +353,35 @@ class ResponseSummaryService {
 	 * responder's display name and guest flag. Strips the free-text comment /
 	 * checkinComment fields unless the caller is permitted to read comments.
 	 */
-	private function serializeResponse($response, $user, bool $includeComments): array {
+	private function serializeResponse(AttendanceResponse $response, IUser $user, bool $includeComments, array $cache = []): array {
 		$responseData = $response->jsonSerialize();
 		if (!$includeComments) {
 			unset($responseData['comment'], $responseData['checkinComment']);
 		}
 		$responseData['userName'] = $user->getDisplayName();
 		$responseData['isGuest'] = $this->guestService->isGuestUser($user->getUID());
+		// Whoever may see who answered what also sees where they stand in the
+		// queue — it is strictly less than the names already in this payload.
+		/** @var array<string, true> $confirmedIds */
+		$confirmedIds = $cache['confirmedIds'] ?? [];
+		$responseData['waitlisted'] = $responseData['response'] === 'yes'
+			&& $confirmedIds !== []
+			&& !isset($confirmedIds[$user->getUID()]);
 		return $responseData;
+	}
+
+	/**
+	 * @return array<string, true> user IDs holding a spot, empty without a limit
+	 */
+	private function confirmedIds(Appointment $appointment): array {
+		if ($this->capacityService->limitOf($appointment) === null) {
+			return [];
+		}
+		$ids = [];
+		foreach ($this->capacityService->split($appointment)['confirmed'] as $row) {
+			$ids[$row->getUserId()] = true;
+		}
+		return $ids;
 	}
 
 	/**
@@ -360,9 +391,10 @@ class ResponseSummaryService {
 		array &$summary,
 		string $groupId,
 		string $responseValue,
-		$response,
-		$user,
+		AttendanceResponse $response,
+		IUser $user,
 		bool $includeComments,
+		array $cache = [],
 	): void {
 		if (!isset($summary['by_group'][$groupId])) {
 			$summary['by_group'][$groupId] = [
@@ -377,7 +409,7 @@ class ResponseSummaryService {
 		$summary['by_group'][$groupId][$responseValue]++;
 
 		// Add the detailed response to this group
-		$summary['by_group'][$groupId]['responses'][] = $this->serializeResponse($response, $user, $includeComments);
+		$summary['by_group'][$groupId]['responses'][] = $this->serializeResponse($response, $user, $includeComments, $cache);
 	}
 
 	/**
@@ -387,8 +419,8 @@ class ResponseSummaryService {
 		array &$summary,
 		string $teamId,
 		string $responseValue,
-		$response,
-		$user,
+		AttendanceResponse $response,
+		IUser $user,
 		array $cache,
 		bool $includeComments,
 	): void {
@@ -407,7 +439,7 @@ class ResponseSummaryService {
 		$summary['by_team'][$teamId][$responseValue]++;
 
 		// Add the detailed response to this team
-		$summary['by_team'][$teamId]['responses'][] = $this->serializeResponse($response, $user, $includeComments);
+		$summary['by_team'][$teamId]['responses'][] = $this->serializeResponse($response, $user, $includeComments, $cache);
 	}
 
 	/**

--- a/openapi-administration.json
+++ b/openapi-administration.json
@@ -215,6 +215,7 @@
                     "remindMaybe",
                     "responseOptions",
                     "allowMaybeDefault",
+                    "attendanceLimit",
                     "responseToggle",
                     "guestInvitation",
                     "auditLog",
@@ -263,6 +264,9 @@
                         "type": "boolean"
                     },
                     "allowMaybeDefault": {
+                        "type": "boolean"
+                    },
+                    "attendanceLimit": {
                         "type": "boolean"
                     },
                     "responseToggle": {

--- a/openapi-administration.json
+++ b/openapi-administration.json
@@ -60,6 +60,7 @@
                     "pushEnabled",
                     "mobileAppBannerEnabled",
                     "bookingEnabled",
+                    "allowMaybe",
                     "selfCheckinWindowMinutes",
                     "guestsApp"
                 ],
@@ -101,6 +102,9 @@
                         "type": "boolean"
                     },
                     "bookingEnabled": {
+                        "type": "boolean"
+                    },
+                    "allowMaybe": {
                         "type": "boolean"
                     },
                     "selfCheckinWindowMinutes": {
@@ -209,6 +213,8 @@
                     "bookingEnabled",
                     "scheduledFilter",
                     "remindMaybe",
+                    "responseOptions",
+                    "allowMaybeDefault",
                     "responseToggle",
                     "guestInvitation",
                     "auditLog",
@@ -251,6 +257,12 @@
                         "type": "boolean"
                     },
                     "remindMaybe": {
+                        "type": "boolean"
+                    },
+                    "responseOptions": {
+                        "type": "boolean"
+                    },
+                    "allowMaybeDefault": {
                         "type": "boolean"
                     },
                     "responseToggle": {
@@ -712,6 +724,12 @@
                                         "nullable": true,
                                         "default": null,
                                         "description": "Whether the booking / planning feature is enabled"
+                                    },
+                                    "allowMaybe": {
+                                        "type": "boolean",
+                                        "nullable": true,
+                                        "default": null,
+                                        "description": "Whether appointments offer \"Maybe\" where they have no override of their own"
                                     },
                                     "selfCheckinWindowMinutes": {
                                         "type": "integer",

--- a/openapi-full.json
+++ b/openapi-full.json
@@ -228,7 +228,11 @@
                     "categoryId",
                     "createTalkRoom",
                     "talkRoomToken",
-                    "allowMaybe"
+                    "allowMaybe",
+                    "maxAttendees",
+                    "waitlistEnabled",
+                    "occupancy",
+                    "isFull"
                 ],
                 "properties": {
                     "id": {
@@ -333,6 +337,21 @@
                         "nullable": true
                     },
                     "allowMaybe": {
+                        "type": "boolean"
+                    },
+                    "maxAttendees": {
+                        "type": "integer",
+                        "format": "int64",
+                        "nullable": true
+                    },
+                    "waitlistEnabled": {
+                        "type": "boolean"
+                    },
+                    "occupancy": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "isFull": {
                         "type": "boolean"
                     }
                 }
@@ -667,6 +686,13 @@
                     },
                     "allowMaybe": {
                         "type": "boolean"
+                    },
+                    "maxAttendees": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "waitlistEnabled": {
+                        "type": "boolean"
                     }
                 }
             },
@@ -685,6 +711,7 @@
                     "remindMaybe",
                     "responseOptions",
                     "allowMaybeDefault",
+                    "attendanceLimit",
                     "responseToggle",
                     "guestInvitation",
                     "auditLog",
@@ -733,6 +760,9 @@
                         "type": "boolean"
                     },
                     "allowMaybeDefault": {
+                        "type": "boolean"
+                    },
+                    "attendanceLimit": {
                         "type": "boolean"
                     },
                     "responseToggle": {
@@ -1080,7 +1110,9 @@
                     "isCheckedIn",
                     "responseSource",
                     "checkinSource",
-                    "bookingStatus"
+                    "bookingStatus",
+                    "waitlisted",
+                    "waitlistPosition"
                 ],
                 "properties": {
                     "id": {
@@ -1131,6 +1163,14 @@
                     "bookingStatus": {
                         "type": "string",
                         "nullable": true
+                    },
+                    "waitlisted": {
+                        "type": "boolean"
+                    },
+                    "waitlistPosition": {
+                        "type": "integer",
+                        "format": "int64",
+                        "nullable": true
                     }
                 }
             },
@@ -1153,7 +1193,8 @@
                     "bookingStatus",
                     "userName",
                     "userGroups",
-                    "isGuest"
+                    "isGuest",
+                    "waitlisted"
                 ],
                 "properties": {
                     "id": {
@@ -1215,6 +1256,9 @@
                         }
                     },
                     "isGuest": {
+                        "type": "boolean"
+                    },
+                    "waitlisted": {
                         "type": "boolean"
                     }
                 }
@@ -2345,6 +2389,18 @@
                                         "nullable": true,
                                         "default": null,
                                         "description": "Offer \"Maybe\" as an answer; null follows the instance-wide default"
+                                    },
+                                    "maxAttendees": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "nullable": true,
+                                        "default": null,
+                                        "description": "Attendance limit; null or zero means no limit"
+                                    },
+                                    "waitlistEnabled": {
+                                        "type": "boolean",
+                                        "default": true,
+                                        "description": "Whether a full appointment offers a place in line"
                                     }
                                 }
                             }
@@ -3033,6 +3089,19 @@
                                         "nullable": true,
                                         "default": null,
                                         "description": "Offer \"Maybe\" as an answer, or null to leave unchanged; applied identically to every affected sibling when scope is future/all"
+                                    },
+                                    "maxAttendees": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "nullable": true,
+                                        "default": null,
+                                        "description": "Attendance limit; null or zero clears it, applied identically to every affected sibling when scope is future/all"
+                                    },
+                                    "waitlistEnabled": {
+                                        "type": "boolean",
+                                        "nullable": true,
+                                        "default": null,
+                                        "description": "Whether a full appointment offers a place in line, or null to leave unchanged"
                                     }
                                 }
                             }
@@ -3328,6 +3397,11 @@
                                         "type": "string",
                                         "default": "",
                                         "description": "Optional comment"
+                                    },
+                                    "acceptWaitlist": {
+                                        "type": "boolean",
+                                        "default": false,
+                                        "description": "Take a place in line when the appointment is already full, instead of being turned away"
                                     }
                                 }
                             }

--- a/openapi-full.json
+++ b/openapi-full.json
@@ -60,6 +60,7 @@
                     "pushEnabled",
                     "mobileAppBannerEnabled",
                     "bookingEnabled",
+                    "allowMaybe",
                     "selfCheckinWindowMinutes",
                     "guestsApp"
                 ],
@@ -101,6 +102,9 @@
                         "type": "boolean"
                     },
                     "bookingEnabled": {
+                        "type": "boolean"
+                    },
+                    "allowMaybe": {
                         "type": "boolean"
                     },
                     "selfCheckinWindowMinutes": {
@@ -223,7 +227,8 @@
                     "location",
                     "categoryId",
                     "createTalkRoom",
-                    "talkRoomToken"
+                    "talkRoomToken",
+                    "allowMaybe"
                 ],
                 "properties": {
                     "id": {
@@ -326,6 +331,9 @@
                     "talkRoomToken": {
                         "type": "string",
                         "nullable": true
+                    },
+                    "allowMaybe": {
+                        "type": "boolean"
                     }
                 }
             },
@@ -656,6 +664,9 @@
                     "categoryId": {
                         "type": "integer",
                         "format": "int64"
+                    },
+                    "allowMaybe": {
+                        "type": "boolean"
                     }
                 }
             },
@@ -672,6 +683,8 @@
                     "bookingEnabled",
                     "scheduledFilter",
                     "remindMaybe",
+                    "responseOptions",
+                    "allowMaybeDefault",
                     "responseToggle",
                     "guestInvitation",
                     "auditLog",
@@ -714,6 +727,12 @@
                         "type": "boolean"
                     },
                     "remindMaybe": {
+                        "type": "boolean"
+                    },
+                    "responseOptions": {
+                        "type": "boolean"
+                    },
+                    "allowMaybeDefault": {
                         "type": "boolean"
                     },
                     "responseToggle": {
@@ -2320,6 +2339,12 @@
                                         "type": "boolean",
                                         "default": false,
                                         "description": "Open a Talk conversation with the scheduled people when the inquiry closes"
+                                    },
+                                    "allowMaybe": {
+                                        "type": "boolean",
+                                        "nullable": true,
+                                        "default": null,
+                                        "description": "Offer \"Maybe\" as an answer; null follows the instance-wide default"
                                     }
                                 }
                             }
@@ -3002,6 +3027,12 @@
                                         "nullable": true,
                                         "default": null,
                                         "description": "Open a Talk conversation when the inquiry closes, or null to leave unchanged"
+                                    },
+                                    "allowMaybe": {
+                                        "type": "boolean",
+                                        "nullable": true,
+                                        "default": null,
+                                        "description": "Offer \"Maybe\" as an answer, or null to leave unchanged; applied identically to every affected sibling when scope is future/all"
                                     }
                                 }
                             }
@@ -7808,6 +7839,12 @@
                                         "nullable": true,
                                         "default": null,
                                         "description": "Whether the booking / planning feature is enabled"
+                                    },
+                                    "allowMaybe": {
+                                        "type": "boolean",
+                                        "nullable": true,
+                                        "default": null,
+                                        "description": "Whether appointments offer \"Maybe\" where they have no override of their own"
                                     },
                                     "selfCheckinWindowMinutes": {
                                         "type": "integer",

--- a/openapi.json
+++ b/openapi.json
@@ -47,7 +47,8 @@
                     "location",
                     "categoryId",
                     "createTalkRoom",
-                    "talkRoomToken"
+                    "talkRoomToken",
+                    "allowMaybe"
                 ],
                 "properties": {
                     "id": {
@@ -150,6 +151,9 @@
                     "talkRoomToken": {
                         "type": "string",
                         "nullable": true
+                    },
+                    "allowMaybe": {
+                        "type": "boolean"
                     }
                 }
             },
@@ -480,6 +484,9 @@
                     "categoryId": {
                         "type": "integer",
                         "format": "int64"
+                    },
+                    "allowMaybe": {
+                        "type": "boolean"
                     }
                 }
             },
@@ -496,6 +503,8 @@
                     "bookingEnabled",
                     "scheduledFilter",
                     "remindMaybe",
+                    "responseOptions",
+                    "allowMaybeDefault",
                     "responseToggle",
                     "guestInvitation",
                     "auditLog",
@@ -538,6 +547,12 @@
                         "type": "boolean"
                     },
                     "remindMaybe": {
+                        "type": "boolean"
+                    },
+                    "responseOptions": {
+                        "type": "boolean"
+                    },
+                    "allowMaybeDefault": {
                         "type": "boolean"
                     },
                     "responseToggle": {
@@ -2036,6 +2051,12 @@
                                         "type": "boolean",
                                         "default": false,
                                         "description": "Open a Talk conversation with the scheduled people when the inquiry closes"
+                                    },
+                                    "allowMaybe": {
+                                        "type": "boolean",
+                                        "nullable": true,
+                                        "default": null,
+                                        "description": "Offer \"Maybe\" as an answer; null follows the instance-wide default"
                                     }
                                 }
                             }
@@ -2718,6 +2739,12 @@
                                         "nullable": true,
                                         "default": null,
                                         "description": "Open a Talk conversation when the inquiry closes, or null to leave unchanged"
+                                    },
+                                    "allowMaybe": {
+                                        "type": "boolean",
+                                        "nullable": true,
+                                        "default": null,
+                                        "description": "Offer \"Maybe\" as an answer, or null to leave unchanged; applied identically to every affected sibling when scope is future/all"
                                     }
                                 }
                             }

--- a/openapi.json
+++ b/openapi.json
@@ -48,7 +48,11 @@
                     "categoryId",
                     "createTalkRoom",
                     "talkRoomToken",
-                    "allowMaybe"
+                    "allowMaybe",
+                    "maxAttendees",
+                    "waitlistEnabled",
+                    "occupancy",
+                    "isFull"
                 ],
                 "properties": {
                     "id": {
@@ -153,6 +157,21 @@
                         "nullable": true
                     },
                     "allowMaybe": {
+                        "type": "boolean"
+                    },
+                    "maxAttendees": {
+                        "type": "integer",
+                        "format": "int64",
+                        "nullable": true
+                    },
+                    "waitlistEnabled": {
+                        "type": "boolean"
+                    },
+                    "occupancy": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "isFull": {
                         "type": "boolean"
                     }
                 }
@@ -487,6 +506,13 @@
                     },
                     "allowMaybe": {
                         "type": "boolean"
+                    },
+                    "maxAttendees": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "waitlistEnabled": {
+                        "type": "boolean"
                     }
                 }
             },
@@ -505,6 +531,7 @@
                     "remindMaybe",
                     "responseOptions",
                     "allowMaybeDefault",
+                    "attendanceLimit",
                     "responseToggle",
                     "guestInvitation",
                     "auditLog",
@@ -553,6 +580,9 @@
                         "type": "boolean"
                     },
                     "allowMaybeDefault": {
+                        "type": "boolean"
+                    },
+                    "attendanceLimit": {
                         "type": "boolean"
                     },
                     "responseToggle": {
@@ -842,7 +872,9 @@
                     "isCheckedIn",
                     "responseSource",
                     "checkinSource",
-                    "bookingStatus"
+                    "bookingStatus",
+                    "waitlisted",
+                    "waitlistPosition"
                 ],
                 "properties": {
                     "id": {
@@ -893,6 +925,14 @@
                     "bookingStatus": {
                         "type": "string",
                         "nullable": true
+                    },
+                    "waitlisted": {
+                        "type": "boolean"
+                    },
+                    "waitlistPosition": {
+                        "type": "integer",
+                        "format": "int64",
+                        "nullable": true
                     }
                 }
             },
@@ -915,7 +955,8 @@
                     "bookingStatus",
                     "userName",
                     "userGroups",
-                    "isGuest"
+                    "isGuest",
+                    "waitlisted"
                 ],
                 "properties": {
                     "id": {
@@ -977,6 +1018,9 @@
                         }
                     },
                     "isGuest": {
+                        "type": "boolean"
+                    },
+                    "waitlisted": {
                         "type": "boolean"
                     }
                 }
@@ -2057,6 +2101,18 @@
                                         "nullable": true,
                                         "default": null,
                                         "description": "Offer \"Maybe\" as an answer; null follows the instance-wide default"
+                                    },
+                                    "maxAttendees": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "nullable": true,
+                                        "default": null,
+                                        "description": "Attendance limit; null or zero means no limit"
+                                    },
+                                    "waitlistEnabled": {
+                                        "type": "boolean",
+                                        "default": true,
+                                        "description": "Whether a full appointment offers a place in line"
                                     }
                                 }
                             }
@@ -2745,6 +2801,19 @@
                                         "nullable": true,
                                         "default": null,
                                         "description": "Offer \"Maybe\" as an answer, or null to leave unchanged; applied identically to every affected sibling when scope is future/all"
+                                    },
+                                    "maxAttendees": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "nullable": true,
+                                        "default": null,
+                                        "description": "Attendance limit; null or zero clears it, applied identically to every affected sibling when scope is future/all"
+                                    },
+                                    "waitlistEnabled": {
+                                        "type": "boolean",
+                                        "nullable": true,
+                                        "default": null,
+                                        "description": "Whether a full appointment offers a place in line, or null to leave unchanged"
                                     }
                                 }
                             }
@@ -3040,6 +3109,11 @@
                                         "type": "string",
                                         "default": "",
                                         "description": "Optional comment"
+                                    },
+                                    "acceptWaitlist": {
+                                        "type": "boolean",
+                                        "default": false,
+                                        "description": "Take a place in line when the appointment is already full, instead of being turned away"
                                     }
                                 }
                             }

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -133,8 +133,7 @@
       <code><![CDATA[new DataResponse($results)]]></code>
     </MixedReturnTypeCoercion>
     <PossiblyUnusedParam>
-      <code><![CDATA[$id]]></code>
-      <code><![CDATA[$id]]></code>
+      <code><![CDATA[$acceptWaitlist]]></code>
       <code><![CDATA[$allowMaybe]]></code>
       <code><![CDATA[$allowMaybe]]></code>
       <code><![CDATA[$appointmentId]]></code>
@@ -173,9 +172,13 @@
       <code><![CDATA[$id]]></code>
       <code><![CDATA[$id]]></code>
       <code><![CDATA[$id]]></code>
+      <code><![CDATA[$id]]></code>
+      <code><![CDATA[$id]]></code>
       <code><![CDATA[$includeComments]]></code>
       <code><![CDATA[$location]]></code>
       <code><![CDATA[$location]]></code>
+      <code><![CDATA[$maxAttendees]]></code>
+      <code><![CDATA[$maxAttendees]]></code>
       <code><![CDATA[$name]]></code>
       <code><![CDATA[$name]]></code>
       <code><![CDATA[$notScheduledOut]]></code>
@@ -184,11 +187,11 @@
       <code><![CDATA[$organizers]]></code>
       <code><![CDATA[$organizers]]></code>
       <code><![CDATA[$organizers]]></code>
+      <code><![CDATA[$response]]></code>
+      <code><![CDATA[$response]]></code>
+      <code><![CDATA[$response]]></code>
       <code><![CDATA[$responseDeadline]]></code>
       <code><![CDATA[$responseDeadline]]></code>
-      <code><![CDATA[$response]]></code>
-      <code><![CDATA[$response]]></code>
-      <code><![CDATA[$response]]></code>
       <code><![CDATA[$scope]]></code>
       <code><![CDATA[$scope]]></code>
       <code><![CDATA[$sendNotification]]></code>
@@ -197,9 +200,9 @@
       <code><![CDATA[$startDate]]></code>
       <code><![CDATA[$startDatetime]]></code>
       <code><![CDATA[$startDatetime]]></code>
-      <code><![CDATA[$targetUserId]]></code>
-      <code><![CDATA[$targetUserId]]></code>
       <code><![CDATA[$target]]></code>
+      <code><![CDATA[$targetUserId]]></code>
+      <code><![CDATA[$targetUserId]]></code>
       <code><![CDATA[$unansweredOnly]]></code>
       <code><![CDATA[$userId]]></code>
       <code><![CDATA[$userId]]></code>
@@ -210,6 +213,8 @@
       <code><![CDATA[$visibleTeams]]></code>
       <code><![CDATA[$visibleUsers]]></code>
       <code><![CDATA[$visibleUsers]]></code>
+      <code><![CDATA[$waitlistEnabled]]></code>
+      <code><![CDATA[$waitlistEnabled]]></code>
     </PossiblyUnusedParam>
     <UndefinedDocblockClass>
       <code><![CDATA[DataResponse<Http::STATUS_CREATED, AttendanceAppointmentData, array{}>|DataResponse<Http::STATUS_BAD_REQUEST, array{error: string}, array{}>|DataResponse<Http::STATUS_UNAUTHORIZED, array{error: string}, array{}>|DataResponse<Http::STATUS_FORBIDDEN, array{error: string}, array{}>]]></code>
@@ -217,6 +222,8 @@
       <code><![CDATA[DataResponse<Http::STATUS_OK, AttendanceAppointmentData, array{}>|DataResponse<Http::STATUS_UNAUTHORIZED, array{error: string}, array{}>|DataResponse<Http::STATUS_FORBIDDEN, array{error: string}, array{}>|DataResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>]]></code>
       <code><![CDATA[DataResponse<Http::STATUS_OK, AttendanceAppointmentData, array{}>|DataResponse<Http::STATUS_UNAUTHORIZED, array{error: string}, array{}>|DataResponse<Http::STATUS_FORBIDDEN, array{error: string}, array{}>|DataResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>]]></code>
       <code><![CDATA[DataResponse<Http::STATUS_OK, AttendanceAppointmentData, array{}>|DataResponse<Http::STATUS_UNAUTHORIZED, array{error: string}, array{}>|DataResponse<Http::STATUS_FORBIDDEN, array{error: string}, array{}>|DataResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>]]></code>
+      <code><![CDATA[DataResponse<Http::STATUS_OK, AttendanceAppointmentData, array{}>|DataResponse<Http::STATUS_UNAUTHORIZED, array{error: string}, array{}>|DataResponse<Http::STATUS_FORBIDDEN, array{error: string}, array{}>|DataResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>|DataResponse<Http::STATUS_BAD_REQUEST, array{error: string}, array{}>]]></code>
+      <code><![CDATA[DataResponse<Http::STATUS_OK, AttendanceAppointmentData, array{}>|DataResponse<Http::STATUS_UNAUTHORIZED, array{error: string}, array{}>|DataResponse<Http::STATUS_FORBIDDEN, array{error: string}, array{}>|DataResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>|DataResponse<Http::STATUS_BAD_REQUEST, array{error: string}, array{}>]]></code>
       <code><![CDATA[DataResponse<Http::STATUS_OK, AttendanceAppointmentData|list<AttendanceAppointmentData>, array{}>|DataResponse<Http::STATUS_BAD_REQUEST, array{error: string}, array{}>|DataResponse<Http::STATUS_UNAUTHORIZED, array{error: string}, array{}>|DataResponse<Http::STATUS_FORBIDDEN, array{error: string}, array{}>|DataResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>]]></code>
       <code><![CDATA[DataResponse<Http::STATUS_OK, AttendanceAppointmentWithResponse, array{}>|DataResponse<Http::STATUS_UNAUTHORIZED, array{error: string}, array{}>|DataResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>]]></code>
       <code><![CDATA[DataResponse<Http::STATUS_OK, AttendanceCapabilities, array{}>]]></code>
@@ -239,8 +246,6 @@
       <code><![CDATA[DataResponse<Http::STATUS_OK, list<AttendanceAppointmentWithResponse>, array{}>|DataResponse<Http::STATUS_UNAUTHORIZED, array{error: string}, array{}>]]></code>
       <code><![CDATA[DataResponse<Http::STATUS_OK, list<AttendanceResponseWithUser>, array{}>|DataResponse<Http::STATUS_UNAUTHORIZED, array{error: string}, array{}>|DataResponse<Http::STATUS_FORBIDDEN, array{error: string}, array{}>|DataResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>]]></code>
       <code><![CDATA[list<AttendanceBulkAppointmentItem>]]></code>
-      <code><![CDATA[DataResponse<Http::STATUS_OK, AttendanceAppointmentData, array{}>|DataResponse<Http::STATUS_UNAUTHORIZED, array{error: string}, array{}>|DataResponse<Http::STATUS_FORBIDDEN, array{error: string}, array{}>|DataResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>|DataResponse<Http::STATUS_BAD_REQUEST, array{error: string}, array{}>]]></code>
-      <code><![CDATA[DataResponse<Http::STATUS_OK, AttendanceAppointmentData, array{}>|DataResponse<Http::STATUS_UNAUTHORIZED, array{error: string}, array{}>|DataResponse<Http::STATUS_FORBIDDEN, array{error: string}, array{}>|DataResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>|DataResponse<Http::STATUS_BAD_REQUEST, array{error: string}, array{}>]]></code>
     </UndefinedDocblockClass>
     <UnusedClass>
       <code><![CDATA[AppointmentController]]></code>
@@ -293,9 +298,9 @@
       <code><![CDATA[$name]]></code>
     </PossiblyUnusedParam>
     <UndefinedDocblockClass>
-      <code><![CDATA[DataResponse<Http::STATUS_OK, list<AttendanceCategoryData>, array{}>|DataResponse<Http::STATUS_UNAUTHORIZED, array{error: string}, array{}>]]></code>
       <code><![CDATA[DataResponse<Http::STATUS_CREATED, AttendanceCategoryData, array{}>|DataResponse<Http::STATUS_BAD_REQUEST, array{error: string}, array{}>|DataResponse<Http::STATUS_UNAUTHORIZED, array{error: string}, array{}>|DataResponse<Http::STATUS_FORBIDDEN, array{error: string}, array{}>]]></code>
       <code><![CDATA[DataResponse<Http::STATUS_OK, AttendanceCategoryData, array{}>|DataResponse<Http::STATUS_BAD_REQUEST, array{error: string}, array{}>|DataResponse<Http::STATUS_UNAUTHORIZED, array{error: string}, array{}>|DataResponse<Http::STATUS_FORBIDDEN, array{error: string}, array{}>|DataResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>]]></code>
+      <code><![CDATA[DataResponse<Http::STATUS_OK, list<AttendanceCategoryData>, array{}>|DataResponse<Http::STATUS_UNAUTHORIZED, array{error: string}, array{}>]]></code>
     </UndefinedDocblockClass>
     <UnusedClass>
       <code><![CDATA[CategoryController]]></code>
@@ -430,6 +435,7 @@
       <code><![CDATA[$endDatetime]]></code>
       <code><![CDATA[$isActive]]></code>
       <code><![CDATA[$location]]></code>
+      <code><![CDATA[$maxAttendees]]></code>
       <code><![CDATA[$name]]></code>
       <code><![CDATA[$organizers]]></code>
       <code><![CDATA[$responseDeadline]]></code>
@@ -442,6 +448,7 @@
       <code><![CDATA[$visibleGroups]]></code>
       <code><![CDATA[$visibleTeams]]></code>
       <code><![CDATA[$visibleUsers]]></code>
+      <code><![CDATA[$waitlistEnabled]]></code>
     </MissingPropertyType>
     <MixedArgument>
       <code><![CDATA[$this->parseJsonField($this->getOrganizers())]]></code>
@@ -463,6 +470,7 @@
       <code><![CDATA[$endDatetime]]></code>
       <code><![CDATA[$isActive]]></code>
       <code><![CDATA[$location]]></code>
+      <code><![CDATA[$maxAttendees]]></code>
       <code><![CDATA[$name]]></code>
       <code><![CDATA[$organizers]]></code>
       <code><![CDATA[$responseDeadline]]></code>
@@ -475,6 +483,7 @@
       <code><![CDATA[$visibleGroups]]></code>
       <code><![CDATA[$visibleTeams]]></code>
       <code><![CDATA[$visibleUsers]]></code>
+      <code><![CDATA[$waitlistEnabled]]></code>
     </PossiblyUnusedProperty>
     <PropertyNotSetInConstructor>
       <code><![CDATA[Appointment]]></code>
@@ -567,7 +576,10 @@
       <code><![CDATA[$respondedAt]]></code>
       <code><![CDATA[$response]]></code>
       <code><![CDATA[$responseSource]]></code>
+      <code><![CDATA[$spotClaimedAt]]></code>
       <code><![CDATA[$userId]]></code>
+      <code><![CDATA[$waitlistNotifiedAt]]></code>
+      <code><![CDATA[$waitlistNotifiedStatus]]></code>
     </MissingPropertyType>
     <PossiblyUnusedProperty>
       <code><![CDATA[$appointmentId]]></code>
@@ -583,7 +595,10 @@
       <code><![CDATA[$respondedAt]]></code>
       <code><![CDATA[$response]]></code>
       <code><![CDATA[$responseSource]]></code>
+      <code><![CDATA[$spotClaimedAt]]></code>
       <code><![CDATA[$userId]]></code>
+      <code><![CDATA[$waitlistNotifiedAt]]></code>
+      <code><![CDATA[$waitlistNotifiedStatus]]></code>
     </PossiblyUnusedProperty>
     <PropertyNotSetInConstructor>
       <code><![CDATA[AttendanceResponse]]></code>
@@ -1277,6 +1292,19 @@
       <code><![CDATA[Version000023Date20260903120000]]></code>
     </UnusedClass>
   </file>
+  <file src="lib/Migration/Version000024Date20260903130000.php">
+    <UnusedClass>
+      <code><![CDATA[Version000024Date20260903130000]]></code>
+    </UnusedClass>
+  </file>
+  <file src="lib/Service/AppointmentSerializer.php">
+    <ClassMustBeFinal>
+      <code><![CDATA[AppointmentSerializer]]></code>
+    </ClassMustBeFinal>
+    <PossiblyUnusedMethod>
+      <code><![CDATA[__construct]]></code>
+    </PossiblyUnusedMethod>
+  </file>
   <file src="lib/Service/AppointmentService.php">
     <ArgumentTypeCoercion>
       <code><![CDATA[$siblings]]></code>
@@ -1347,10 +1375,6 @@
     <MixedOperand>
       <code><![CDATA[$result['id']]]></code>
     </MixedOperand>
-    <MixedReturnTypeCoercion>
-      <code><![CDATA[$data]]></code>
-      <code><![CDATA[array<string, mixed>|null]]></code>
-    </MixedReturnTypeCoercion>
     <PossiblyFalseArgument>
       <code><![CDATA[$normalized === [] ? null : json_encode($normalized)]]></code>
       <code><![CDATA[$visibleGroupsJson]]></code>
@@ -1540,6 +1564,14 @@
       <code><![CDATA[__construct]]></code>
     </PossiblyUnusedMethod>
   </file>
+  <file src="lib/Service/CapacityService.php">
+    <ClassMustBeFinal>
+      <code><![CDATA[CapacityService]]></code>
+    </ClassMustBeFinal>
+    <PossiblyUnusedMethod>
+      <code><![CDATA[__construct]]></code>
+    </PossiblyUnusedMethod>
+  </file>
   <file src="lib/Service/CategoryService.php">
     <ClassMustBeFinal>
       <code><![CDATA[CategoryService]]></code>
@@ -1563,19 +1595,7 @@
       <code><![CDATA[$userId]]></code>
       <code><![CDATA[$whitelistedGroups]]></code>
     </MixedArgument>
-    <MixedArrayAccess>
-      <code><![CDATA[$responseData['checkinAt']]]></code>
-      <code><![CDATA[$responseData['checkinBy']]]></code>
-      <code><![CDATA[$responseData['checkinComment']]]></code>
-      <code><![CDATA[$responseData['checkinSource']]]></code>
-      <code><![CDATA[$responseData['checkinState']]]></code>
-      <code><![CDATA[$responseData['comment']]]></code>
-      <code><![CDATA[$responseData['isCheckedIn']]]></code>
-      <code><![CDATA[$responseData['response']]]></code>
-    </MixedArrayAccess>
     <MixedAssignment>
-      <code><![CDATA[$response]]></code>
-      <code><![CDATA[$responseData]]></code>
       <code><![CDATA[$userData['checkinAt']]]></code>
       <code><![CDATA[$userData['checkinBy']]]></code>
       <code><![CDATA[$userData['checkinComment']]]></code>
@@ -1588,7 +1608,6 @@
     </MixedAssignment>
     <MixedMethodCall>
       <code><![CDATA[getUID]]></code>
-      <code><![CDATA[jsonSerialize]]></code>
     </MixedMethodCall>
     <PossiblyUnusedMethod>
       <code><![CDATA[__construct]]></code>
@@ -1686,56 +1705,23 @@
     <MixedArgument>
       <code><![CDATA[$a->getStartDatetime()]]></code>
       <code><![CDATA[$a['displayName']]]></code>
-      <code><![CDATA[$appointment->getName()]]></code>
-      <code><![CDATA[$appointment->getStartDatetime()]]></code>
       <code><![CDATA[$b->getStartDatetime()]]></code>
       <code><![CDATA[$b['displayName']]]></code>
-      <code><![CDATA[$checkinValue]]></code>
-      <code><![CDATA[$location]]></code>
-      <code><![CDATA[$response->getComment()]]></code>
-      <code><![CDATA[$rsvpValue]]></code>
-      <code><![CDATA[$user['displayName']]]></code>
-      <code><![CDATA[$user['group']]]></code>
     </MixedArgument>
     <MixedArrayAccess>
       <code><![CDATA[$a['displayName']]]></code>
-      <code><![CDATA[$appointmentResponses[$appointment->getId()][$user['userId']]]]></code>
       <code><![CDATA[$b['displayName']]]></code>
-      <code><![CDATA[$user['displayName']]]></code>
-      <code><![CDATA[$user['group']]]></code>
-      <code><![CDATA[$user['userId']]]></code>
     </MixedArrayAccess>
-    <MixedArrayOffset>
-      <code><![CDATA[$appointmentResponses[$appointment->getId()]]]></code>
-      <code><![CDATA[$appointmentResponses[$appointment->getId()][$user['userId']]]]></code>
-    </MixedArrayOffset>
     <MixedAssignment>
-      <code><![CDATA[$appointment]]></code>
-      <code><![CDATA[$appointment]]></code>
-      <code><![CDATA[$appointment]]></code>
-      <code><![CDATA[$appointment]]></code>
       <code><![CDATA[$attendanceFolder]]></code>
-      <code><![CDATA[$checkinValue]]></code>
       <code><![CDATA[$existingFile]]></code>
       <code><![CDATA[$file]]></code>
-      <code><![CDATA[$location]]></code>
-      <code><![CDATA[$response]]></code>
-      <code><![CDATA[$rsvpValue]]></code>
-      <code><![CDATA[$user]]></code>
       <code><![CDATA[$userFolder]]></code>
     </MixedAssignment>
     <MixedMethodCall>
       <code><![CDATA[delete]]></code>
       <code><![CDATA[get]]></code>
       <code><![CDATA[get]]></code>
-      <code><![CDATA[getCheckinState]]></code>
-      <code><![CDATA[getComment]]></code>
-      <code><![CDATA[getComment]]></code>
-      <code><![CDATA[getId]]></code>
-      <code><![CDATA[getLocation]]></code>
-      <code><![CDATA[getName]]></code>
-      <code><![CDATA[getResponse]]></code>
-      <code><![CDATA[getStartDatetime]]></code>
       <code><![CDATA[getStartDatetime]]></code>
       <code><![CDATA[getStartDatetime]]></code>
       <code><![CDATA[newFile]]></code>
@@ -1755,6 +1741,7 @@
     </PossiblyUnusedMethod>
     <PossiblyUnusedParam>
       <code><![CDATA[$appointmentMapper]]></code>
+      <code><![CDATA[$capacityService]]></code>
       <code><![CDATA[$configService]]></code>
       <code><![CDATA[$groupManager]]></code>
       <code><![CDATA[$l10n]]></code>
@@ -1765,9 +1752,6 @@
     </PossiblyUnusedParam>
     <RiskyTruthyFalsyComparison>
       <code><![CDATA[$attendanceFolder->nodeExists($filename)]]></code>
-      <code><![CDATA[$response]]></code>
-      <code><![CDATA[$response]]></code>
-      <code><![CDATA[$response]]></code>
     </RiskyTruthyFalsyComparison>
     <UnusedForeachValue>
       <code><![CDATA[$appointment]]></code>
@@ -1800,24 +1784,15 @@
     <DeprecatedMethod>
       <code><![CDATA[getUserValue]]></code>
     </DeprecatedMethod>
-    <MissingParamType>
-      <code><![CDATA[$l]]></code>
-      <code><![CDATA[$response]]></code>
-    </MissingParamType>
     <MixedArgument>
       <code><![CDATA[$appointment]]></code>
-      <code><![CDATA[$response]]></code>
-      <code><![CDATA[$response->getRespondedAt()]]></code>
     </MixedArgument>
     <MixedArgumentTypeCoercion>
       <code><![CDATA[$attachmentLines]]></code>
-      <code><![CDATA[$descriptionParts]]></code>
     </MixedArgumentTypeCoercion>
     <MixedArrayOffset>
       <code><![CDATA[$attachmentUrls[$attachment->getFileId()]]]></code>
       <code><![CDATA[$attachmentUrls[$attachment->getFileId()]]]></code>
-      <code><![CDATA[$responseLabels[$responseState]]]></code>
-      <code><![CDATA[$transpMap[$responseState]]]></code>
       <code><![CDATA[$userResponses[$appointment->getId()]]]></code>
     </MixedArrayOffset>
     <MixedAssignment>
@@ -1825,50 +1800,18 @@
       <code><![CDATA[$attachment]]></code>
       <code><![CDATA[$attachment]]></code>
       <code><![CDATA[$attachmentLines[]]]></code>
-      <code><![CDATA[$descriptionParts[]]]></code>
       <code><![CDATA[$instanceName]]></code>
-      <code><![CDATA[$responseComment]]></code>
-      <code><![CDATA[$responseLabel]]></code>
-      <code><![CDATA[$responseState]]></code>
-      <code><![CDATA[$statusLabel]]></code>
-      <code><![CDATA[$statusLabel]]></code>
     </MixedAssignment>
     <MixedMethodCall>
-      <code><![CDATA[getComment]]></code>
       <code><![CDATA[getFileId]]></code>
       <code><![CDATA[getFileId]]></code>
       <code><![CDATA[getFileId]]></code>
       <code><![CDATA[getFileName]]></code>
       <code><![CDATA[getId]]></code>
-      <code><![CDATA[getRespondedAt]]></code>
-      <code><![CDATA[getRespondedAt]]></code>
-      <code><![CDATA[getResponse]]></code>
-      <code><![CDATA[t]]></code>
-      <code><![CDATA[t]]></code>
-      <code><![CDATA[t]]></code>
-      <code><![CDATA[t]]></code>
-      <code><![CDATA[t]]></code>
-      <code><![CDATA[t]]></code>
-      <code><![CDATA[t]]></code>
-      <code><![CDATA[t]]></code>
-      <code><![CDATA[t]]></code>
-      <code><![CDATA[t]]></code>
-      <code><![CDATA[t]]></code>
-      <code><![CDATA[t]]></code>
     </MixedMethodCall>
     <MixedOperand>
       <code><![CDATA[$attachment->getFileId()]]></code>
       <code><![CDATA[$instanceName]]></code>
-      <code><![CDATA[$l->t('Attachments')]]></code>
-      <code><![CDATA[$l->t('Cancelled')]]></code>
-      <code><![CDATA[$l->t('Me')]]></code>
-      <code><![CDATA[$l->t('Me')]]></code>
-      <code><![CDATA[$l->t('View or change your response')]]></code>
-      <code><![CDATA[$l->t('Your response')]]></code>
-      <code><![CDATA[$responseComment]]></code>
-      <code><![CDATA[$responseLabel]]></code>
-      <code><![CDATA[$responseLabel]]></code>
-      <code><![CDATA[$statusLabel]]></code>
     </MixedOperand>
     <PossiblyFalseArgument>
       <code><![CDATA[$domain]]></code>
@@ -1998,15 +1941,6 @@
     <MissingClosureReturnType>
       <code><![CDATA[fn ($r) => $r->getUserId()]]></code>
     </MissingClosureReturnType>
-    <MissingParamType>
-      <code><![CDATA[$response]]></code>
-      <code><![CDATA[$response]]></code>
-      <code><![CDATA[$response]]></code>
-      <code><![CDATA[$response]]></code>
-      <code><![CDATA[$user]]></code>
-      <code><![CDATA[$user]]></code>
-      <code><![CDATA[$user]]></code>
-    </MissingParamType>
     <MixedArgument>
       <code><![CDATA[$cache['appointmentVisibleGroupsLower']]]></code>
       <code><![CDATA[$cache['groupUsers']]]></code>
@@ -2024,14 +1958,10 @@
       <code><![CDATA[$summary['by_team']]]></code>
       <code><![CDATA[$teamMemberIds]]></code>
       <code><![CDATA[$teamMemberIds]]></code>
-      <code><![CDATA[$user->getUID()]]></code>
-      <code><![CDATA[$userId]]></code>
       <code><![CDATA[$userId]]></code>
     </MixedArgument>
     <MixedArrayAccess>
       <code><![CDATA[$cache['groupUsers'][$groupId]]]></code>
-      <code><![CDATA[$responseData['checkinComment']]]></code>
-      <code><![CDATA[$responseData['comment']]]></code>
       <code><![CDATA[$summary['by_group'][$groupId]]]></code>
       <code><![CDATA[$summary['by_group'][$groupId][$responseValue]]]></code>
       <code><![CDATA[$summary['by_team'][$teamId]]]></code>
@@ -2041,8 +1971,6 @@
       <code><![CDATA[$teamInfo['label']]]></code>
     </MixedArrayAccess>
     <MixedArrayAssignment>
-      <code><![CDATA[$responseData['isGuest']]]></code>
-      <code><![CDATA[$responseData['userName']]]></code>
       <code><![CDATA[$summary['by_group'][$groupId]]]></code>
       <code><![CDATA[$summary['by_group'][$groupId]]]></code>
       <code><![CDATA[$summary['by_group'][$groupId]]]></code>
@@ -2096,8 +2024,6 @@
       <code><![CDATA[$nameA]]></code>
       <code><![CDATA[$nameB]]></code>
       <code><![CDATA[$nameB]]></code>
-      <code><![CDATA[$responseData]]></code>
-      <code><![CDATA[$responseData['userName']]]></code>
       <code><![CDATA[$sortedByGroup[$groupId]]]></code>
       <code><![CDATA[$sortedByGroup[$groupId]]]></code>
       <code><![CDATA[$sortedByGroup[$groupId]]]></code>
@@ -2112,23 +2038,16 @@
       <code><![CDATA[$teamInfo]]></code>
       <code><![CDATA[$teamMemberIds]]></code>
       <code><![CDATA[$teamMemberIds]]></code>
-      <code><![CDATA[$user]]></code>
       <code><![CDATA[$userGroups]]></code>
       <code><![CDATA[$userGroups]]></code>
-      <code><![CDATA[$userId]]></code>
       <code><![CDATA[$userId]]></code>
       <code><![CDATA[$userResponse]]></code>
       <code><![CDATA[$userResponse]]></code>
     </MixedAssignment>
     <MixedMethodCall>
-      <code><![CDATA[getDisplayName]]></code>
       <code><![CDATA[getGID]]></code>
       <code><![CDATA[getGID]]></code>
-      <code><![CDATA[getResponse]]></code>
-      <code><![CDATA[getUID]]></code>
       <code><![CDATA[getUserId]]></code>
-      <code><![CDATA[getUserId]]></code>
-      <code><![CDATA[jsonSerialize]]></code>
     </MixedMethodCall>
     <MixedOperand>
       <code><![CDATA[$summary[$responseValue]]]></code>
@@ -2136,9 +2055,6 @@
       <code><![CDATA[$summary['by_team'][$teamId][$responseValue]]]></code>
       <code><![CDATA[$summary['others'][$responseValue]]]></code>
     </MixedOperand>
-    <MixedReturnStatement>
-      <code><![CDATA[$responseData]]></code>
-    </MixedReturnStatement>
     <PossiblyUndefinedArrayOffset>
       <code><![CDATA[$byGroup[$groupId]]]></code>
       <code><![CDATA[$byTeam[$teamId]]]></code>
@@ -2150,7 +2066,6 @@
       <code><![CDATA[$info]]></code>
       <code><![CDATA[$teamInfo]]></code>
       <code><![CDATA[$teamInfo]]></code>
-      <code><![CDATA[$user]]></code>
     </RiskyTruthyFalsyComparison>
   </file>
   <file src="lib/Service/SelfCheckinService.php">

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -135,6 +135,8 @@
     <PossiblyUnusedParam>
       <code><![CDATA[$id]]></code>
       <code><![CDATA[$id]]></code>
+      <code><![CDATA[$allowMaybe]]></code>
+      <code><![CDATA[$allowMaybe]]></code>
       <code><![CDATA[$appointmentId]]></code>
       <code><![CDATA[$appointmentId]]></code>
       <code><![CDATA[$appointmentIds]]></code>
@@ -415,6 +417,7 @@
       <code><![CDATA[public function jsonSerialize(): array {]]></code>
     </MissingOverrideAttribute>
     <MissingPropertyType>
+      <code><![CDATA[$allowMaybe]]></code>
       <code><![CDATA[$calendarEventUid]]></code>
       <code><![CDATA[$calendarUri]]></code>
       <code><![CDATA[$cancelledAt]]></code>
@@ -447,6 +450,7 @@
       <code><![CDATA[$decoded]]></code>
     </MixedAssignment>
     <PossiblyUnusedProperty>
+      <code><![CDATA[$allowMaybe]]></code>
       <code><![CDATA[$calendarEventUid]]></code>
       <code><![CDATA[$calendarUri]]></code>
       <code><![CDATA[$cancelledAt]]></code>
@@ -1268,6 +1272,11 @@
       <code><![CDATA[Version000022Date20260816120000]]></code>
     </UnusedClass>
   </file>
+  <file src="lib/Migration/Version000023Date20260903120000.php">
+    <UnusedClass>
+      <code><![CDATA[Version000023Date20260903120000]]></code>
+    </UnusedClass>
+  </file>
   <file src="lib/Service/AppointmentService.php">
     <ArgumentTypeCoercion>
       <code><![CDATA[$siblings]]></code>
@@ -1951,6 +1960,14 @@
     <MixedReturnStatement>
       <code><![CDATA[$this->config->getSystemValue('secret', '')]]></code>
     </MixedReturnStatement>
+    <PossiblyUnusedMethod>
+      <code><![CDATA[__construct]]></code>
+    </PossiblyUnusedMethod>
+  </file>
+  <file src="lib/Service/ResponsePolicyService.php">
+    <ClassMustBeFinal>
+      <code><![CDATA[ResponsePolicyService]]></code>
+    </ClassMustBeFinal>
     <PossiblyUnusedMethod>
       <code><![CDATA[__construct]]></code>
     </PossiblyUnusedMethod>

--- a/src/components/appointment/AppointmentCard.vue
+++ b/src/components/appointment/AppointmentCard.vue
@@ -110,7 +110,11 @@
 				:comment="appointment.userResponse?.comment || ''"
 				:responseDeadline="appointment.responseDeadline"
 				:responseOptions="responseOptions"
-				@submitResponse="(id, response) => emit('submitResponse', id, response)" />
+				:isFull="appointment.isFull === true"
+				:waitlistEnabled="appointment.waitlistEnabled === true"
+				:waitlisted="appointment.userResponse?.waitlisted === true"
+				:waitlistPosition="appointment.userResponse?.waitlistPosition ?? null"
+				@submitResponse="(id, response, acceptWaitlist) => emit('submitResponse', id, response, acceptWaitlist)" />
 		</div>
 
 		<!-- Response: read-only once closed or cancelled -->

--- a/src/components/appointment/AppointmentCard.vue
+++ b/src/components/appointment/AppointmentCard.vue
@@ -109,6 +109,7 @@
 				:userResponse="userResponse"
 				:comment="appointment.userResponse?.comment || ''"
 				:responseDeadline="appointment.responseDeadline"
+				:responseOptions="responseOptions"
 				@submitResponse="(id, response) => emit('submitResponse', id, response)" />
 		</div>
 
@@ -151,6 +152,7 @@
 			:appointmentId="appointment.id"
 			:isClosed="isClosed"
 			:acceptsResponses="acceptsResponses"
+			:responseOptions="responseOptions"
 			@refreshAppointment="emit('refreshAppointment')" />
 	</div>
 </template>
@@ -176,7 +178,7 @@ import { finalScheduleStatus, formatCancelledLabel, formatClosedLabel } from '..
 import { categoryIconComponent } from '../../utils/categoryIcons.js'
 import { formatTime } from '../../utils/datetime.js'
 import { renderMarkdown, sanitizeHtml } from '../../utils/markdown.js'
-import { getResponseText } from '../../utils/response.js'
+import { getResponseText, responseOptionsFor } from '../../utils/response.js'
 
 const props = defineProps({
 	appointment: {
@@ -196,6 +198,10 @@ const emit = defineEmits([
 	'showAuditLog',
 	'refreshAppointment',
 ])
+
+// Answers this appointment offers — the buttons must not show one the server
+// would reject.
+const responseOptions = computed(() => responseOptionsFor(props.appointment.allowMaybe))
 
 // NB: pass a getter, never bind it to a name — every top-level binding in
 // <script setup> is exposed to the template, and a local `appointment` would

--- a/src/components/appointment/AppointmentListCard.vue
+++ b/src/components/appointment/AppointmentListCard.vue
@@ -75,7 +75,11 @@
 				:comment="appointment.userResponse?.comment || ''"
 				:responseDeadline="appointment.responseDeadline"
 				:responseOptions="responseOptions"
-				@submitResponse="(id, response) => emit('submitResponse', id, response)">
+				:isFull="appointment.isFull === true"
+				:waitlistEnabled="appointment.waitlistEnabled === true"
+				:waitlisted="appointment.userResponse?.waitlisted === true"
+				:waitlistPosition="appointment.userResponse?.waitlistPosition ?? null"
+				@submitResponse="(id, response, acceptWaitlist) => emit('submitResponse', id, response, acceptWaitlist)">
 				<template #label>
 					<span class="list-card__label">{{ t("attendance", "Your response") }}</span>
 				</template>

--- a/src/components/appointment/AppointmentListCard.vue
+++ b/src/components/appointment/AppointmentListCard.vue
@@ -74,6 +74,7 @@
 				:userResponse="userResponse"
 				:comment="appointment.userResponse?.comment || ''"
 				:responseDeadline="appointment.responseDeadline"
+				:responseOptions="responseOptions"
 				@submitResponse="(id, response) => emit('submitResponse', id, response)">
 				<template #label>
 					<span class="list-card__label">{{ t("attendance", "Your response") }}</span>
@@ -124,7 +125,7 @@ import { useAppointmentCard } from '../../composables/useAppointmentCard.js'
 import { appointmentDetailUrl, formatCancelledLabel, formatClosedLabel } from '../../utils/appointment.js'
 import { categoryIconComponent } from '../../utils/categoryIcons.js'
 import { stripMarkdown } from '../../utils/markdown.js'
-import { getResponseText, responseSegments } from '../../utils/response.js'
+import { getResponseText, responseOptionsFor, responseSegments } from '../../utils/response.js'
 
 const props = defineProps({
 	appointment: {
@@ -144,6 +145,10 @@ const emit = defineEmits([
 	'closedToggled',
 	'showAuditLog',
 ])
+
+// Answers this appointment offers — the buttons must not show one the server
+// would reject.
+const responseOptions = computed(() => responseOptionsFor(props.appointment.allowMaybe))
 
 const {
 	isCancelled,

--- a/src/components/appointment/NonRespondingUserList.vue
+++ b/src/components/appointment/NonRespondingUserList.vue
@@ -15,6 +15,7 @@
 					:userId="user.userId"
 					:displayName="user.displayName"
 					:pending="settingAnswer.has(user.userId)"
+					:responseOptions="responseOptions"
 					@setAnswer="(userId, value) => emit('setAnswer', userId, value)">
 					<template #default="{ pending }">
 						<NcButton
@@ -62,8 +63,14 @@ import BellRingOutlineIcon from 'vue-material-design-icons/BellRingOutline.vue'
 import PencilOutlineIcon from 'vue-material-design-icons/PencilOutline.vue'
 import RemindUserPopover from './RemindUserPopover.vue'
 import SetAnswerPopover from './SetAnswerPopover.vue'
+import { RESPONSE_ORDER } from '../../utils/response.js'
 
 const props = defineProps({
+	// Which answers this appointment offers, in display order.
+	responseOptions: {
+		type: Array,
+		default: () => RESPONSE_ORDER,
+	},
 	users: {
 		type: Array,
 		required: true,

--- a/src/components/appointment/ResponseEditor.vue
+++ b/src/components/appointment/ResponseEditor.vue
@@ -56,6 +56,14 @@
 		</div>
 
 		<div
+			v-if="capacityNotice"
+			class="response-editor__capacity"
+			data-test="capacity-notice">
+			<AccountGroupIcon :size="15" />
+			<span>{{ capacityNotice }}</span>
+		</div>
+
+		<div
 			v-if="formattedDeadline"
 			class="response-editor__deadline"
 			data-test="deadline-info">
@@ -68,6 +76,7 @@
 <script setup>
 import { NcButton, NcInputField } from '@nextcloud/vue'
 import { computed, nextTick, ref, watch } from 'vue'
+import AccountGroupIcon from 'vue-material-design-icons/AccountGroup.vue'
 import CheckCircle from 'vue-material-design-icons/CheckCircle.vue'
 import ClockIcon from 'vue-material-design-icons/Clock.vue'
 import CloseCircle from 'vue-material-design-icons/CloseCircle.vue'
@@ -104,6 +113,26 @@ const props = defineProps({
 		type: Array,
 		default: () => RESPONSE_ORDER,
 	},
+	// The appointment has an attendance limit and it is taken.
+	isFull: {
+		type: Boolean,
+		default: false,
+	},
+	// This person's yes is a place in line rather than a spot.
+	waitlisted: {
+		type: Boolean,
+		default: false,
+	},
+	// Their place in line, counted from 1.
+	waitlistPosition: {
+		type: Number,
+		default: null,
+	},
+	// A full appointment can turn people away instead of queueing them.
+	waitlistEnabled: {
+		type: Boolean,
+		default: false,
+	},
 })
 
 const emit = defineEmits(['submitResponse'])
@@ -111,12 +140,35 @@ const emit = defineEmits(['submitResponse'])
 // Labels, variants and glyphs all come from the shared response helpers, so
 // the buttons carry the same filled circles the sidebar uses.
 const ICONS = { CheckCircle, HelpCircle, CloseCircle }
-const options = computed(() => props.responseOptions.map((value) => ({
-	value,
-	label: getResponseText(value),
-	variant: getResponseVariant(value),
-	icon: ICONS[getResponseIcon(value)],
-})))
+// Somebody who has not got a spot is offered the queue instead of a yes, so
+// the button says what the click will actually do. "No" is never taken away:
+// declining a full appointment is information the organizer wants.
+const joiningWaitlist = computed(() => props.isFull && props.waitlistEnabled && props.userResponse !== 'yes')
+
+const options = computed(() => props.responseOptions
+	.filter((value) => value !== 'yes' || !props.isFull || props.waitlistEnabled || props.userResponse === 'yes')
+	.map((value) => ({
+		value,
+		label: value === 'yes' && joiningWaitlist.value
+			? t('attendance', 'Join waitlist')
+			: getResponseText(value),
+		variant: getResponseVariant(value),
+		icon: ICONS[getResponseIcon(value)],
+	})))
+
+const capacityNotice = computed(() => {
+	if (props.waitlisted) {
+		return props.waitlistPosition
+			? t('attendance', 'You are number {position} on the waitlist', { position: props.waitlistPosition })
+			: t('attendance', 'You are on the waitlist')
+	}
+	if (props.isFull && props.userResponse !== 'yes') {
+		return props.waitlistEnabled
+			? t('attendance', 'This appointment is full. Join the waitlist to take the next free spot.')
+			: t('attendance', 'This appointment is full.')
+	}
+	return ''
+})
 
 const buttonSize = computed(() => (props.compact ? 'small' : 'normal'))
 
@@ -127,7 +179,11 @@ const { responseCooldown, resolveNext, startCooldown } = useResponseCooldown(() 
 function handleResponse(response) {
 	if (responseCooldown.value) return
 	startCooldown()
-	emit('submitResponse', props.appointmentId, resolveNext(response))
+	const next = resolveNext(response)
+	// Only a click on the button that says "Join waitlist" carries the intent.
+	// Without it a yes on an appointment that filled up since the page loaded is
+	// refused, rather than quietly turning into a place in line.
+	emit('submitResponse', props.appointmentId, next, next === 'yes' && joiningWaitlist.value)
 }
 
 // The extractor needs the NBSP before the ellipsis (Nextcloud l10n rule).
@@ -234,6 +290,14 @@ async function saveComment() {
             flex: 1;
             min-width: 0;
         }
+    }
+
+    &__capacity {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        font-size: 13px;
+        color: var(--color-text-maxcontrast);
     }
 
     &__deadline {

--- a/src/components/appointment/ResponseEditor.vue
+++ b/src/components/appointment/ResponseEditor.vue
@@ -99,6 +99,11 @@ const props = defineProps({
 		type: Boolean,
 		default: false,
 	},
+	// Which answers this appointment offers, in display order.
+	responseOptions: {
+		type: Array,
+		default: () => RESPONSE_ORDER,
+	},
 })
 
 const emit = defineEmits(['submitResponse'])
@@ -106,7 +111,7 @@ const emit = defineEmits(['submitResponse'])
 // Labels, variants and glyphs all come from the shared response helpers, so
 // the buttons carry the same filled circles the sidebar uses.
 const ICONS = { CheckCircle, HelpCircle, CloseCircle }
-const options = computed(() => RESPONSE_ORDER.map((value) => ({
+const options = computed(() => props.responseOptions.map((value) => ({
 	value,
 	label: getResponseText(value),
 	variant: getResponseVariant(value),

--- a/src/components/appointment/ResponseRow.vue
+++ b/src/components/appointment/ResponseRow.vue
@@ -13,6 +13,7 @@
 					:displayName="response.userName"
 					:currentResponse="response.response"
 					:pending="isSettingAnswer"
+					:responseOptions="responseOptions"
 					@setAnswer="(userId, value) => emit('setAnswer', userId, value)">
 					<template #default="{ pending }">
 						<NcButton
@@ -92,8 +93,14 @@ import PencilOutlineIcon from 'vue-material-design-icons/PencilOutline.vue'
 import RemindUserPopover from './RemindUserPopover.vue'
 import ResponseDot from './ResponseDot.vue'
 import SetAnswerPopover from './SetAnswerPopover.vue'
+import { RESPONSE_ORDER } from '../../utils/response.js'
 
 const props = defineProps({
+	// Which answers this appointment offers, in display order.
+	responseOptions: {
+		type: Array,
+		default: () => RESPONSE_ORDER,
+	},
 	response: {
 		type: Object,
 		required: true,

--- a/src/components/appointment/ResponseSummary.vue
+++ b/src/components/appointment/ResponseSummary.vue
@@ -49,6 +49,7 @@
 							:remindingUsers="remindingUsers"
 							:togglingBooking="togglingBooking"
 							:settingAnswer="settingAnswer"
+							:responseOptions="responseOptions"
 							@remind="remindUser"
 							@toggleBooking="toggleBooking"
 							@setAnswer="setAnswer" />
@@ -60,6 +61,7 @@
 						:headerText="t('attendance', 'No response yet:')"
 						:canManageAppointments="canSendReminders"
 						:canSetAnswer="canSetAnswer"
+						:responseOptions="responseOptions"
 						:appointmentId="appointmentId"
 						:remindingUsers="remindingUsers"
 						:settingAnswer="settingAnswer"
@@ -84,7 +86,7 @@ import ResponseBar from './ResponseBar.vue'
 import ResponseRow from './ResponseRow.vue'
 import { usePermissions } from '../../composables/usePermissions.js'
 import { formatGroupLabel } from '../../utils/groups.js'
-import { responseSegments } from '../../utils/response.js'
+import { RESPONSE_ORDER, responseSegments } from '../../utils/response.js'
 
 const props = defineProps({
 	responseSummary: {
@@ -112,6 +114,12 @@ const props = defineProps({
 	acceptsResponses: {
 		type: Boolean,
 		default: false,
+	},
+	// Which answers this appointment offers, forwarded to the on-behalf answer
+	// editors so they cannot show one the server would reject.
+	responseOptions: {
+		type: Array,
+		default: () => RESPONSE_ORDER,
 	},
 })
 

--- a/src/components/appointment/SetAnswerPopover.vue
+++ b/src/components/appointment/SetAnswerPopover.vue
@@ -12,7 +12,7 @@
 			<p>{{ t('attendance', 'Set answer for {name}', { name: displayName }) }}</p>
 			<div class="set-answer-popover__options">
 				<NcButton
-					v-for="option in RESPONSE_ORDER"
+					v-for="option in responseOptions"
 					:key="option"
 					:variant="option === currentResponse ? getResponseVariant(option) : 'secondary'"
 					size="small"
@@ -70,6 +70,11 @@ const props = defineProps({
 	pending: {
 		type: Boolean,
 		default: false,
+	},
+	// Which answers this appointment offers, in display order.
+	responseOptions: {
+		type: Array,
+		default: () => RESPONSE_ORDER,
 	},
 })
 

--- a/src/components/widget/WidgetAppointmentItem.vue
+++ b/src/components/widget/WidgetAppointmentItem.vue
@@ -41,6 +41,7 @@
 			:appointmentId="item.id"
 			:userResponse="item.userResponse?.response ?? null"
 			:comment="item.userResponse?.comment || ''"
+			:responseOptions="responseOptions"
 			@submitResponse="(id, response) => emit('respond', id, response)" />
 	</div>
 </template>
@@ -51,6 +52,7 @@ import { computed } from 'vue'
 import ListStatusIcon from 'vue-material-design-icons/ListStatus.vue'
 import ResponseEditor from '../appointment/ResponseEditor.vue'
 import { formatDateTime } from '../../utils/datetime.js'
+import { responseOptionsFor } from '../../utils/response.js'
 
 const props = defineProps({
 	item: {
@@ -68,6 +70,10 @@ const props = defineProps({
 })
 
 const emit = defineEmits(['respond', 'openCheckin', 'openDetail'])
+
+// Answers this appointment offers — the buttons must not show one the server
+// would reject.
+const responseOptions = computed(() => responseOptionsFor(props.item.allowMaybe))
 
 const formattedDate = computed(() => formatDateTime(props.item.subText))
 </script>

--- a/src/components/widget/WidgetAppointmentItem.vue
+++ b/src/components/widget/WidgetAppointmentItem.vue
@@ -42,7 +42,11 @@
 			:userResponse="item.userResponse?.response ?? null"
 			:comment="item.userResponse?.comment || ''"
 			:responseOptions="responseOptions"
-			@submitResponse="(id, response) => emit('respond', id, response)" />
+			:isFull="item.isFull === true"
+			:waitlistEnabled="item.waitlistEnabled === true"
+			:waitlisted="item.userResponse?.waitlisted === true"
+			:waitlistPosition="item.userResponse?.waitlistPosition ?? null"
+			@submitResponse="(id, response, acceptWaitlist) => emit('respond', id, response, acceptWaitlist)" />
 	</div>
 </template>
 

--- a/src/composables/useAppointmentResponse.js
+++ b/src/composables/useAppointmentResponse.js
@@ -65,13 +65,15 @@ export function useAppointmentResponse(options = {}) {
 	 * @param {number} appointmentId - The appointment ID
 	 * @param {string|null} response - The response (yes, no, maybe) or null to withdraw
 	 * @param {string} comment - The comment text
+	 * @param {boolean} [acceptWaitlist] - Take a place in line if the appointment turns out to be full
 	 * @return {Promise<object>} The axios response
 	 */
-	const postRespond = async (appointmentId, response, comment) => {
+	const postRespond = async (appointmentId, response, comment, acceptWaitlist = false) => {
 		const url = generateUrl('/apps/attendance/api/appointments/{id}/respond', { id: appointmentId })
 		const axiosResponse = await axios.post(url, {
 			response,
 			comment,
+			acceptWaitlist,
 		})
 
 		if (axiosResponse.status < 200 || axiosResponse.status >= 300) {
@@ -87,13 +89,14 @@ export function useAppointmentResponse(options = {}) {
 	 * @param {number} appointmentId - The appointment ID
 	 * @param {string|null} response - The response (yes, no, maybe) or null to withdraw
 	 * @param {string} comment - Optional comment
+	 * @param {boolean} [acceptWaitlist] - Take a place in line if the appointment turns out to be full
 	 * @return {Promise<object>} The API response
 	 */
-	const submitResponse = async (appointmentId, response, comment = '') => {
+	const submitResponse = async (appointmentId, response, comment = '', acceptWaitlist = false) => {
 		const t = window.t || ((app, text) => text)
 
 		try {
-			const axiosResponse = await postRespond(appointmentId, response, comment)
+			const axiosResponse = await postRespond(appointmentId, response, comment, acceptWaitlist)
 
 			showSuccess(response === null
 				? t('attendance', 'Response withdrawn')
@@ -106,7 +109,10 @@ export function useAppointmentResponse(options = {}) {
 			return axiosResponse.data
 		} catch (error) {
 			console.error('Failed to submit response:', error)
-			showError(t('attendance', 'Error updating response'))
+			// The server explains a refusal the client could not foresee — most
+			// of all somebody taking the last spot between the page load and
+			// the click — so show what it said rather than a generic failure.
+			showError(error?.response?.data?.error || t('attendance', 'Error updating response'))
 
 			if (onError) {
 				onError(error)

--- a/src/utils/auditFormat.js
+++ b/src/utils/auditFormat.js
@@ -196,6 +196,17 @@ export function formatAuditEvent(event) {
 				iconVariant: 'default',
 				segments: textOnly(t('attendance', '{actor} updated their comment', { actor })),
 			}
+		case 'waitlist.promoted':
+			return {
+				icon: 'AccountArrowUp',
+				iconVariant: 'success',
+				// No actor: a spot came free and the queue moved on its own,
+				// which is the whole reason this entry is worth having.
+				segments: textOnly(subject
+					// TRANSLATORS: Audit-log entry. A spot came free and {subject} (a name) moved off the waitlist into the appointment. Nobody performed this — it followed from someone else dropping out.
+					? t('attendance', '{subject} moved off the waitlist into a free spot', { subject })
+					: t('attendance', 'Someone moved off the waitlist into a free spot')),
+			}
 		case 'checkin.recorded':
 			return formatCheckin(
 				'AccountCheck',

--- a/src/utils/response.js
+++ b/src/utils/response.js
@@ -20,6 +20,21 @@ export const RESPONSES = {
 export const RESPONSE_ORDER = [RESPONSES.YES, RESPONSES.MAYBE, RESPONSES.NO]
 
 /**
+ * The answers an appointment offers, in display order. Appointments that turned
+ * "Maybe" off — and the ones with a limit, which never offer it — drop it here
+ * so no button appears for an answer the server would reject.
+ *
+ * @param {boolean} [allowMaybe] The appointment's resolved allowMaybe flag.
+ * @return {string[]} Response values to render.
+ */
+export function responseOptionsFor(allowMaybe) {
+	if (allowMaybe === false) {
+		return RESPONSE_ORDER.filter((response) => response !== RESPONSES.MAYBE)
+	}
+	return RESPONSE_ORDER
+}
+
+/**
  * Response variant mapping for UI components.
  */
 export const RESPONSE_VARIANTS = {

--- a/src/views/AdminSettings.vue
+++ b/src/views/AdminSettings.vue
@@ -466,6 +466,18 @@
 				</NcCheckboxRadioSwitch>
 			</NcSettingsSection>
 
+			<!-- TRANSLATORS: Admin settings section title for which answers appointments offer. -->
+			<NcSettingsSection id="answer-options"
+				:name="t('attendance', 'Answer options')"
+				:description="t('attendance', 'What every appointment offers unless its organizer decides otherwise.')">
+				<NcCheckboxRadioSwitch v-model="allowMaybe"
+					type="switch"
+					data-test="switch-allow-maybe">
+					<!-- TRANSLATORS: Switch label — appointments offer Yes, Maybe and No rather than just Yes and No. -->
+					{{ t('attendance', 'Offer “Maybe” as an answer') }}
+				</NcCheckboxRadioSwitch>
+			</NcSettingsSection>
+
 			<NcSettingsSection id="display-options"
 				:name="t('attendance', 'Display options')"
 				:description="t('attendance', 'Choose how appointments are displayed across the app.')">
@@ -708,6 +720,7 @@ const navSections = [
 	{ id: 'org-calendar', label: t('attendance', 'Organization calendar') },
 	{ id: 'audit-log', label: t('attendance', 'Audit log') },
 	{ id: 'scheduling', label: t('attendance', 'Scheduling') },
+	{ id: 'answer-options', label: t('attendance', 'Answer options') },
 	{ id: 'display-options', label: t('attendance', 'Display options') },
 	{ id: 'mobile-apps', label: t('attendance', 'Mobile apps') },
 	{ id: 'guests', label: t('attendance', 'Guest invitation') },
@@ -857,6 +870,7 @@ const auditLogVisibility = ref('managers')
 const pushEnabled = ref(true)
 const mobileAppBannerEnabled = ref(true)
 const bookingEnabled = ref(false)
+const allowMaybe = ref(true)
 const displayOrder = ref('name_first')
 const pushDeviceCount = ref(0)
 const loadingData = ref(true)
@@ -1047,6 +1061,7 @@ autoSave(
 	() => ({ mobileAppBannerEnabled: mobileAppBannerEnabled.value }),
 )
 autoSave(bookingEnabled, 'bookingEnabled', () => ({ bookingEnabled: bookingEnabled.value }))
+autoSave(allowMaybe, 'allowMaybe', () => ({ allowMaybe: allowMaybe.value }))
 
 // Methods
 function scrollToSection(id) {
@@ -1134,6 +1149,7 @@ async function loadSettings() {
 
 		// Load planning / booking setting (opt-in, defaults off)
 		bookingEnabled.value = config.bookingEnabled === true
+		allowMaybe.value = config.allowMaybe !== false
 
 		// Load guests app status (for whitelist warning)
 		if (config.guestsApp) {

--- a/src/views/AllAppointments.vue
+++ b/src/views/AllAppointments.vue
@@ -696,10 +696,10 @@ async function loadDetailedResponses() {
 	}))
 }
 
-async function submitResponse(appointmentId, response) {
+async function submitResponse(appointmentId, response, acceptWaitlist = false) {
 	const appointment = appointments.value.find((a) => a.id === appointmentId)
 	const comment = appointment?.userResponse?.comment || ''
-	await submitResponseApi(appointmentId, response, comment)
+	await submitResponseApi(appointmentId, response, comment, acceptWaitlist)
 }
 
 function deleteAppointment(appointmentId) {

--- a/src/views/AppointmentDetail.vue
+++ b/src/views/AppointmentDetail.vue
@@ -151,7 +151,7 @@ function showExportDialog() {
 	exportDialogVisible.value = true
 }
 
-async function submitResponse(appointmentId, response) {
+async function submitResponse(appointmentId, response, acceptWaitlist = false) {
 	const comment = appointment.value.userResponse?.comment || ''
 
 	if (response === null) {
@@ -163,7 +163,7 @@ async function submitResponse(appointmentId, response) {
 		appointment.value.userResponse.response = response
 	}
 
-	await submitResponseApi(appointmentId, response, comment)
+	await submitResponseApi(appointmentId, response, comment, acceptWaitlist)
 }
 
 function onClosedToggled(updated) {

--- a/src/views/AppointmentForm.vue
+++ b/src/views/AppointmentForm.vue
@@ -297,6 +297,24 @@
 				</p>
 			</div>
 
+			<div v-if="responseOptionsAvailable" class="form-section">
+				<h3>{{ t("attendance", "Answer options") }}</h3>
+				<!-- TRANSLATORS: Hint under the "Maybe" switch in the appointment form. It explains what turning the option off does — people are left with a straight yes or no — and is aimed at organizers who find "Maybe" unhelpful for this particular appointment. Sample German: "Ohne „Vielleicht“ bleibt nur eine klare Zu- oder Absage." -->
+				<p class="hint-text">
+					{{
+						t(
+							"attendance",
+							"Without “Maybe” people are left with a clear yes or no.",
+						)
+					}}
+				</p>
+				<NcCheckboxRadioSwitch
+					v-model="allowMaybe"
+					data-test="checkbox-allow-maybe">
+					{{ t("attendance", "Offer “Maybe” as an answer") }}
+				</NcCheckboxRadioSwitch>
+			</div>
+
 			<div
 				v-if="notificationsAppEnabled && (mode === 'create' || mode === 'copy')"
 				class="form-section">
@@ -650,6 +668,7 @@ const organizersAvailable = computed(() => capabilities.organizers === true)
 
 const locationsAvailable = computed(() => capabilities.locationsAvailable === true)
 const talkRoomsAvailable = computed(() => capabilities.talkRoomsAvailable === true)
+const responseOptionsAvailable = computed(() => capabilities.responseOptions === true)
 
 // Who lands in the room depends on the planning feature, and so does when the
 // room opens — promising "the scheduled people" on an instance without planning
@@ -705,6 +724,9 @@ const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
 const isEmailAddress = (value) => typeof value === 'string' && EMAIL_REGEX.test(value.trim())
 const sendNotification = ref(false)
 const createTalkRoom = ref(false)
+// A new appointment starts on whatever the instance offers; editing an existing
+// one loads its own answer, and saving always writes one either way.
+const allowMaybe = ref(capabilities.allowMaybeDefault !== false)
 const trackingGroups = ref([])
 const trackingTeams = ref([])
 const attachments = ref([])
@@ -1109,6 +1131,7 @@ async function loadAppointment() {
 		}
 
 		createTalkRoom.value = appointment.createTalkRoom === true
+		allowMaybe.value = appointment.allowMaybe !== false
 
 		// Load notification preference for copy mode
 		if (props.mode === 'copy') {
@@ -1455,6 +1478,7 @@ async function handleRecurringCreate() {
 				visibleUsers: formData.visibleUsers || [],
 				visibleGroups: formData.visibleGroups || [],
 				visibleTeams: formData.visibleTeams || [],
+				allowMaybe: allowMaybe.value,
 			}
 			if (formData.categoryId) {
 				item.categoryId = formData.categoryId
@@ -1588,6 +1612,7 @@ async function saveAppointment(scope = 'single') {
 				visibleTeams: formData.visibleTeams || [],
 				attachments: attachmentFileIds.value,
 				createTalkRoom: createTalkRoom.value,
+				allowMaybe: allowMaybe.value,
 				scope,
 			}
 			const organizersChanged = initialOrganizerIds.value === null
@@ -1620,6 +1645,7 @@ async function saveAppointment(scope = 'single') {
 				organizers: formData.organizers || [],
 				sendNotification: sendNotification.value,
 				createTalkRoom: createTalkRoom.value,
+				allowMaybe: allowMaybe.value,
 				calendarUri: calendarReference.value.calendarUri,
 				calendarEventUid: calendarReference.value.calendarEventUid,
 				attachments: attachmentFileIds.value,

--- a/src/views/AppointmentForm.vue
+++ b/src/views/AppointmentForm.vue
@@ -297,7 +297,35 @@
 				</p>
 			</div>
 
-			<div v-if="responseOptionsAvailable" class="form-section">
+			<div v-if="attendanceLimitAvailable" class="form-section">
+				<h3>{{ t("attendance", "Attendance limit") }}</h3>
+				<!-- TRANSLATORS: Hint under the attendance-limit field in the appointment form. It explains what setting a number does — once that many people have said yes, the rest can only queue — and that leaving it empty keeps the appointment open to everyone. Sample German: "Sobald so viele zugesagt haben, ist der Termin voll. Leer lassen für unbegrenzt." -->
+				<p class="hint-text">
+					{{
+						t(
+							"attendance",
+							"Once that many people have said yes the appointment is full. Leave empty for no limit.",
+						)
+					}}
+				</p>
+				<div class="form-field">
+					<NcTextField
+						:modelValue="maxAttendeesInput"
+						type="number"
+						min="0"
+						:label="t('attendance', 'Maximum attendees')"
+						data-test="input-max-attendees"
+						@update:modelValue="(value) => (maxAttendeesInput = value)" />
+				</div>
+				<NcCheckboxRadioSwitch
+					v-if="hasAttendanceLimit"
+					v-model="waitlistEnabled"
+					data-test="checkbox-waitlist-enabled">
+					{{ t("attendance", "Offer a waitlist when full") }}
+				</NcCheckboxRadioSwitch>
+			</div>
+
+			<div v-if="responseOptionsAvailable && !hasAttendanceLimit" class="form-section">
 				<h3>{{ t("attendance", "Answer options") }}</h3>
 				<!-- TRANSLATORS: Hint under the "Maybe" switch in the appointment form. It explains what turning the option off does — people are left with a straight yes or no — and is aimed at organizers who find "Maybe" unhelpful for this particular appointment. Sample German: "Ohne „Vielleicht“ bleibt nur eine klare Zu- oder Absage." -->
 				<p class="hint-text">
@@ -669,6 +697,7 @@ const organizersAvailable = computed(() => capabilities.organizers === true)
 const locationsAvailable = computed(() => capabilities.locationsAvailable === true)
 const talkRoomsAvailable = computed(() => capabilities.talkRoomsAvailable === true)
 const responseOptionsAvailable = computed(() => capabilities.responseOptions === true)
+const attendanceLimitAvailable = computed(() => capabilities.attendanceLimit === true)
 
 // Who lands in the room depends on the planning feature, and so does when the
 // room opens — promising "the scheduled people" on an instance without planning
@@ -727,6 +756,18 @@ const createTalkRoom = ref(false)
 // A new appointment starts on whatever the instance offers; editing an existing
 // one loads its own answer, and saving always writes one either way.
 const allowMaybe = ref(capabilities.allowMaybeDefault !== false)
+// Kept as the raw field text so an empty box stays empty rather than snapping
+// to 0; the payload turns it into a number or null on save.
+const maxAttendeesInput = ref('')
+const waitlistEnabled = ref(true)
+const attendanceLimit = computed(() => {
+	const parsed = Number.parseInt(maxAttendeesInput.value, 10)
+	return Number.isFinite(parsed) && parsed > 0 ? parsed : null
+})
+// A limit and "Maybe" cannot coexist — a maybe would hold a spot away from
+// somebody who would commit — so the answer-options section steps aside, the
+// same rule the server applies.
+const hasAttendanceLimit = computed(() => attendanceLimit.value !== null)
 const trackingGroups = ref([])
 const trackingTeams = ref([])
 const attachments = ref([])
@@ -1132,6 +1173,8 @@ async function loadAppointment() {
 
 		createTalkRoom.value = appointment.createTalkRoom === true
 		allowMaybe.value = appointment.allowMaybe !== false
+		maxAttendeesInput.value = appointment.maxAttendees ? String(appointment.maxAttendees) : ''
+		waitlistEnabled.value = appointment.waitlistEnabled !== false
 
 		// Load notification preference for copy mode
 		if (props.mode === 'copy') {
@@ -1479,6 +1522,8 @@ async function handleRecurringCreate() {
 				visibleGroups: formData.visibleGroups || [],
 				visibleTeams: formData.visibleTeams || [],
 				allowMaybe: allowMaybe.value,
+				maxAttendees: attendanceLimit.value,
+				waitlistEnabled: waitlistEnabled.value,
 			}
 			if (formData.categoryId) {
 				item.categoryId = formData.categoryId
@@ -1613,6 +1658,8 @@ async function saveAppointment(scope = 'single') {
 				attachments: attachmentFileIds.value,
 				createTalkRoom: createTalkRoom.value,
 				allowMaybe: allowMaybe.value,
+				maxAttendees: attendanceLimit.value,
+				waitlistEnabled: waitlistEnabled.value,
 				scope,
 			}
 			const organizersChanged = initialOrganizerIds.value === null
@@ -1646,6 +1693,8 @@ async function saveAppointment(scope = 'single') {
 				sendNotification: sendNotification.value,
 				createTalkRoom: createTalkRoom.value,
 				allowMaybe: allowMaybe.value,
+				maxAttendees: attendanceLimit.value,
+				waitlistEnabled: waitlistEnabled.value,
 				calendarUri: calendarReference.value.calendarUri,
 				calendarEventUid: calendarReference.value.calendarEventUid,
 				attachments: attachmentFileIds.value,

--- a/src/views/Widget.vue
+++ b/src/views/Widget.vue
@@ -85,14 +85,14 @@ const items = computed(() => {
 })
 
 // Methods
-async function respond(appointmentId, response) {
+async function respond(appointmentId, response, acceptWaitlist = false) {
 	const appointmentIndex = appointments.value.findIndex((a) => a.id === appointmentId)
 	// The endpoint stores response and comment together, so posting an empty
 	// string here would wipe a comment the user wrote earlier.
 	const comment = appointments.value[appointmentIndex]?.userResponse?.comment || ''
 
 	try {
-		await submitResponseApi(appointmentId, response, comment)
+		await submitResponseApi(appointmentId, response, comment, acceptWaitlist)
 		if (appointmentIndex !== -1) {
 			appointments.value[appointmentIndex].userResponse = response === null
 				? null

--- a/tests/e2e/33-attendance-limit.spec.js
+++ b/tests/e2e/33-attendance-limit.spec.js
@@ -1,0 +1,168 @@
+import {
+	authHeaders,
+	closeAppointmentViaAPI,
+	createAppointmentViaAPI,
+	deleteAllAppointments,
+	expect,
+	forceWipeAllAppointments,
+	listAppointmentsViaAPI,
+	respondToAppointmentViaAPI,
+	test,
+} from './fixtures/nextcloud.js'
+
+const BASE = `${process.env.NEXTCLOUD_URL || 'http://localhost:8080'}/index.php`
+
+/**
+ * Answer yes, saying explicitly whether a place in line is acceptable. The
+ * raw request rather than the fixture: what this suite is about is the status
+ * code a full appointment answers with.
+ */
+async function answerYes(request, appointmentId, user, acceptWaitlist = false) {
+	return request.post(
+		`${BASE}/apps/attendance/api/appointments/${appointmentId}/respond`,
+		{
+			headers: authHeaders(user, user),
+			data: { response: 'yes', comment: '', acceptWaitlist },
+		},
+	)
+}
+
+async function appointmentFor(request, appointmentId, user) {
+	const appointments = await listAppointmentsViaAPI(request, {
+		showPast: false,
+		username: user,
+		password: user,
+	})
+	return appointments.find((a) => a.id === appointmentId)
+}
+
+test.describe('Attendance limit and waitlist', () => {
+	test.beforeEach(async ({ request }) => {
+		await deleteAllAppointments(request)
+	})
+
+	test.afterAll(async ({ request }) => {
+		await forceWipeAllAppointments(request)
+	})
+
+	test('a full appointment queues the next person and promotes them when a spot frees up', async ({ request }) => {
+		const appointment = await createAppointmentViaAPI(request, {
+			name: 'Limited rehearsal',
+			visibleUsers: ['test', 'test1'],
+			maxAttendees: 1,
+		})
+		expect(appointment.id).toBeTruthy()
+
+		// The only spot goes to whoever claims it first.
+		expect((await answerYes(request, appointment.id, 'test')).status()).toBe(200)
+
+		const forTest = await appointmentFor(request, appointment.id, 'test')
+		expect(forTest.isFull).toBe(true)
+		expect(forTest.occupancy).toBe(1)
+		expect(forTest.userResponse.waitlisted).toBe(false)
+
+		// A plain yes is refused rather than silently queued — the person asked
+		// for a spot, not for a place in line.
+		const refused = await answerYes(request, appointment.id, 'test1')
+		expect(refused.status()).toBe(400)
+		expect((await refused.json()).error).toContain('full')
+
+		// Asking for the queue explicitly works, and reports where they stand.
+		expect((await answerYes(request, appointment.id, 'test1', true)).status()).toBe(200)
+		const queued = await appointmentFor(request, appointment.id, 'test1')
+		expect(queued.userResponse.waitlisted).toBe(true)
+		expect(queued.userResponse.waitlistPosition).toBe(1)
+		expect(queued.occupancy).toBe(2)
+
+		// Nobody performs the promotion: the spot frees up and the queue moves.
+		await respondToAppointmentViaAPI(request, appointment.id, {
+			response: 'no',
+			username: 'test',
+			password: 'test',
+		})
+
+		const promoted = await appointmentFor(request, appointment.id, 'test1')
+		expect(promoted.userResponse.response).toBe('yes')
+		expect(promoted.userResponse.waitlisted).toBe(false)
+		expect(promoted.userResponse.waitlistPosition).toBe(null)
+		expect(promoted.isFull).toBe(true)
+	})
+
+	test('a limit takes "maybe" off the table', async ({ request }) => {
+		const appointment = await createAppointmentViaAPI(request, {
+			name: 'No maybes here',
+			visibleUsers: ['test'],
+			maxAttendees: 5,
+		})
+
+		const visible = await appointmentFor(request, appointment.id, 'test')
+		expect(visible.allowMaybe).toBe(false)
+
+		const maybe = await request.post(
+			`${BASE}/apps/attendance/api/appointments/${appointment.id}/respond`,
+			{
+				headers: authHeaders('test', 'test'),
+				data: { response: 'maybe', comment: '' },
+			},
+		)
+		expect(maybe.status()).toBe(400)
+	})
+
+	test('without a waitlist a full appointment simply turns people away', async ({ request }) => {
+		const appointment = await createAppointmentViaAPI(request, {
+			name: 'Hard cap',
+			visibleUsers: ['test', 'test1'],
+			maxAttendees: 1,
+			waitlistEnabled: false,
+		})
+
+		expect((await answerYes(request, appointment.id, 'test')).status()).toBe(200)
+
+		// Even somebody willing to wait has nothing to wait for.
+		expect((await answerYes(request, appointment.id, 'test1', true)).status()).toBe(400)
+
+		// Declining is never blocked — the organizer wants that answer too.
+		const declined = await respondToAppointmentViaAPI(request, appointment.id, {
+			response: 'no',
+			username: 'test1',
+			password: 'test1',
+		})
+		expect(declined.response).toBe('no')
+	})
+
+	test('an appointment without a limit behaves exactly as before', async ({ request }) => {
+		const appointment = await createAppointmentViaAPI(request, {
+			name: 'Unlimited',
+			visibleUsers: ['test', 'test1'],
+		})
+
+		for (const user of ['test', 'test1']) {
+			expect((await answerYes(request, appointment.id, user)).status()).toBe(200)
+		}
+
+		const visible = await appointmentFor(request, appointment.id, 'test')
+		expect(visible.maxAttendees).toBe(null)
+		expect(visible.isFull).toBe(false)
+		expect(visible.allowMaybe).toBe(true)
+		expect(visible.userResponse.waitlisted).toBe(false)
+	})
+
+	test('closing a full appointment leaves nobody waiting on an answer', async ({ request }) => {
+		const appointment = await createAppointmentViaAPI(request, {
+			name: 'Closes full',
+			visibleUsers: ['test', 'test1'],
+			maxAttendees: 1,
+		})
+
+		expect((await answerYes(request, appointment.id, 'test')).status()).toBe(200)
+		expect((await answerYes(request, appointment.id, 'test1', true)).status()).toBe(200)
+
+		await closeAppointmentViaAPI(request, appointment.id)
+
+		// The queue is frozen with the closed inquiry: still waiting, and no
+		// longer able to answer.
+		const queued = await appointmentFor(request, appointment.id, 'test1')
+		expect(queued.userResponse.waitlisted).toBe(true)
+		expect((await answerYes(request, appointment.id, 'test1', true)).status()).toBe(400)
+	})
+})

--- a/tests/e2e/fixtures/nextcloud.js
+++ b/tests/e2e/fixtures/nextcloud.js
@@ -146,6 +146,8 @@ export async function createAppointmentViaAPI(request, {
 	responseDeadline,
 	location,
 	categoryId,
+	maxAttendees,
+	waitlistEnabled,
 	username = 'admin',
 	password = 'admin',
 } = {}) {
@@ -165,6 +167,8 @@ export async function createAppointmentViaAPI(request, {
 		...(responseDeadline ? { responseDeadline: responseDeadline.toISOString() } : {}),
 		...(location !== undefined ? { location } : {}),
 		...(categoryId !== undefined ? { categoryId } : {}),
+		...(maxAttendees !== undefined ? { maxAttendees } : {}),
+		...(waitlistEnabled !== undefined ? { waitlistEnabled } : {}),
 	}
 	const resp = await resilientJson(() => request.post(`${API_BASE}/apps/attendance/api/appointments`, {
 		headers: authHeaders(username, password),

--- a/tests/unit/Notification/NotifierTest.php
+++ b/tests/unit/Notification/NotifierTest.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace OCA\Attendance\Tests\Unit\Notification;
 
+use OCA\Attendance\Db\AppointmentMapper;
 use OCA\Attendance\Db\AttendanceResponse;
 use OCA\Attendance\Db\AttendanceResponseMapper;
 use OCA\Attendance\Notification\Notifier;
 use OCA\Attendance\Service\QuickResponseTokenService;
+use OCA\Attendance\Service\ResponsePolicyService;
 use OCP\IConfig;
 use OCP\IL10N;
 use OCP\IURLGenerator;
@@ -31,6 +33,12 @@ class NotifierTest extends TestCase {
 	private $config;
 	/** @var AttendanceResponseMapper|MockObject */
 	private $responseMapper;
+
+	/** @var AppointmentMapper|MockObject */
+	private $appointmentMapper;
+
+	/** @var ResponsePolicyService|MockObject */
+	private $responsePolicyService;
 	/** @var IUserManager|MockObject */
 	private $userManager;
 
@@ -43,6 +51,11 @@ class NotifierTest extends TestCase {
 		$this->config = $this->createMock(IConfig::class);
 		$this->responseMapper = $this->createMock(AttendanceResponseMapper::class);
 		$this->userManager = $this->createMock(IUserManager::class);
+		$this->appointmentMapper = $this->createMock(AppointmentMapper::class);
+		$this->responsePolicyService = $this->createMock(ResponsePolicyService::class);
+		// Notifications carry all three quick-response buttons unless a test
+		// takes "Maybe" away.
+		$this->responsePolicyService->method('isMaybeAllowed')->willReturn(true);
 
 		$this->config->method('getUserValue')->willReturn('');
 
@@ -63,6 +76,8 @@ class NotifierTest extends TestCase {
 			$this->config,
 			$this->responseMapper,
 			$this->userManager,
+			$this->appointmentMapper,
+			$this->responsePolicyService,
 		);
 	}
 

--- a/tests/unit/Service/AppointmentServiceTest.php
+++ b/tests/unit/Service/AppointmentServiceTest.php
@@ -11,10 +11,12 @@ use OCA\Attendance\Db\AttendanceResponse;
 use OCA\Attendance\Db\AttendanceResponseMapper;
 use OCA\Attendance\Db\Category;
 use OCA\Attendance\Db\CategoryMapper;
+use OCA\Attendance\Service\AppointmentSerializer;
 use OCA\Attendance\Service\AppointmentService;
 use OCA\Attendance\Service\AttachmentService;
 use OCA\Attendance\Service\AuditEventService;
 use OCA\Attendance\Service\BookingService;
+use OCA\Attendance\Service\CapacityService;
 use OCA\Attendance\Service\ConfigService;
 use OCA\Attendance\Service\DeadlineUpdate;
 use OCA\Attendance\Service\GuestService;
@@ -87,6 +89,7 @@ class AppointmentServiceTest extends TestCase {
 	private $talkRoomService;
 
 	private ResponsePolicyService $responsePolicyService;
+	private CapacityService $capacityService;
 
 	private AppointmentService $service;
 
@@ -112,7 +115,12 @@ class AppointmentServiceTest extends TestCase {
 		// The real policy, not a mock: the guard is the thing these tests need to
 		// see fire. Appointments offer all three answers unless one opts out.
 		$this->configService->method('isMaybeAllowed')->willReturn(true);
-		$this->responsePolicyService = new ResponsePolicyService($this->configService);
+		$this->capacityService = new CapacityService(
+			$this->responseMapper,
+			$this->notificationService,
+			$this->auditEventService,
+		);
+		$this->responsePolicyService = new ResponsePolicyService($this->configService, $this->capacityService);
 
 		$this->service = new AppointmentService(
 			$this->appointmentMapper,
@@ -134,6 +142,8 @@ class AppointmentServiceTest extends TestCase {
 			$this->categoryMapper,
 			$this->talkRoomService,
 			$this->responsePolicyService,
+			$this->capacityService,
+			new AppointmentSerializer($this->responsePolicyService, $this->capacityService),
 		);
 	}
 

--- a/tests/unit/Service/AppointmentServiceTest.php
+++ b/tests/unit/Service/AppointmentServiceTest.php
@@ -21,6 +21,7 @@ use OCA\Attendance\Service\GuestService;
 use OCA\Attendance\Service\NotificationService;
 use OCA\Attendance\Service\OrgCalendarSyncService;
 use OCA\Attendance\Service\PermissionService;
+use OCA\Attendance\Service\ResponsePolicyService;
 use OCA\Attendance\Service\ResponseSummaryService;
 use OCA\Attendance\Service\TalkRoomService;
 use OCA\Attendance\Service\VisibilityService;
@@ -85,6 +86,8 @@ class AppointmentServiceTest extends TestCase {
 	private $categoryMapper;
 	private $talkRoomService;
 
+	private ResponsePolicyService $responsePolicyService;
+
 	private AppointmentService $service;
 
 	protected function setUp(): void {
@@ -106,6 +109,10 @@ class AppointmentServiceTest extends TestCase {
 		$this->orgCalendarSyncService = $this->createMock(OrgCalendarSyncService::class);
 		$this->categoryMapper = $this->createMock(CategoryMapper::class);
 		$this->talkRoomService = $this->createMock(TalkRoomService::class);
+		// The real policy, not a mock: the guard is the thing these tests need to
+		// see fire. Appointments offer all three answers unless one opts out.
+		$this->configService->method('isMaybeAllowed')->willReturn(true);
+		$this->responsePolicyService = new ResponsePolicyService($this->configService);
 
 		$this->service = new AppointmentService(
 			$this->appointmentMapper,
@@ -126,6 +133,7 @@ class AppointmentServiceTest extends TestCase {
 			$this->orgCalendarSyncService,
 			$this->categoryMapper,
 			$this->talkRoomService,
+			$this->responsePolicyService,
 		);
 	}
 
@@ -526,6 +534,63 @@ class AppointmentServiceTest extends TestCase {
 		$this->expectException(\RuntimeException::class);
 		$this->expectExceptionMessage('closed');
 		$this->service->submitResponse(9, 'alice', 'yes');
+	}
+
+	public function testSubmitResponseRejectsMaybeWhereTheAppointmentDoesNotOfferIt(): void {
+		$appointment = new Appointment();
+		$appointment->setId(9);
+		$appointment->setAllowMaybe(false);
+
+		$this->appointmentMapper->method('find')->with(9)->willReturn($appointment);
+		$this->visibilityService->method('canUserSeeAppointment')->willReturn(true);
+		$this->responseMapper->expects($this->never())->method('insert');
+		$this->responseMapper->expects($this->never())->method('update');
+
+		$this->expectException(\InvalidArgumentException::class);
+		$this->expectExceptionMessage('maybe');
+		$this->service->submitResponse(9, 'alice', 'maybe');
+	}
+
+	public function testSubmitResponseForUserRejectsMaybeWhereTheAppointmentDoesNotOfferIt(): void {
+		$appointment = new Appointment();
+		$appointment->setId(9);
+		$appointment->setAllowMaybe(false);
+
+		$this->userManager->method('get')->willReturn($this->createMock(\OCP\IUser::class));
+		$this->visibilityService->method('canUserSeeAppointment')->willReturn(true);
+		$this->responseMapper->expects($this->never())->method('insert');
+		$this->responseMapper->expects($this->never())->method('update');
+
+		$this->expectException(\InvalidArgumentException::class);
+		$this->expectExceptionMessage('maybe');
+		$this->service->submitResponseForUser($appointment, 'bob', 'maybe', 'manager');
+	}
+
+	public function testSubmitResponseKeepsMaybeWhereTheAppointmentStillOffersIt(): void {
+		$appointment = new Appointment();
+		$appointment->setId(9);
+		$appointment->setAllowMaybe(true);
+
+		$this->appointmentMapper->method('find')->with(9)->willReturn($appointment);
+		$this->visibilityService->method('canUserSeeAppointment')->willReturn(true);
+		$this->responseMapper->method('findByAppointmentAndUser')
+			->willThrowException(new \OCP\AppFramework\Db\DoesNotExistException('none'));
+		$this->responseMapper->expects($this->once())->method('insert')->willReturnArgument(0);
+
+		$this->assertSame('maybe', $this->service->submitResponse(9, 'alice', 'maybe')->getResponse());
+	}
+
+	public function testSerializeAppointmentResolvesAllowMaybeAgainstTheInstanceDefault(): void {
+		$undecided = new Appointment();
+		$undecided->setId(3);
+
+		$optedOut = new Appointment();
+		$optedOut->setId(4);
+		$optedOut->setAllowMaybe(false);
+
+		// The instance default is true throughout this test class.
+		$this->assertTrue($this->service->serializeAppointment($undecided)['allowMaybe']);
+		$this->assertFalse($this->service->serializeAppointment($optedOut)['allowMaybe']);
 	}
 
 	public function testCancelAppointmentRecordsAuditEventAndNotifies(): void {

--- a/tests/unit/Service/CapacityServiceTest.php
+++ b/tests/unit/Service/CapacityServiceTest.php
@@ -1,0 +1,203 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\Attendance\Tests\Unit\Service;
+
+use OCA\Attendance\Audit\Verb;
+use OCA\Attendance\Db\Appointment;
+use OCA\Attendance\Db\AttendanceResponse;
+use OCA\Attendance\Db\AttendanceResponseMapper;
+use OCA\Attendance\Service\AuditEventService;
+use OCA\Attendance\Service\CapacityService;
+use OCA\Attendance\Service\NotificationService;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class CapacityServiceTest extends TestCase {
+	/** @var AttendanceResponseMapper|MockObject */
+	private $responseMapper;
+
+	/** @var NotificationService|MockObject */
+	private $notificationService;
+
+	/** @var AuditEventService|MockObject */
+	private $auditEventService;
+
+	private CapacityService $service;
+
+	protected function setUp(): void {
+		$this->responseMapper = $this->createMock(AttendanceResponseMapper::class);
+		$this->notificationService = $this->createMock(NotificationService::class);
+		$this->auditEventService = $this->createMock(AuditEventService::class);
+		$this->service = new CapacityService(
+			$this->responseMapper,
+			$this->notificationService,
+			$this->auditEventService,
+		);
+	}
+
+	private function appointment(?int $limit, bool $waitlist = true): Appointment {
+		$appointment = new Appointment();
+		$appointment->setId(1);
+		$appointment->setMaxAttendees($limit);
+		$appointment->setWaitlistEnabled($waitlist);
+		return $appointment;
+	}
+
+	/**
+	 * @param list<string> $userIds in queue order
+	 * @param array<string, ?string> $notified per-user notification marker
+	 */
+	private function queue(array $userIds, array $notified = []): void {
+		$rows = [];
+		foreach ($userIds as $userId) {
+			$response = new AttendanceResponse();
+			$response->setUserId($userId);
+			$response->setResponse('yes');
+			$response->setWaitlistNotifiedStatus($notified[$userId] ?? null);
+			$rows[] = $response;
+		}
+		$this->responseMapper->method('findClaimedSpots')->willReturn($rows);
+	}
+
+	public function testNoLimitMeansNoQueryAndNobodyWaiting(): void {
+		$this->responseMapper->expects($this->never())->method('findClaimedSpots');
+		$appointment = $this->appointment(null);
+
+		$this->assertNull($this->service->limitOf($appointment));
+		$this->assertSame(0, $this->service->occupancy($appointment));
+		$this->assertFalse($this->service->isFull($appointment));
+		$this->assertFalse($this->service->isWaitlistEnabled($appointment));
+		$this->assertTrue($this->service->holdsSpot($appointment, 'alice'));
+	}
+
+	public function testZeroIsReadAsNoLimit(): void {
+		$this->assertNull($this->service->limitOf($this->appointment(0)));
+	}
+
+	public function testTheFirstOnesInHoldTheSpotsAndTheRestQueueInOrder(): void {
+		$this->queue(['alice', 'bob', 'carol', 'dave']);
+		$appointment = $this->appointment(2);
+
+		$this->assertTrue($this->service->holdsSpot($appointment, 'alice'));
+		$this->assertTrue($this->service->holdsSpot($appointment, 'bob'));
+		$this->assertFalse($this->service->holdsSpot($appointment, 'carol'));
+
+		$this->assertSame(
+			['waitlisted' => true, 'waitlistPosition' => 1],
+			$this->service->standingOf($appointment, 'carol'),
+		);
+		$this->assertSame(
+			['waitlisted' => true, 'waitlistPosition' => 2],
+			$this->service->standingOf($appointment, 'dave'),
+		);
+		$this->assertSame(
+			['waitlisted' => false, 'waitlistPosition' => null],
+			$this->service->standingOf($appointment, 'alice'),
+		);
+	}
+
+	public function testOccupancyMayExceedTheLimitWithoutDemotingAnyone(): void {
+		$this->queue(['alice', 'bob', 'carol']);
+		// The organizer lowered the limit under what is already taken.
+		$appointment = $this->appointment(2);
+
+		$this->assertSame(3, $this->service->occupancy($appointment));
+		$this->assertTrue($this->service->isFull($appointment));
+		$this->assertTrue($this->service->holdsSpot($appointment, 'alice'));
+	}
+
+	public function testClaimingASpotStampsTheOrderingKey(): void {
+		$response = new AttendanceResponse();
+
+		$this->service->applySpotClaim($response, null, 'yes');
+
+		$this->assertNotNull($response->getSpotClaimedAt());
+	}
+
+	public function testResavingAYesKeepsThePlaceInLine(): void {
+		$response = new AttendanceResponse();
+		$response->setSpotClaimedAt('2026-01-01 10:00:00');
+
+		$this->service->applySpotClaim($response, 'yes', 'yes');
+
+		$this->assertSame('2026-01-01 10:00:00', $response->getSpotClaimedAt());
+	}
+
+	public function testLeavingTheQueueGivesUpThePlaceEntirely(): void {
+		$response = new AttendanceResponse();
+		$response->setSpotClaimedAt('2026-01-01 10:00:00');
+		$response->setWaitlistNotifiedStatus(CapacityService::NOTIFIED_WAITLISTED);
+
+		$this->service->applySpotClaim($response, 'yes', 'no');
+
+		// Answering yes again later joins the back, and can be notified afresh.
+		$this->assertNull($response->getSpotClaimedAt());
+		$this->assertNull($response->getWaitlistNotifiedStatus());
+	}
+
+	public function testPromotionNotifiesOnlySomebodyWhoWasWaiting(): void {
+		$this->queue(
+			['alice', 'bob'],
+			['alice' => null, 'bob' => CapacityService::NOTIFIED_WAITLISTED],
+		);
+		$appointment = $this->appointment(2);
+
+		// Only bob moved from waiting to holding a spot; alice was never told
+		// anything, so there is nothing to tell her now.
+		$this->notificationService->expects($this->once())
+			->method('sendWaitlistNotification')
+			->with($appointment, 'bob', 'waitlist_promoted');
+		$this->auditEventService->expects($this->once())
+			->method('record')
+			->with(Verb::WAITLIST_PROMOTED, 1, null, 'bob');
+
+		$this->service->syncWaitlistNotifications($appointment);
+	}
+
+	public function testJoiningTheQueueIsRecordedButNotAnnounced(): void {
+		$this->queue(['alice', 'bob']);
+		$appointment = $this->appointment(1);
+
+		$this->notificationService->expects($this->never())->method('sendWaitlistNotification');
+		$this->responseMapper->expects($this->once())
+			->method('update')
+			->with($this->callback(
+				fn (AttendanceResponse $r): bool => $r->getUserId() === 'bob'
+					&& $r->getWaitlistNotifiedStatus() === CapacityService::NOTIFIED_WAITLISTED,
+			));
+
+		$this->service->syncWaitlistNotifications($appointment);
+	}
+
+	public function testAnAlreadyMarkedWaiterIsNotMarkedAgain(): void {
+		$this->queue(
+			['alice', 'bob'],
+			['bob' => CapacityService::NOTIFIED_WAITLISTED],
+		);
+		$appointment = $this->appointment(1);
+
+		$this->responseMapper->expects($this->never())->method('update');
+
+		$this->service->syncWaitlistNotifications($appointment);
+	}
+
+	public function testClosingTellsEveryoneStillWaitingOnce(): void {
+		$this->queue(
+			['alice', 'bob', 'carol'],
+			[
+				'bob' => CapacityService::NOTIFIED_WAITLISTED,
+				'carol' => CapacityService::NOTIFIED_NOT_PROMOTED,
+			],
+		);
+		$appointment = $this->appointment(1);
+
+		// carol already heard; alice holds the only spot.
+		$this->notificationService->expects($this->once())
+			->method('sendWaitlistNotification')
+			->with($appointment, 'bob', 'waitlist_not_promoted');
+
+		$this->service->notifyNotPromoted($appointment);
+	}
+}

--- a/tests/unit/Service/IcalServiceTest.php
+++ b/tests/unit/Service/IcalServiceTest.php
@@ -12,7 +12,9 @@ use OCA\Attendance\Db\AttendanceResponseMapper;
 use OCA\Attendance\Db\Category;
 use OCA\Attendance\Db\CategoryMapper;
 use OCA\Attendance\Db\IcalTokenMapper;
+use OCA\Attendance\Service\AuditEventService;
 use OCA\Attendance\Service\BookingService;
+use OCA\Attendance\Service\CapacityService;
 use OCA\Attendance\Service\ConfigService;
 use OCA\Attendance\Service\IcalService;
 use OCA\Attendance\Service\NotificationService;
@@ -30,6 +32,9 @@ class IcalServiceTest extends TestCase {
 	private ConfigService $configService;
 	private AppointmentAttachmentMapper $attachmentMapper;
 	private CategoryMapper $categoryMapper;
+
+	/** @var AttendanceResponseMapper|MockObject */
+	private $responseMapper;
 	private IcalService $service;
 
 	protected function setUp(): void {
@@ -37,6 +42,7 @@ class IcalServiceTest extends TestCase {
 		$this->attachmentMapper = $this->createMock(AppointmentAttachmentMapper::class);
 		$this->attachmentMapper->method('findByAppointment')->willReturn([]);
 		$this->categoryMapper = $this->createMock(CategoryMapper::class);
+		$this->responseMapper = $this->createMock(AttendanceResponseMapper::class);
 
 		$urlGenerator = $this->createMock(IURLGenerator::class);
 		$urlGenerator->method('getAbsoluteURL')->willReturn('https://example.test/');
@@ -63,6 +69,13 @@ class IcalServiceTest extends TestCase {
 			$this->createMock(IL10NFactory::class),
 			$this->createMock(IConfig::class),
 			$this->categoryMapper,
+			// Real again: whether a yes holds a spot is what decides the title and
+			// the busy flag, and it only reads the queue it is handed.
+			new CapacityService(
+				$this->responseMapper,
+				$this->createMock(NotificationService::class),
+				$this->createMock(AuditEventService::class),
+			),
 		);
 	}
 

--- a/tests/unit/Service/ResponsePolicyServiceTest.php
+++ b/tests/unit/Service/ResponsePolicyServiceTest.php
@@ -5,7 +5,12 @@ declare(strict_types=1);
 namespace OCA\Attendance\Tests\Unit\Service;
 
 use OCA\Attendance\Db\Appointment;
+use OCA\Attendance\Db\AttendanceResponse;
+use OCA\Attendance\Db\AttendanceResponseMapper;
+use OCA\Attendance\Service\AuditEventService;
+use OCA\Attendance\Service\CapacityService;
 use OCA\Attendance\Service\ConfigService;
+use OCA\Attendance\Service\NotificationService;
 use OCA\Attendance\Service\ResponsePolicyService;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -14,17 +19,44 @@ class ResponsePolicyServiceTest extends TestCase {
 	/** @var ConfigService|MockObject */
 	private $configService;
 
+	/** @var AttendanceResponseMapper|MockObject */
+	private $responseMapper;
+
 	private ResponsePolicyService $service;
 
 	protected function setUp(): void {
 		$this->configService = $this->createMock(ConfigService::class);
-		$this->service = new ResponsePolicyService($this->configService);
+		$this->responseMapper = $this->createMock(AttendanceResponseMapper::class);
+		// The real capacity rules, on a mocked queue.
+		$this->service = new ResponsePolicyService(
+			$this->configService,
+			new CapacityService(
+				$this->responseMapper,
+				$this->createMock(NotificationService::class),
+				$this->createMock(AuditEventService::class),
+			),
+		);
 	}
 
-	private function appointment(?bool $allowMaybe): Appointment {
+	private function appointment(?bool $allowMaybe, ?int $maxAttendees = null, bool $waitlist = true): Appointment {
 		$appointment = new Appointment();
+		$appointment->setId(1);
 		$appointment->setAllowMaybe($allowMaybe);
+		$appointment->setMaxAttendees($maxAttendees);
+		$appointment->setWaitlistEnabled($waitlist);
 		return $appointment;
+	}
+
+	/** Fill the queue with $count yes-responses from distinct people. */
+	private function queueOf(int $count): void {
+		$rows = [];
+		for ($i = 0; $i < $count; $i++) {
+			$response = new AttendanceResponse();
+			$response->setUserId('user' . $i);
+			$response->setResponse('yes');
+			$rows[] = $response;
+		}
+		$this->responseMapper->method('findClaimedSpots')->willReturn($rows);
 	}
 
 	public function testUndecidedAppointmentFollowsTheInstanceDefault(): void {
@@ -68,5 +100,64 @@ class ResponsePolicyServiceTest extends TestCase {
 
 		$this->expectException(\InvalidArgumentException::class);
 		$this->service->assertResponseAllowed($this->appointment(true), 'perhaps');
+	}
+
+	public function testALimitTakesMaybeAwayWhateverTheAppointmentSays(): void {
+		$this->configService->method('isMaybeAllowed')->willReturn(true);
+
+		$this->assertFalse($this->service->isMaybeAllowed($this->appointment(true, 10)));
+	}
+
+	public function testAFreshYesIsTurnedAwayFromAFullAppointment(): void {
+		$this->configService->method('isMaybeAllowed')->willReturn(true);
+		$this->queueOf(4);
+
+		$this->expectException(\RuntimeException::class);
+		$this->expectExceptionMessage('full');
+		$this->service->assertResponseAllowed($this->appointment(null, 4), 'yes', null);
+	}
+
+	public function testAFreshYesIsAcceptedWhenTheWaitlistIsAccepted(): void {
+		$this->configService->method('isMaybeAllowed')->willReturn(true);
+		$this->queueOf(4);
+
+		$this->service->assertResponseAllowed($this->appointment(null, 4), 'yes', null, true);
+		$this->addToAssertionCount(1);
+	}
+
+	public function testAFullAppointmentWithoutAWaitlistTurnsAwayEvenAWillingWaiter(): void {
+		$this->configService->method('isMaybeAllowed')->willReturn(true);
+		$this->queueOf(4);
+
+		$this->expectException(\RuntimeException::class);
+		$this->service->assertResponseAllowed($this->appointment(null, 4, false), 'yes', null, true);
+	}
+
+	public function testResavingAYesIsNeverTurnedAway(): void {
+		$this->configService->method('isMaybeAllowed')->willReturn(true);
+		$this->queueOf(4);
+
+		// Somebody already in the queue editing their comment must not be
+		// rejected just because the appointment filled up meanwhile.
+		$this->service->assertResponseAllowed($this->appointment(null, 4), 'yes', 'yes');
+		$this->addToAssertionCount(1);
+	}
+
+	public function testAnOrganizerMayOverbook(): void {
+		$this->configService->method('isMaybeAllowed')->willReturn(true);
+		$this->queueOf(4);
+
+		$this->service->assertResponseAllowed($this->appointment(null, 4), 'yes', null, false, true);
+		$this->addToAssertionCount(1);
+	}
+
+	public function testNoAndWithdrawAreNeverBlockedByAFullAppointment(): void {
+		$this->configService->method('isMaybeAllowed')->willReturn(true);
+		$this->queueOf(4);
+		$appointment = $this->appointment(null, 4);
+
+		$this->service->assertResponseAllowed($appointment, 'no', null);
+		$this->service->assertResponseAllowed($appointment, null, 'yes');
+		$this->addToAssertionCount(2);
 	}
 }

--- a/tests/unit/Service/ResponsePolicyServiceTest.php
+++ b/tests/unit/Service/ResponsePolicyServiceTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\Attendance\Tests\Unit\Service;
+
+use OCA\Attendance\Db\Appointment;
+use OCA\Attendance\Service\ConfigService;
+use OCA\Attendance\Service\ResponsePolicyService;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class ResponsePolicyServiceTest extends TestCase {
+	/** @var ConfigService|MockObject */
+	private $configService;
+
+	private ResponsePolicyService $service;
+
+	protected function setUp(): void {
+		$this->configService = $this->createMock(ConfigService::class);
+		$this->service = new ResponsePolicyService($this->configService);
+	}
+
+	private function appointment(?bool $allowMaybe): Appointment {
+		$appointment = new Appointment();
+		$appointment->setAllowMaybe($allowMaybe);
+		return $appointment;
+	}
+
+	public function testUndecidedAppointmentFollowsTheInstanceDefault(): void {
+		$this->configService->method('isMaybeAllowed')->willReturn(false);
+
+		$this->assertFalse($this->service->isMaybeAllowed($this->appointment(null)));
+	}
+
+	public function testAppointmentOverridesTheInstanceDefaultBothWays(): void {
+		$this->configService->method('isMaybeAllowed')->willReturn(false);
+
+		$this->assertTrue($this->service->isMaybeAllowed($this->appointment(true)));
+		$this->assertFalse($this->service->isMaybeAllowed($this->appointment(false)));
+	}
+
+	public function testMaybeIsRejectedWhereTheAppointmentDoesNotOfferIt(): void {
+		$this->configService->method('isMaybeAllowed')->willReturn(true);
+
+		$this->expectException(\InvalidArgumentException::class);
+		$this->service->assertResponseAllowed($this->appointment(false), 'maybe');
+	}
+
+	public function testYesAndNoSurviveWithoutMaybe(): void {
+		$this->configService->method('isMaybeAllowed')->willReturn(true);
+		$appointment = $this->appointment(false);
+
+		$this->service->assertResponseAllowed($appointment, 'yes');
+		$this->service->assertResponseAllowed($appointment, 'no');
+		$this->addToAssertionCount(2);
+	}
+
+	public function testWithdrawingIsAlwaysAllowed(): void {
+		$this->configService->method('isMaybeAllowed')->willReturn(false);
+
+		$this->service->assertResponseAllowed($this->appointment(false), null);
+		$this->addToAssertionCount(1);
+	}
+
+	public function testUnknownAnswerIsRejected(): void {
+		$this->configService->method('isMaybeAllowed')->willReturn(true);
+
+		$this->expectException(\InvalidArgumentException::class);
+		$this->service->assertResponseAllowed($this->appointment(true), 'perhaps');
+	}
+}

--- a/tests/unit/Service/ResponseServiceTest.php
+++ b/tests/unit/Service/ResponseServiceTest.php
@@ -8,6 +8,7 @@ use OCA\Attendance\Db\Appointment;
 use OCA\Attendance\Db\AppointmentMapper;
 use OCA\Attendance\Db\AttendanceResponseMapper;
 use OCA\Attendance\Service\AuditEventService;
+use OCA\Attendance\Service\CapacityService;
 use OCA\Attendance\Service\ConfigService;
 use OCA\Attendance\Service\GuestService;
 use OCA\Attendance\Service\NotificationService;
@@ -44,6 +45,11 @@ class ResponseServiceTest extends TestCase {
 		$this->responseMapper = $this->createMock(AttendanceResponseMapper::class);
 		$this->configService = $this->createMock(ConfigService::class);
 		$this->configService->method('isMaybeAllowed')->willReturn(true);
+		$capacityService = new CapacityService(
+			$this->responseMapper,
+			$this->createMock(NotificationService::class),
+			$this->createMock(AuditEventService::class),
+		);
 
 		$this->service = new ResponseService(
 			$this->appointmentMapper,
@@ -56,7 +62,8 @@ class ResponseServiceTest extends TestCase {
 			$this->createMock(AuditEventService::class),
 			$this->createMock(OrgCalendarSyncService::class),
 			$this->createMock(TalkRoomService::class),
-			new ResponsePolicyService($this->configService),
+			new ResponsePolicyService($this->configService, $capacityService),
+			$capacityService,
 		);
 	}
 

--- a/tests/unit/Service/ResponseServiceTest.php
+++ b/tests/unit/Service/ResponseServiceTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\Attendance\Tests\Unit\Service;
+
+use OCA\Attendance\Db\Appointment;
+use OCA\Attendance\Db\AppointmentMapper;
+use OCA\Attendance\Db\AttendanceResponseMapper;
+use OCA\Attendance\Service\AuditEventService;
+use OCA\Attendance\Service\ConfigService;
+use OCA\Attendance\Service\GuestService;
+use OCA\Attendance\Service\NotificationService;
+use OCA\Attendance\Service\OrgCalendarSyncService;
+use OCA\Attendance\Service\ResponsePolicyService;
+use OCA\Attendance\Service\ResponseService;
+use OCA\Attendance\Service\TalkRoomService;
+use OCA\Attendance\Service\VisibilityService;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\IGroupManager;
+use OCP\IUserManager;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The quick-response links are the second writer of a response, next to
+ * AppointmentService::applyResponse(). These cover the rules that have to hold
+ * on both paths — a gate that only guards the app would be a hole here.
+ */
+class ResponseServiceTest extends TestCase {
+	/** @var AppointmentMapper|MockObject */
+	private $appointmentMapper;
+
+	/** @var AttendanceResponseMapper|MockObject */
+	private $responseMapper;
+
+	/** @var ConfigService|MockObject */
+	private $configService;
+
+	private ResponseService $service;
+
+	protected function setUp(): void {
+		$this->appointmentMapper = $this->createMock(AppointmentMapper::class);
+		$this->responseMapper = $this->createMock(AttendanceResponseMapper::class);
+		$this->configService = $this->createMock(ConfigService::class);
+		$this->configService->method('isMaybeAllowed')->willReturn(true);
+
+		$this->service = new ResponseService(
+			$this->appointmentMapper,
+			$this->responseMapper,
+			$this->createMock(VisibilityService::class),
+			$this->createMock(NotificationService::class),
+			$this->createMock(IGroupManager::class),
+			$this->createMock(IUserManager::class),
+			$this->createMock(GuestService::class),
+			$this->createMock(AuditEventService::class),
+			$this->createMock(OrgCalendarSyncService::class),
+			$this->createMock(TalkRoomService::class),
+			new ResponsePolicyService($this->configService),
+		);
+	}
+
+	public function testQuickLinkCannotAnswerMaybeWhereTheAppointmentDoesNotOfferIt(): void {
+		$appointment = new Appointment();
+		$appointment->setId(7);
+		$appointment->setAllowMaybe(false);
+
+		$this->appointmentMapper->method('find')->with(7)->willReturn($appointment);
+		$this->responseMapper->expects($this->never())->method('insert');
+		$this->responseMapper->expects($this->never())->method('update');
+
+		$this->expectException(\InvalidArgumentException::class);
+		$this->expectExceptionMessage('maybe');
+		$this->service->submitResponse(7, 'alice', 'maybe');
+	}
+
+	public function testQuickLinkStillAnswersYesOnAnAppointmentWithoutMaybe(): void {
+		$appointment = new Appointment();
+		$appointment->setId(7);
+		$appointment->setAllowMaybe(false);
+
+		$this->appointmentMapper->method('find')->with(7)->willReturn($appointment);
+		$this->responseMapper->method('findByAppointmentAndUser')
+			->willThrowException(new DoesNotExistException('none'));
+		$this->responseMapper->expects($this->once())->method('insert')->willReturnArgument(0);
+
+		$this->assertSame('yes', $this->service->submitResponse(7, 'alice', 'yes')->getResponse());
+	}
+
+	public function testQuickLinkAnswersMaybeWhereTheAppointmentOffersIt(): void {
+		$appointment = new Appointment();
+		$appointment->setId(7);
+		$appointment->setAllowMaybe(true);
+
+		$this->appointmentMapper->method('find')->with(7)->willReturn($appointment);
+		$this->responseMapper->method('findByAppointmentAndUser')
+			->willThrowException(new DoesNotExistException('none'));
+		$this->responseMapper->expects($this->once())->method('insert')->willReturnArgument(0);
+
+		$this->assertSame('maybe', $this->service->submitResponse(7, 'alice', 'maybe')->getResponse());
+	}
+}

--- a/tests/unit/Service/ResponseSummaryServiceTest.php
+++ b/tests/unit/Service/ResponseSummaryServiceTest.php
@@ -8,8 +8,11 @@ use OCA\Attendance\Db\Appointment;
 use OCA\Attendance\Db\AppointmentMapper;
 use OCA\Attendance\Db\AttendanceResponse;
 use OCA\Attendance\Db\AttendanceResponseMapper;
+use OCA\Attendance\Service\AuditEventService;
+use OCA\Attendance\Service\CapacityService;
 use OCA\Attendance\Service\ConfigService;
 use OCA\Attendance\Service\GuestService;
+use OCA\Attendance\Service\NotificationService;
 use OCA\Attendance\Service\ResponseSummaryService;
 use OCA\Attendance\Service\VisibilityService;
 use OCP\IGroup;
@@ -60,6 +63,11 @@ class ResponseSummaryServiceTest extends TestCase {
 			$this->groupManager,
 			$this->userManager,
 			$this->guestService,
+			new CapacityService(
+				$this->responseMapper,
+				$this->createMock(NotificationService::class),
+				$this->createMock(AuditEventService::class),
+			),
 		);
 	}
 


### PR DESCRIPTION
Closes #27, and lands the half of #12 that #27 needed.

Two commits, meant to be read in order — the second depends on the first.

## `9a3d120` — an appointment can drop "Maybe" from its answers

The narrow slice of #12: the option set stays `yes`/`no`/`maybe` in storage, an appointment only decides whether the third one is offered. A full custom-options refactor would have to touch those literals across thirty PHP files and every old mobile client; this doesn't.

`allow_maybe` is tri-state on purpose. NULL means the appointment has no opinion and follows the instance-wide setting, so flipping that setting still reaches every appointment nobody has decided about. The parameter has no such state — null there means the caller left the field alone.

## `3f9b57a` — attendance limit with an optional waitlist

Cap how many people get in; once full the next person queues, and a spot that frees up promotes whoever is next.

**Who holds a spot is derived, never stored.** Yes-responses ordered by `spot_claimed_at`, the first `max_attendees` in, the rest waiting. That is what makes promotion free: somebody withdraws and everyone behind them moves up as a consequence of the ordering — no write, no job, nothing that can drift out of step with the answers it is built from.

`spot_claimed_at` rather than `responded_at`, because the latter is rewritten when somebody only edits their comment, which would quietly send them to the back of the queue.

## Design decisions worth reviewing

- **One guard, two writers.** `AppointmentService::applyResponse()` (web, mobile, on-behalf) and `ResponseService::submitResponse()` (quick-response links) are near-identical twins that have already drifted. Both now call `ResponsePolicyService`, and both have a test that fails if the call goes away. Collapsing the duplication is worth doing on its own and deliberately isn't in here — it changes quick-link behaviour in two user-visible ways.
- **Orthogonal to booking.** Both answer "who has a place", but booking is organizer-authored and instance-wide, capacity is self-service and per-appointment. Overloading `booking_status` would leave the close-time wave unable to tell "the organizer did not plan you in" from "you were fourth in line".
- **A limit takes "Maybe" off the table**, on the server and not only in the form — a maybe holds a spot away from somebody who would commit.
- **Intent is explicit, not inferred.** `respond` takes `acceptWaitlist`; without it a full appointment answers 400. An old mobile build, a signed quick-response link, or a page loaded before the last spot went gets an honest refusal instead of a silent place in line its UI would render as "attending".
- **Organizers may overbook** via respond-on-behalf; making them edit the limit and edit it back would produce a worse audit trail.
- **Lowering a limit demotes nobody.** The appointment sits over capacity until people drop out — a waitlist must never take back a spot somebody was told they had.

## Where a place in line differs from a place at the appointment

The calendar feed leaves the slot free and marks the title (immediately, not gated on close — this is where the person stands, not a verdict the organizer has yet to make); the export sheet says Waitlist rather than Yes; the check-in list flags them. Statistics stay on the raw response: they measure responsiveness over time, and queue position is transient.

Two fire-once notifications in the same shape as the booking wave — a spot came free, and at close no spot came free, which is what releases somebody from holding a date for nothing. Joining the queue is recorded but never announced. The promotion is the one state change here with no human behind it, so it gets an audit entry: it answers "why am I suddenly in?".

## psalm-baseline.xml shrinks by 89 entries

The new code reached through four untyped legacy parameters — `generateVEvent`'s `$l` and `$response`, `getTableXml`'s rows, the summary's `serializeResponse`. Typing them fixed 105 findings and let those entries leave the baseline. The ~16 added back are the structural kind every sibling already carries: route-dispatched controller params, entity properties behind the magic accessors, the migration's `UnusedClass`, and `ClassMustBeFinal` plus the DI constructor for the two new services (final would break PHPUnit mocking).

## Verification

`./scripts/check.sh` passes all ten gates — 410 unit tests, psalm, php-cs-fixer, eslint, stylelint, the vite build, both l10n checks, and the OpenAPI diff.

**`tests/e2e/33-attendance-limit.spec.js` has not been run.** No Docker in the environment it was written in, so it is unverified until CI runs it. It covers full → refused → join → drop → promote, the maybe interaction, the no-waitlist path, and that an unlimited appointment behaves exactly as before.

## Follow-ups, not in here

- **Flutter gate.** Capabilities are `attendanceLimit` and `responseOptions`, plus `allowMaybeDefault`. Appointments carry `maxAttendees`, `waitlistEnabled`, `occupancy`, `isFull`; responses carry `waitlisted` / `waitlistPosition`. Server-first is safe by construction — old clients get the explicit 400 rather than a silent wrong state.
- **Collapsing the two response writers**, as above.
- **The rest of #12** — arbitrary custom options with their own colours — is untouched; this is the stepping stone, and the switch it adds gets replaced when that lands.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HTQweHTfkj8qSZQYccEk8d

---
_Generated by [Claude Code](https://claude.ai/code/session_01HTQweHTfkj8qSZQYccEk8d)_