### PR TITLE
feat(summary): make response-summary grouping an explicit mode

### DIFF
--- a/lib/Controller/AdminController.php
+++ b/lib/Controller/AdminController.php
@@ -136,6 +136,8 @@ class AdminController extends Controller {
 				'config' => [
 					'whitelistedGroups' => $whitelistedGroups,
 					'whitelistedTeams' => $whitelistedTeams,
+					'responseSummaryGroupsMode' => $this->configService->getResponseSummaryGroupsMode(),
+					'responseSummaryTeamsMode' => $this->configService->getResponseSummaryTeamsMode(),
 					'permissions' => $permissionSettings,
 					'reminders' => [
 						'enabled' => $this->config->getAppValue('attendance', 'reminders_enabled', 'no') === 'yes',
@@ -188,6 +190,8 @@ class AdminController extends Controller {
 	 *
 	 * @param ?list<string> $whitelistedGroups Group IDs allowed to use the app
 	 * @param ?list<string> $whitelistedTeams Team IDs allowed to use the app
+	 * @param ?string $responseSummaryGroupsMode How the response summary groups by Nextcloud group: none|specific|all
+	 * @param ?string $responseSummaryTeamsMode How the response summary groups by Nextcloud team: none|specific
 	 * @param ?array<string, array{mode: string, groups: list<string>}> $permissions Permission name to access mode (all|groups|nobody) and group IDs
 	 * @param ?array{enabled?: bool, reminderDays?: int, reminderFrequency?: int, reminderTarget?: string} $reminders Reminder settings
 	 * @param ?array{enabled?: bool} $calendarSync Calendar sync settings
@@ -206,6 +210,8 @@ class AdminController extends Controller {
 	public function saveSettings(
 		?array $whitelistedGroups = null,
 		?array $whitelistedTeams = null,
+		?string $responseSummaryGroupsMode = null,
+		?string $responseSummaryTeamsMode = null,
 		?array $permissions = null,
 		?array $reminders = null,
 		?array $calendarSync = null,
@@ -235,6 +241,12 @@ class AdminController extends Controller {
 			}
 			if ($whitelistedTeams !== null) {
 				$this->configService->setWhitelistedTeams($whitelistedTeams);
+			}
+			if ($responseSummaryGroupsMode !== null) {
+				$this->configService->setResponseSummaryGroupsMode($responseSummaryGroupsMode);
+			}
+			if ($responseSummaryTeamsMode !== null) {
+				$this->configService->setResponseSummaryTeamsMode($responseSummaryTeamsMode);
 			}
 
 			if ($permissions !== null) {

--- a/lib/ResponseDefinitions.php
+++ b/lib/ResponseDefinitions.php
@@ -249,6 +249,8 @@ namespace OCA\Attendance;
  * @psalm-type AttendanceAdminConfig = array{
  *   whitelistedGroups: list<string>,
  *   whitelistedTeams: list<AttendanceTeamOption>,
+ *   responseSummaryGroupsMode: string,
+ *   responseSummaryTeamsMode: string,
  *   permissions: AttendancePermissionSettings,
  *   reminders: AttendanceAdminReminderConfig,
  *   calendarSync: AttendanceAdminCalendarSyncConfig,

--- a/lib/Service/ConfigService.php
+++ b/lib/Service/ConfigService.php
@@ -16,6 +16,13 @@ class ConfigService {
 	public const DEFAULT_PUSH_PROXY_SERVER = 'https://push.anwesenheit.app';
 	public const VALID_REMINDER_TARGETS = ['non_responders', 'maybe', 'both'];
 
+	public const RESPONSE_SUMMARY_MODE_NONE = 'none';
+	public const RESPONSE_SUMMARY_MODE_SPECIFIC = 'specific';
+	public const RESPONSE_SUMMARY_MODE_ALL = 'all';
+	/** Teams have no "all" mode: unlike Nextcloud groups, there is no cheap way to enumerate every team. */
+	public const RESPONSE_SUMMARY_GROUP_MODES = [self::RESPONSE_SUMMARY_MODE_NONE, self::RESPONSE_SUMMARY_MODE_SPECIFIC, self::RESPONSE_SUMMARY_MODE_ALL];
+	public const RESPONSE_SUMMARY_TEAM_MODES = [self::RESPONSE_SUMMARY_MODE_NONE, self::RESPONSE_SUMMARY_MODE_SPECIFIC];
+
 	private IConfig $config;
 	private IAppConfig $appConfig;
 
@@ -42,6 +49,25 @@ class ConfigService {
 	 */
 	public function setWhitelistedGroups(array $groups): void {
 		$this->config->setAppValue(self::APP_ID, 'whitelisted_groups', json_encode($groups));
+	}
+
+	/**
+	 * How the response summary groups by Nextcloud group: no sections at all
+	 * ('none'), only the configured whitelist ('specific'), or every group
+	 * ('all'). With no mode stored yet, derive it from the whitelist so an
+	 * upgrade keeps today's behavior — an empty list means no sections, a
+	 * non-empty one means specific groups.
+	 */
+	public function getResponseSummaryGroupsMode(): string {
+		return $this->getStoredMode(
+			'response_summary_groups_mode',
+			self::RESPONSE_SUMMARY_GROUP_MODES,
+			empty($this->getWhitelistedGroups()) ? self::RESPONSE_SUMMARY_MODE_NONE : self::RESPONSE_SUMMARY_MODE_SPECIFIC,
+		);
+	}
+
+	public function setResponseSummaryGroupsMode(string $mode): void {
+		$this->setStoredMode('response_summary_groups_mode', $mode, self::RESPONSE_SUMMARY_GROUP_MODES);
 	}
 
 	/**
@@ -81,6 +107,48 @@ class ConfigService {
 	 */
 	public function setWhitelistedTeams(array $teams): void {
 		$this->config->setAppValue(self::APP_ID, 'whitelisted_teams', json_encode($teams));
+	}
+
+	/**
+	 * How the response summary groups by Nextcloud team: no sections at all
+	 * ('none') or only the configured whitelist ('specific'). Same
+	 * migration rule as the groups mode: derive from the whitelist when no
+	 * mode is stored yet.
+	 */
+	public function getResponseSummaryTeamsMode(): string {
+		return $this->getStoredMode(
+			'response_summary_teams_mode',
+			self::RESPONSE_SUMMARY_TEAM_MODES,
+			empty($this->getWhitelistedTeams()) ? self::RESPONSE_SUMMARY_MODE_NONE : self::RESPONSE_SUMMARY_MODE_SPECIFIC,
+		);
+	}
+
+	public function setResponseSummaryTeamsMode(string $mode): void {
+		$this->setStoredMode('response_summary_teams_mode', $mode, self::RESPONSE_SUMMARY_TEAM_MODES);
+	}
+
+	/**
+	 * Shared read path for the response-summary mode settings: the stored
+	 * value if it's still a valid mode, otherwise the migration-implied
+	 * default for an install that predates the mode key.
+	 *
+	 * @param list<string> $validModes
+	 */
+	private function getStoredMode(string $key, array $validModes, string $impliedDefault): string {
+		$mode = $this->appConfig->getValueString(self::APP_ID, $key);
+		return in_array($mode, $validModes, true) ? $mode : $impliedDefault;
+	}
+
+	/**
+	 * Shared write path for the response-summary mode settings.
+	 *
+	 * @param list<string> $validModes
+	 */
+	private function setStoredMode(string $key, string $mode, array $validModes): void {
+		if (!in_array($mode, $validModes, true)) {
+			throw new \InvalidArgumentException("Invalid mode for {$key}: {$mode}");
+		}
+		$this->appConfig->setValueString(self::APP_ID, $key, $mode);
 	}
 
 	/**

--- a/lib/Service/ResponseSummaryService.php
+++ b/lib/Service/ResponseSummaryService.php
@@ -83,8 +83,12 @@ class ResponseSummaryService {
 		$summary['by_group'] = $this->filterEmptyGroups($summary['by_group']);
 		$summary['by_team'] = $this->filterEmptyGroups($summary['by_team']);
 
-		$summary['by_group'] = $this->sortGroups($summary['by_group'], $cache['whitelistedGroups']);
-		$summary['by_team'] = $this->sortTeams($summary['by_team'], $cache['whitelistedTeams']);
+		/** @var list<string> $sectionGroups */
+		$sectionGroups = $cache['sectionGroups'];
+		/** @var list<string> $sectionTeams */
+		$sectionTeams = $cache['sectionTeams'];
+		$summary['by_group'] = $this->sortGroups($summary['by_group'], $sectionGroups);
+		$summary['by_team'] = $this->sortTeams($summary['by_team'], $sectionTeams);
 
 		return $summary;
 	}
@@ -138,11 +142,17 @@ class ResponseSummaryService {
 	private function buildCache(Appointment $appointment, array $responses): array {
 		// Cache whitelisted groups (called once instead of per-group)
 		$whitelistedGroups = $this->configService->getWhitelistedGroups();
-		$whitelistedGroupsLower = array_map('strtolower', $whitelistedGroups);
-		$allowAllGroups = empty($whitelistedGroups);
+		$groupsMode = $this->configService->getResponseSummaryGroupsMode();
+		// Only "specific" mode pins sections to the whitelist. The raw list
+		// still separately narrows the audience of open appointments via
+		// getTargetAttendees() below, regardless of this display mode.
+		$sectionGroups = $groupsMode === ConfigService::RESPONSE_SUMMARY_MODE_SPECIFIC ? $whitelistedGroups : [];
+		$sectionGroupsLower = array_map('strtolower', $sectionGroups);
 
 		// Cache whitelisted teams
 		$whitelistedTeams = $this->configService->getWhitelistedTeams();
+		$teamsMode = $this->configService->getResponseSummaryTeamsMode();
+		$sectionTeams = $teamsMode === ConfigService::RESPONSE_SUMMARY_MODE_SPECIFIC ? $whitelistedTeams : [];
 
 		$visibilitySettings = $this->visibilityService->getVisibilitySettings($appointment);
 		$appointmentHasRestrictions = $this->visibilityService->hasRestrictedVisibility($appointment);
@@ -161,26 +171,40 @@ class ResponseSummaryService {
 			}
 		}
 
-		// Pre-fetch whitelisted group objects and their users
+		// Pre-fetch group objects and their users for whichever groups can
+		// render as sections, mirroring isGroupAllowedCached()'s precedence:
+		// the whitelist in "specific" mode; a restricted appointment's own
+		// restriction groups regardless of mode (issue #199 — only those can
+		// ever pass, so fetching every instance group would be wasted work);
+		// every Nextcloud group otherwise, but only in "all" mode ("none"
+		// suppresses grouping entirely on a fully open appointment).
+		/** @var array<array-key, list<\OCP\IUser>> $groupUsers */
 		$groupUsers = [];
-		if ($allowAllGroups) {
-			$allGroups = $this->groupManager->search('');
-			foreach ($allGroups as $group) {
-				$groupUsers[$group->getGID()] = $group->getUsers();
-			}
-		} else {
-			foreach ($whitelistedGroups as $groupId) {
+		if ($groupsMode === ConfigService::RESPONSE_SUMMARY_MODE_SPECIFIC) {
+			foreach ($sectionGroups as $groupId) {
 				$group = $this->groupManager->get($groupId);
 				if ($group) {
 					$groupUsers[$groupId] = $group->getUsers();
 				}
+			}
+		} elseif (!empty($appointmentVisibleGroupsLower)) {
+			foreach ($visibilitySettings['groups'] as $groupId) {
+				$group = $this->groupManager->get($groupId);
+				if ($group) {
+					$groupUsers[$groupId] = $group->getUsers();
+				}
+			}
+		} elseif ($groupsMode === ConfigService::RESPONSE_SUMMARY_MODE_ALL) {
+			$allGroups = $this->groupManager->search('');
+			foreach ($allGroups as $group) {
+				$groupUsers[$group->getGID()] = $group->getUsers();
 			}
 		}
 
 		// Pre-fetch whitelisted team members and info
 		$teamMembers = [];
 		$teamInfo = [];
-		foreach ($whitelistedTeams as $teamId) {
+		foreach ($sectionTeams as $teamId) {
 			$teamMembers[$teamId] = $this->visibilityService->getTeamMembers($teamId);
 			$info = $this->visibilityService->getTeamInfo($teamId);
 			if ($info) {
@@ -201,10 +225,10 @@ class ResponseSummaryService {
 		}
 
 		return [
-			'whitelistedGroups' => $whitelistedGroups,
-			'whitelistedGroupsLower' => $whitelistedGroupsLower,
-			'allowAllGroups' => $allowAllGroups,
-			'whitelistedTeams' => $whitelistedTeams,
+			'groupsMode' => $groupsMode,
+			'sectionGroups' => $sectionGroups,
+			'sectionGroupsLower' => $sectionGroupsLower,
+			'sectionTeams' => $sectionTeams,
 			'teamMembers' => $teamMembers,
 			'teamInfo' => $teamInfo,
 			'users' => $users,
@@ -221,20 +245,26 @@ class ResponseSummaryService {
 	/**
 	 * Check if a group may appear as a section in the summary (using cache).
 	 *
-	 * A configured whitelist alone decides the sections — visibility
-	 * restrictions only narrow the audience (issue #199). Without a whitelist,
-	 * a group-restricted appointment groups by its restriction groups.
+	 * Driven by the admin's chosen response-summary-groups mode: 'specific'
+	 * sections only the configured whitelist regardless of the appointment's
+	 * own visibility restrictions (issue #199). 'none' and 'all' both still
+	 * section a restricted appointment by its own restriction groups (issue
+	 * #199 applies with no whitelist too) — only a fully open appointment
+	 * tells them apart: 'none' sections nothing there (issue #212), 'all'
+	 * sections every group the responder belongs to.
 	 */
 	private function isGroupAllowedCached(string $groupId, array $cache): bool {
-		if (!$cache['allowAllGroups']) {
-			return in_array(strtolower($groupId), $cache['whitelistedGroupsLower']);
+		if ($cache['groupsMode'] === ConfigService::RESPONSE_SUMMARY_MODE_SPECIFIC) {
+			/** @var list<string> $sectionGroupsLower */
+			$sectionGroupsLower = $cache['sectionGroupsLower'];
+			return in_array(strtolower($groupId), $sectionGroupsLower);
 		}
 
 		if (!empty($cache['appointmentVisibleGroupsLower'])) {
 			return in_array(strtolower($groupId), $cache['appointmentVisibleGroupsLower']);
 		}
 
-		return true;
+		return $cache['groupsMode'] === ConfigService::RESPONSE_SUMMARY_MODE_ALL;
 	}
 
 	/**
@@ -242,18 +272,13 @@ class ResponseSummaryService {
 	 *
 	 * Same as isGroupAllowedCached but hides the Guests app's system group
 	 * unless an admin opts in via the whitelist — otherwise every guest user
-	 * would be lumped under one section regardless of context. Also hides
-	 * every group when neither a whitelist nor an appointment restriction is
-	 * configured: otherwise every Nextcloud group a target attendee happens
-	 * to belong to becomes a section, however unrelated to attendance
-	 * tracking (issue #212). Everyone still counts, just under Others.
+	 * would be lumped under one section regardless of context.
 	 */
 	private function isGroupVisibleAsSection(string $groupId, array $cache): bool {
-		if ($cache['allowAllGroups'] && empty($cache['appointmentVisibleGroupsLower'])) {
-			return false;
-		}
+		/** @var list<string> $sectionGroupsLower */
+		$sectionGroupsLower = $cache['sectionGroupsLower'];
 		if (GuestService::isGuestsSystemGroup($groupId)
-			&& !in_array(GuestService::GUESTS_SYSTEM_GROUP, $cache['whitelistedGroupsLower'], true)) {
+			&& !in_array(GuestService::GUESTS_SYSTEM_GROUP, $sectionGroupsLower, true)) {
 			return false;
 		}
 		return $this->isGroupAllowedCached($groupId, $cache);
@@ -345,9 +370,9 @@ class ResponseSummaryService {
 			}
 
 			// Check teams (user can be in both groups AND teams - duplicates allowed)
-			/** @var list<string> $whitelistedTeams */
-			$whitelistedTeams = $cache['whitelistedTeams'];
-			foreach ($whitelistedTeams as $teamId) {
+			/** @var list<string> $sectionTeams */
+			$sectionTeams = $cache['sectionTeams'];
+			foreach ($sectionTeams as $teamId) {
 				$teamMemberIds = $cache['teamMembers'][$teamId] ?? [];
 				if (in_array($userId, $teamMemberIds)) {
 					$userInWhitelistedTeam = true;
@@ -443,11 +468,12 @@ class ResponseSummaryService {
 		array $respondedUserIds,
 		array $cache,
 	): void {
-		$groupsToProcess = $cache['allowAllGroups']
-			? array_keys($cache['groupUsers'])
-			: $cache['whitelistedGroups'];
-
-		foreach ($groupsToProcess as $groupId) {
+		// $cache['groupUsers'] already holds exactly the candidate groups for
+		// the active mode (every group for 'all', the whitelist for
+		// 'specific', none for 'none') — no need to branch on mode again here.
+		/** @var list<array-key> $groupIds */
+		$groupIds = array_keys($cache['groupUsers']);
+		foreach ($groupIds as $groupId) {
 			// Numeric-string group IDs get coerced to int when used as array keys (issue #63)
 			$groupId = (string)$groupId;
 
@@ -512,9 +538,9 @@ class ResponseSummaryService {
 		array $respondedUserIds,
 		array $cache,
 	): void {
-		/** @var list<string> $whitelistedTeams */
-		$whitelistedTeams = $cache['whitelistedTeams'];
-		foreach ($whitelistedTeams as $teamId) {
+		/** @var list<string> $sectionTeams */
+		$sectionTeams = $cache['sectionTeams'];
+		foreach ($sectionTeams as $teamId) {
 			$teamInfo = $cache['teamInfo'][$teamId] ?? null;
 
 			if (!isset($summary['by_team'][$teamId])) {
@@ -585,8 +611,8 @@ class ResponseSummaryService {
 		$othersNonResponding = [];
 		$othersMaybe = [];
 		$skipUnaffiliated = !$cache['appointmentHasRestrictions'];
-		/** @var list<string> $whitelistedTeams */
-		$whitelistedTeams = $cache['whitelistedTeams'];
+		/** @var list<string> $sectionTeams */
+		$sectionTeams = $cache['sectionTeams'];
 
 		/** @var \OCP\IUser $user */
 		foreach ($cache['allUsers'] as $user) {
@@ -615,7 +641,7 @@ class ResponseSummaryService {
 
 			$hasRelevantTeam = false;
 			if (!$hasVisibleGroup) {
-				foreach ($whitelistedTeams as $teamId) {
+				foreach ($sectionTeams as $teamId) {
 					$teamMemberIds = $cache['teamMembers'][$teamId] ?? [];
 					if (in_array($userId, $teamMemberIds)) {
 						$hasRelevantTeam = true;

--- a/lib/Service/ResponseSummaryService.php
+++ b/lib/Service/ResponseSummaryService.php
@@ -242,9 +242,16 @@ class ResponseSummaryService {
 	 *
 	 * Same as isGroupAllowedCached but hides the Guests app's system group
 	 * unless an admin opts in via the whitelist — otherwise every guest user
-	 * would be lumped under one section regardless of context.
+	 * would be lumped under one section regardless of context. Also hides
+	 * every group when neither a whitelist nor an appointment restriction is
+	 * configured: otherwise every Nextcloud group a target attendee happens
+	 * to belong to becomes a section, however unrelated to attendance
+	 * tracking (issue #212). Everyone still counts, just under Others.
 	 */
 	private function isGroupVisibleAsSection(string $groupId, array $cache): bool {
+		if ($cache['allowAllGroups'] && empty($cache['appointmentVisibleGroupsLower'])) {
+			return false;
+		}
 		if (GuestService::isGuestsSystemGroup($groupId)
 			&& !in_array(GuestService::GUESTS_SYSTEM_GROUP, $cache['whitelistedGroupsLower'], true)) {
 			return false;

--- a/openapi-administration.json
+++ b/openapi-administration.json
@@ -51,6 +51,8 @@
                 "required": [
                     "whitelistedGroups",
                     "whitelistedTeams",
+                    "responseSummaryGroupsMode",
+                    "responseSummaryTeamsMode",
                     "permissions",
                     "reminders",
                     "calendarSync",
@@ -75,6 +77,12 @@
                         "items": {
                             "$ref": "#/components/schemas/TeamOption"
                         }
+                    },
+                    "responseSummaryGroupsMode": {
+                        "type": "string"
+                    },
+                    "responseSummaryTeamsMode": {
+                        "type": "string"
                     },
                     "permissions": {
                         "$ref": "#/components/schemas/PermissionSettings"
@@ -600,6 +608,18 @@
                                         "items": {
                                             "type": "string"
                                         }
+                                    },
+                                    "responseSummaryGroupsMode": {
+                                        "type": "string",
+                                        "nullable": true,
+                                        "default": null,
+                                        "description": "How the response summary groups by Nextcloud group: none|specific|all"
+                                    },
+                                    "responseSummaryTeamsMode": {
+                                        "type": "string",
+                                        "nullable": true,
+                                        "default": null,
+                                        "description": "How the response summary groups by Nextcloud team: none|specific"
                                     },
                                     "permissions": {
                                         "type": "object",

--- a/openapi-full.json
+++ b/openapi-full.json
@@ -51,6 +51,8 @@
                 "required": [
                     "whitelistedGroups",
                     "whitelistedTeams",
+                    "responseSummaryGroupsMode",
+                    "responseSummaryTeamsMode",
                     "permissions",
                     "reminders",
                     "calendarSync",
@@ -75,6 +77,12 @@
                         "items": {
                             "$ref": "#/components/schemas/TeamOption"
                         }
+                    },
+                    "responseSummaryGroupsMode": {
+                        "type": "string"
+                    },
+                    "responseSummaryTeamsMode": {
+                        "type": "string"
                     },
                     "permissions": {
                         "$ref": "#/components/schemas/PermissionSettings"
@@ -7696,6 +7704,18 @@
                                         "items": {
                                             "type": "string"
                                         }
+                                    },
+                                    "responseSummaryGroupsMode": {
+                                        "type": "string",
+                                        "nullable": true,
+                                        "default": null,
+                                        "description": "How the response summary groups by Nextcloud group: none|specific|all"
+                                    },
+                                    "responseSummaryTeamsMode": {
+                                        "type": "string",
+                                        "nullable": true,
+                                        "default": null,
+                                        "description": "How the response summary groups by Nextcloud team: none|specific"
                                     },
                                     "permissions": {
                                         "type": "object",

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -133,8 +133,6 @@
       <code><![CDATA[new DataResponse($results)]]></code>
     </MixedReturnTypeCoercion>
     <PossiblyUnusedParam>
-      <code><![CDATA[$id]]></code>
-      <code><![CDATA[$id]]></code>
       <code><![CDATA[$appointmentId]]></code>
       <code><![CDATA[$appointmentId]]></code>
       <code><![CDATA[$appointmentIds]]></code>
@@ -171,6 +169,8 @@
       <code><![CDATA[$id]]></code>
       <code><![CDATA[$id]]></code>
       <code><![CDATA[$id]]></code>
+      <code><![CDATA[$id]]></code>
+      <code><![CDATA[$id]]></code>
       <code><![CDATA[$includeComments]]></code>
       <code><![CDATA[$location]]></code>
       <code><![CDATA[$location]]></code>
@@ -182,11 +182,11 @@
       <code><![CDATA[$organizers]]></code>
       <code><![CDATA[$organizers]]></code>
       <code><![CDATA[$organizers]]></code>
+      <code><![CDATA[$response]]></code>
+      <code><![CDATA[$response]]></code>
+      <code><![CDATA[$response]]></code>
       <code><![CDATA[$responseDeadline]]></code>
       <code><![CDATA[$responseDeadline]]></code>
-      <code><![CDATA[$response]]></code>
-      <code><![CDATA[$response]]></code>
-      <code><![CDATA[$response]]></code>
       <code><![CDATA[$scope]]></code>
       <code><![CDATA[$scope]]></code>
       <code><![CDATA[$sendNotification]]></code>
@@ -195,9 +195,9 @@
       <code><![CDATA[$startDate]]></code>
       <code><![CDATA[$startDatetime]]></code>
       <code><![CDATA[$startDatetime]]></code>
-      <code><![CDATA[$targetUserId]]></code>
-      <code><![CDATA[$targetUserId]]></code>
       <code><![CDATA[$target]]></code>
+      <code><![CDATA[$targetUserId]]></code>
+      <code><![CDATA[$targetUserId]]></code>
       <code><![CDATA[$unansweredOnly]]></code>
       <code><![CDATA[$userId]]></code>
       <code><![CDATA[$userId]]></code>
@@ -215,6 +215,8 @@
       <code><![CDATA[DataResponse<Http::STATUS_OK, AttendanceAppointmentData, array{}>|DataResponse<Http::STATUS_UNAUTHORIZED, array{error: string}, array{}>|DataResponse<Http::STATUS_FORBIDDEN, array{error: string}, array{}>|DataResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>]]></code>
       <code><![CDATA[DataResponse<Http::STATUS_OK, AttendanceAppointmentData, array{}>|DataResponse<Http::STATUS_UNAUTHORIZED, array{error: string}, array{}>|DataResponse<Http::STATUS_FORBIDDEN, array{error: string}, array{}>|DataResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>]]></code>
       <code><![CDATA[DataResponse<Http::STATUS_OK, AttendanceAppointmentData, array{}>|DataResponse<Http::STATUS_UNAUTHORIZED, array{error: string}, array{}>|DataResponse<Http::STATUS_FORBIDDEN, array{error: string}, array{}>|DataResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>]]></code>
+      <code><![CDATA[DataResponse<Http::STATUS_OK, AttendanceAppointmentData, array{}>|DataResponse<Http::STATUS_UNAUTHORIZED, array{error: string}, array{}>|DataResponse<Http::STATUS_FORBIDDEN, array{error: string}, array{}>|DataResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>|DataResponse<Http::STATUS_BAD_REQUEST, array{error: string}, array{}>]]></code>
+      <code><![CDATA[DataResponse<Http::STATUS_OK, AttendanceAppointmentData, array{}>|DataResponse<Http::STATUS_UNAUTHORIZED, array{error: string}, array{}>|DataResponse<Http::STATUS_FORBIDDEN, array{error: string}, array{}>|DataResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>|DataResponse<Http::STATUS_BAD_REQUEST, array{error: string}, array{}>]]></code>
       <code><![CDATA[DataResponse<Http::STATUS_OK, AttendanceAppointmentData|list<AttendanceAppointmentData>, array{}>|DataResponse<Http::STATUS_BAD_REQUEST, array{error: string}, array{}>|DataResponse<Http::STATUS_UNAUTHORIZED, array{error: string}, array{}>|DataResponse<Http::STATUS_FORBIDDEN, array{error: string}, array{}>|DataResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>]]></code>
       <code><![CDATA[DataResponse<Http::STATUS_OK, AttendanceAppointmentWithResponse, array{}>|DataResponse<Http::STATUS_UNAUTHORIZED, array{error: string}, array{}>|DataResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>]]></code>
       <code><![CDATA[DataResponse<Http::STATUS_OK, AttendanceCapabilities, array{}>]]></code>
@@ -237,8 +239,6 @@
       <code><![CDATA[DataResponse<Http::STATUS_OK, list<AttendanceAppointmentWithResponse>, array{}>|DataResponse<Http::STATUS_UNAUTHORIZED, array{error: string}, array{}>]]></code>
       <code><![CDATA[DataResponse<Http::STATUS_OK, list<AttendanceResponseWithUser>, array{}>|DataResponse<Http::STATUS_UNAUTHORIZED, array{error: string}, array{}>|DataResponse<Http::STATUS_FORBIDDEN, array{error: string}, array{}>|DataResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>]]></code>
       <code><![CDATA[list<AttendanceBulkAppointmentItem>]]></code>
-      <code><![CDATA[DataResponse<Http::STATUS_OK, AttendanceAppointmentData, array{}>|DataResponse<Http::STATUS_UNAUTHORIZED, array{error: string}, array{}>|DataResponse<Http::STATUS_FORBIDDEN, array{error: string}, array{}>|DataResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>|DataResponse<Http::STATUS_BAD_REQUEST, array{error: string}, array{}>]]></code>
-      <code><![CDATA[DataResponse<Http::STATUS_OK, AttendanceAppointmentData, array{}>|DataResponse<Http::STATUS_UNAUTHORIZED, array{error: string}, array{}>|DataResponse<Http::STATUS_FORBIDDEN, array{error: string}, array{}>|DataResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>|DataResponse<Http::STATUS_BAD_REQUEST, array{error: string}, array{}>]]></code>
     </UndefinedDocblockClass>
     <UnusedClass>
       <code><![CDATA[AppointmentController]]></code>
@@ -291,9 +291,9 @@
       <code><![CDATA[$name]]></code>
     </PossiblyUnusedParam>
     <UndefinedDocblockClass>
-      <code><![CDATA[DataResponse<Http::STATUS_OK, list<AttendanceCategoryData>, array{}>|DataResponse<Http::STATUS_UNAUTHORIZED, array{error: string}, array{}>]]></code>
       <code><![CDATA[DataResponse<Http::STATUS_CREATED, AttendanceCategoryData, array{}>|DataResponse<Http::STATUS_BAD_REQUEST, array{error: string}, array{}>|DataResponse<Http::STATUS_UNAUTHORIZED, array{error: string}, array{}>|DataResponse<Http::STATUS_FORBIDDEN, array{error: string}, array{}>]]></code>
       <code><![CDATA[DataResponse<Http::STATUS_OK, AttendanceCategoryData, array{}>|DataResponse<Http::STATUS_BAD_REQUEST, array{error: string}, array{}>|DataResponse<Http::STATUS_UNAUTHORIZED, array{error: string}, array{}>|DataResponse<Http::STATUS_FORBIDDEN, array{error: string}, array{}>|DataResponse<Http::STATUS_NOT_FOUND, array{error: string}, array{}>]]></code>
+      <code><![CDATA[DataResponse<Http::STATUS_OK, list<AttendanceCategoryData>, array{}>|DataResponse<Http::STATUS_UNAUTHORIZED, array{error: string}, array{}>]]></code>
     </UndefinedDocblockClass>
     <UnusedClass>
       <code><![CDATA[CategoryController]]></code>
@@ -1966,10 +1966,6 @@
     <MixedArgument>
       <code><![CDATA[$cache['appointmentVisibleGroupsLower']]]></code>
       <code><![CDATA[$cache['groupUsers']]]></code>
-      <code><![CDATA[$cache['whitelistedGroups']]]></code>
-      <code><![CDATA[$cache['whitelistedGroupsLower']]]></code>
-      <code><![CDATA[$cache['whitelistedGroupsLower']]]></code>
-      <code><![CDATA[$cache['whitelistedTeams']]]></code>
       <code><![CDATA[$gid]]></code>
       <code><![CDATA[$groupId]]></code>
       <code><![CDATA[$nameA]]></code>
@@ -2045,9 +2041,7 @@
       <code><![CDATA[$group]]></code>
       <code><![CDATA[$groupId]]></code>
       <code><![CDATA[$groupId]]></code>
-      <code><![CDATA[$groupId]]></code>
       <code><![CDATA[$groupUsers]]></code>
-      <code><![CDATA[$groupsToProcess]]></code>
       <code><![CDATA[$nameA]]></code>
       <code><![CDATA[$nameA]]></code>
       <code><![CDATA[$nameB]]></code>

--- a/src/components/admin/PermissionRow.vue
+++ b/src/components/admin/PermissionRow.vue
@@ -7,7 +7,7 @@
 			{{ hint }}
 		</p>
 		<div class="permission-row__modes">
-			<NcCheckboxRadioSwitch v-for="mode in MODES"
+			<NcCheckboxRadioSwitch v-for="mode in modes"
 				:key="mode.value"
 				:modelValue="modelValue.mode"
 				:value="mode.value"
@@ -20,18 +20,20 @@
 				{{ mode.label }}
 			</NcCheckboxRadioSwitch>
 		</div>
-		<template v-if="modelValue.mode === 'groups'">
-			<GroupSelect
-				:modelValue="modelValue.groups"
-				:options="options"
-				:placeholder="t('attendance', 'Select groups …')"
-				:data-test="`${dataTest}-groups`"
-				@update:modelValue="setGroups" />
+		<template v-if="modelValue.mode === pickerMode">
+			<slot name="picker" :value="modelValue.groups" :setValue="setGroups">
+				<GroupSelect
+					:modelValue="modelValue.groups"
+					:options="options"
+					:placeholder="t('attendance', 'Select groups …')"
+					:data-test="`${dataTest}-groups`"
+					@update:modelValue="setGroups" />
+			</slot>
 			<p v-if="modelValue.groups.length === 0" class="permission-row__note permission-row__note--warning">
-				{{ t('attendance', 'No groups selected yet — currently nobody is granted this.') }}
+				{{ noSelectionHint }}
 			</p>
 		</template>
-		<p v-if="warningWhenAll && modelValue.mode === 'all'" class="permission-row__note permission-row__note--warning">
+		<p v-if="warningWhenAll && modelValue.mode === warningWhenMode" class="permission-row__note permission-row__note--warning">
 			<AlertIcon :size="16" />
 			{{ warningWhenAll }}
 		</p>
@@ -64,10 +66,29 @@ const props = defineProps({
 		type: String,
 		required: true,
 	},
-	/** { mode: 'all'|'groups'|'nobody', groups: Array<{id, displayName}> } */
+	/** { mode: string, groups: Array<{id, displayName}> } — mode is one of `modes`' values */
 	modelValue: {
 		type: Object,
 		required: true,
+	},
+	/** Radio options. Defaults to the permission catalogue's all/groups/nobody. */
+	modes: {
+		type: Array,
+		default: () => [
+			{ value: 'all', label: t('attendance', 'All users') },
+			{ value: 'groups', label: t('attendance', 'Specific groups') },
+			{ value: 'nobody', label: t('attendance', 'Nobody') },
+		],
+	},
+	/** Which mode value reveals the picker slot below the radios. */
+	pickerMode: {
+		type: String,
+		default: 'groups',
+	},
+	/** Shown while in pickerMode with nothing selected yet. */
+	noSelectionHint: {
+		type: String,
+		default: () => t('attendance', 'No groups selected yet — currently nobody is granted this.'),
 	},
 	options: {
 		type: Array,
@@ -83,10 +104,15 @@ const props = defineProps({
 		type: Object,
 		default: null,
 	},
-	/** Warning note shown while the "all users" mode is selected */
+	/** Warning note shown while modelValue.mode === warningWhenMode */
 	warningWhenAll: {
 		type: String,
 		default: '',
+	},
+	/** Which mode value triggers warningWhenAll. */
+	warningWhenMode: {
+		type: String,
+		default: 'all',
 	},
 	dataTest: {
 		type: String,
@@ -97,12 +123,6 @@ const props = defineProps({
 const emit = defineEmits(['update:modelValue', 'navigate'])
 
 const implicationParts = computed(() => props.implication.split('{section}'))
-
-const MODES = [
-	{ value: 'all', label: t('attendance', 'All users') },
-	{ value: 'groups', label: t('attendance', 'Specific groups') },
-	{ value: 'nobody', label: t('attendance', 'Nobody') },
-]
 
 function setMode(mode) {
 	emit('update:modelValue', { ...props.modelValue, mode })

--- a/src/components/onboarding/OnboardingWizard.vue
+++ b/src/components/onboarding/OnboardingWizard.vue
@@ -49,7 +49,7 @@
 
 				<!-- Response summary groups -->
 				<template v-else-if="currentStep.id === 'groups'">
-					<p>{{ t('attendance', 'Pick the groups that should get their own section. Everyone else appears under Others. Leave it empty to include all groups.') }}</p>
+					<p>{{ t('attendance', 'Pick the groups that should get their own section. Everyone else appears under Others. Leave it empty for no grouping — more options are in the Response summary groups section of the admin settings.') }}</p>
 					<GroupSelect
 						v-model="whitelistedGroups"
 						:options="availableGroups"

--- a/src/utils/permissions.js
+++ b/src/utils/permissions.js
@@ -115,6 +115,19 @@ export const AUDIT_VISIBILITIES = [
 	{ value: 'all_with_response_overview', label: t('attendance', 'Everyone who can see the response overview') },
 ]
 
+/** Matches ConfigService::RESPONSE_SUMMARY_GROUP_MODES. */
+export const RESPONSE_SUMMARY_GROUP_MODES = [
+	{ value: 'none', label: t('attendance', 'No grouping') },
+	{ value: 'specific', label: t('attendance', 'Specific groups') },
+	{ value: 'all', label: t('attendance', 'All groups') },
+]
+
+/** Matches ConfigService::RESPONSE_SUMMARY_TEAM_MODES — teams have no "all" mode: unlike Nextcloud groups, there is no cheap way to enumerate every team. */
+export const RESPONSE_SUMMARY_TEAM_MODES = [
+	{ value: 'none', label: t('attendance', 'No grouping') },
+	{ value: 'specific', label: t('attendance', 'Specific teams') },
+]
+
 /** Matches ConfigService::VALID_REMINDER_TARGETS. */
 export const REMINDER_TARGETS = [
 	{

--- a/src/views/AdminSettings.vue
+++ b/src/views/AdminSettings.vue
@@ -29,35 +29,63 @@
 				</NcButton>
 			</NcSettingsSection>
 
-			<!-- TRANSLATORS: Admin settings section title. The "Response summary" is the main feature of this app - it shows attendance statistics on the appointment detail page, counting users by their Nextcloud group membership. Groups selected here will have their own sections in the summary; users not in these groups appear under "Others". -->
+			<!-- TRANSLATORS: Admin settings section title. The "Response summary" is the main feature of this app - it shows attendance statistics on the appointment detail page, counting users by their Nextcloud group membership. -->
 			<NcSettingsSection id="response-summary"
 				:name="t('attendance', 'Response summary groups')"
-				:description="t('attendance', 'Select which groups to include in response summaries. Users outside these groups will appear under Others. Leave empty to include all groups.')"
+				:description="t('attendance', 'Choose how responses are grouped into sections on the appointment detail page.')"
 				data-test="section-tracking-groups">
-				<GroupSelect
-					v-model="selectedGroups"
+				<PermissionRow
+					:modelValue="responseSummaryGroups"
+					:modes="RESPONSE_SUMMARY_GROUP_MODES"
+					pickerMode="specific"
+					:title="t('attendance', 'Group by')"
+					:hint="t('attendance', 'No grouping puts every response under Others. Specific groups only creates sections for the groups you select below — everyone else appears under Others. All groups creates a section for every Nextcloud group a responder belongs to.')"
+					:noSelectionHint="t('attendance', 'No groups selected yet — nothing groups into sections; everyone appears under Others.')"
+					:warningWhenAll="t('attendance', 'Every Nextcloud group becomes a section, including ones unrelated to attendance — group names become visible to anyone who can see the response overview.')"
 					:options="availableGroups"
-					:placeholder="t('attendance', 'Select groups …')"
-					:sortable="true"
-					data-test="select-whitelisted-groups" />
-				<p class="hint-text">
-					{{ n('attendance', '%n group selected', '%n groups selected', selectedGroups.length, { n: selectedGroups.length }) }}
-				</p>
+					dataTest="response-summary-groups"
+					@update:modelValue="onResponseSummaryGroupsChange">
+					<template #picker="{ value, setValue }">
+						<GroupSelect
+							:modelValue="value"
+							:options="availableGroups"
+							:placeholder="t('attendance', 'Select groups …')"
+							:sortable="true"
+							data-test="select-whitelisted-groups"
+							@update:modelValue="setValue" />
+						<p class="hint-text">
+							{{ n('attendance', '%n group selected', '%n groups selected', value.length, { n: value.length }) }}
+						</p>
+					</template>
+				</PermissionRow>
 			</NcSettingsSection>
 
-			<!-- TRANSLATORS: Admin settings section title. Similar to groups above, but for Nextcloud Teams (formerly Circles). Teams selected here will have their own sections in the attendance statistics on the appointment detail page, showing how many team members responded yes/no/maybe. -->
+			<!-- TRANSLATORS: Admin settings section title. Similar to groups above, but for Nextcloud Teams (formerly Circles). -->
 			<NcSettingsSection v-if="teamsAvailable"
 				:name="t('attendance', 'Response summary teams')"
-				:description="t('attendance', 'Select which teams to include in response summaries. Team members will be grouped together like regular groups.')"
+				:description="t('attendance', 'Choose how responses are grouped into sections by Nextcloud Team.')"
 				data-test="section-tracking-teams">
-				<TeamSelect
-					v-model="selectedTeams"
-					:placeholder="t('attendance', 'Search and select teams …')"
-					:sortable="true"
-					data-test="select-whitelisted-teams" />
-				<p class="hint-text">
-					{{ n('attendance', '%n team selected', '%n teams selected', selectedTeams.length, { n: selectedTeams.length }) }}
-				</p>
+				<PermissionRow
+					:modelValue="responseSummaryTeams"
+					:modes="RESPONSE_SUMMARY_TEAM_MODES"
+					pickerMode="specific"
+					:title="t('attendance', 'Group by')"
+					:hint="t('attendance', 'No grouping puts every response under Others. Specific teams only creates sections for the teams you select below — team members outside them appear under Others.')"
+					:noSelectionHint="t('attendance', 'No teams selected yet — nothing groups into sections; everyone appears under Others.')"
+					dataTest="response-summary-teams"
+					@update:modelValue="onResponseSummaryTeamsChange">
+					<template #picker="{ value, setValue }">
+						<TeamSelect
+							:modelValue="value"
+							:placeholder="t('attendance', 'Search and select teams …')"
+							:sortable="true"
+							data-test="select-whitelisted-teams"
+							@update:modelValue="setValue" />
+						<p class="hint-text">
+							{{ n('attendance', '%n team selected', '%n teams selected', value.length, { n: value.length }) }}
+						</p>
+					</template>
+				</PermissionRow>
 			</NcSettingsSection>
 
 			<NcSettingsSection id="categories"
@@ -695,7 +723,7 @@ import { copyToClipboard } from '../utils/clipboard.js'
 import { formatDate, formatDateTimeMedium } from '../utils/datetime.js'
 import { toGroupObjects } from '../utils/groups.js'
 import { MOBILE_APP_STORES } from '../utils/mobileApp.js'
-import { AUDIT_VISIBILITIES, permissionGroups as buildPermissionGroups, emptyPermissionState, PERMISSION_NAMES, PERMISSION_ROWS, REMINDER_TARGETS } from '../utils/permissions.js'
+import { AUDIT_VISIBILITIES, permissionGroups as buildPermissionGroups, emptyPermissionState, PERMISSION_NAMES, PERMISSION_ROWS, REMINDER_TARGETS, RESPONSE_SUMMARY_GROUP_MODES, RESPONSE_SUMMARY_TEAM_MODES } from '../utils/permissions.js'
 
 const navSections = [
 	{ id: 'setup-wizard', label: t('attendance', 'Setup wizard') },
@@ -831,8 +859,10 @@ function implicationLinkFor(name) {
 
 // State
 const availableGroups = ref([])
-const selectedGroups = ref([])
-const selectedTeams = ref([])
+/** { mode: 'none'|'specific'|'all', groups: Array<{id, displayName}> } */
+const responseSummaryGroups = ref({ mode: 'none', groups: [] })
+/** { mode: 'none'|'specific', groups: Array<{id, label}> } */
+const responseSummaryTeams = ref({ mode: 'none', groups: [] })
 const teamsAvailable = ref(false)
 const permissions = ref(emptyPermissionState())
 const selfCheckinWindowMinutes = ref(30)
@@ -981,17 +1011,29 @@ function autoSave(source, key, payloadFactory, delay = 0) {
 
 const SELECT_DEBOUNCE = 800
 
-autoSave(
-	selectedGroups,
+// Mode and group list save together, like a permission row: the backend
+// leaves omitted settings untouched, so a stale local mode can't clobber a
+// concurrent admin's group-list edit or vice versa.
+function makeGroupingModeHandler(targetRef, saveKey, modeField, listField) {
+	return (value) => {
+		targetRef.value = value
+		queueSave(saveKey, () => ({
+			[modeField]: targetRef.value.mode,
+			[listField]: targetRef.value.groups.map((g) => g.id),
+		}), SELECT_DEBOUNCE)
+	}
+}
+const onResponseSummaryGroupsChange = makeGroupingModeHandler(
+	responseSummaryGroups,
+	'responseSummaryGroups',
+	'responseSummaryGroupsMode',
 	'whitelistedGroups',
-	() => ({ whitelistedGroups: selectedGroups.value.map((g) => g.id) }),
-	SELECT_DEBOUNCE,
 )
-autoSave(
-	selectedTeams,
+const onResponseSummaryTeamsChange = makeGroupingModeHandler(
+	responseSummaryTeams,
+	'responseSummaryTeams',
+	'responseSummaryTeamsMode',
 	'whitelistedTeams',
-	() => ({ whitelistedTeams: selectedTeams.value.map((team) => team.id) }),
-	SELECT_DEBOUNCE,
 )
 // Per permission, not the whole map: the backend leaves omitted permissions
 // untouched, so concurrent admins and stale local state cannot overwrite
@@ -1071,10 +1113,16 @@ async function loadSettings() {
 		const caps = capabilitiesRes.data
 
 		availableGroups.value = groups
-		selectedGroups.value = toGroupObjects(config.whitelistedGroups, groups)
+		responseSummaryGroups.value = {
+			mode: config.responseSummaryGroupsMode || 'none',
+			groups: toGroupObjects(config.whitelistedGroups, groups),
+		}
 
 		teamsAvailable.value = caps.teamsAvailable || false
-		selectedTeams.value = config.whitelistedTeams ?? []
+		responseSummaryTeams.value = {
+			mode: config.responseSummaryTeamsMode || 'none',
+			groups: config.whitelistedTeams ?? [],
+		}
 
 		// Load permission settings
 		if (config.permissions) {

--- a/tests/e2e/4-admin-settings.spec.js
+++ b/tests/e2e/4-admin-settings.spec.js
@@ -256,6 +256,11 @@ test.describe('Attendance App - Admin Settings', () => {
 			await page.goto('/settings/admin/attendance')
 			await page.waitForLoadState('networkidle')
 
+			// The picker only appears once "Specific groups" mode is selected
+			const groupingRow = page.locator('[data-test="response-summary-groups"]')
+			await expect(groupingRow).toBeVisible()
+			await groupingRow.getByText('Specific groups', { exact: true }).click()
+
 			// Find whitelisted groups selector
 			const groupsSelect = page.locator('[data-test="select-whitelisted-groups"]')
 			await expect(groupsSelect).toBeVisible()

--- a/tests/unit/Service/ConfigServiceTest.php
+++ b/tests/unit/Service/ConfigServiceTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\Attendance\Tests\Unit\Service;
+
+use OCA\Attendance\Service\ConfigService;
+use OCP\IAppConfig;
+use OCP\IConfig;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class ConfigServiceTest extends TestCase {
+	/** @var IConfig|MockObject */
+	private $config;
+
+	/** @var IAppConfig|MockObject */
+	private $appConfig;
+
+	private ConfigService $service;
+
+	protected function setUp(): void {
+		$this->config = $this->createMock(IConfig::class);
+		$this->appConfig = $this->createMock(IAppConfig::class);
+
+		$this->service = new ConfigService($this->config, $this->appConfig);
+	}
+
+	/**
+	 * @param array<string, string> $values Keyed by the raw config key (no 'attendance' app prefix).
+	 */
+	private function configValues(array $values): void {
+		$this->config->method('getAppValue')
+			->willReturnCallback(
+				fn (string $app, string $key, string $default = '') => $values[$key] ?? $default,
+			);
+		$this->appConfig->method('getValueString')
+			->willReturnCallback(
+				fn (string $app, string $key, string $default = '') => $values[$key] ?? $default,
+			);
+	}
+
+	// --- response summary groups mode ---
+
+	public function testGetResponseSummaryGroupsModeReturnsStoredValue(): void {
+		$this->configValues(['response_summary_groups_mode' => 'all']);
+
+		$this->assertSame('all', $this->service->getResponseSummaryGroupsMode());
+	}
+
+	public function testGetResponseSummaryGroupsModeDefaultsToNoneWhenWhitelistIsEmpty(): void {
+		$this->configValues(['whitelisted_groups' => '[]']);
+
+		$this->assertSame('none', $this->service->getResponseSummaryGroupsMode());
+	}
+
+	public function testGetResponseSummaryGroupsModeDefaultsToSpecificWhenWhitelistIsNotEmpty(): void {
+		$this->configValues(['whitelisted_groups' => '["choir"]']);
+
+		$this->assertSame('specific', $this->service->getResponseSummaryGroupsMode());
+	}
+
+	public function testGetResponseSummaryGroupsModeIgnoresInvalidStoredValue(): void {
+		$this->configValues(['response_summary_groups_mode' => 'bogus', 'whitelisted_groups' => '["choir"]']);
+
+		$this->assertSame('specific', $this->service->getResponseSummaryGroupsMode());
+	}
+
+	public function testSetResponseSummaryGroupsModeWritesTheMode(): void {
+		$this->appConfig->expects($this->once())
+			->method('setValueString')
+			->with('attendance', 'response_summary_groups_mode', 'all');
+
+		$this->service->setResponseSummaryGroupsMode('all');
+	}
+
+	public function testSetResponseSummaryGroupsModeRejectsInvalidValue(): void {
+		$this->appConfig->expects($this->never())->method('setValueString');
+
+		$this->expectException(\InvalidArgumentException::class);
+		$this->service->setResponseSummaryGroupsMode('bogus');
+	}
+
+	// --- response summary teams mode ---
+
+	public function testGetResponseSummaryTeamsModeReturnsStoredValue(): void {
+		$this->configValues(['response_summary_teams_mode' => 'specific']);
+
+		$this->assertSame('specific', $this->service->getResponseSummaryTeamsMode());
+	}
+
+	public function testGetResponseSummaryTeamsModeDefaultsToNoneWhenWhitelistIsEmpty(): void {
+		$this->configValues(['whitelisted_teams' => '[]']);
+
+		$this->assertSame('none', $this->service->getResponseSummaryTeamsMode());
+	}
+
+	public function testGetResponseSummaryTeamsModeDefaultsToSpecificWhenWhitelistIsNotEmpty(): void {
+		$this->configValues(['whitelisted_teams' => '["choir-team"]']);
+
+		$this->assertSame('specific', $this->service->getResponseSummaryTeamsMode());
+	}
+
+	/**
+	 * Unlike groups, teams have no "all" mode: there is no cheap way to
+	 * enumerate every Nextcloud Team.
+	 */
+	public function testSetResponseSummaryTeamsModeRejectsAll(): void {
+		$this->appConfig->expects($this->never())->method('setValueString');
+
+		$this->expectException(\InvalidArgumentException::class);
+		$this->service->setResponseSummaryTeamsMode('all');
+	}
+}

--- a/tests/unit/Service/ResponseSummaryServiceTest.php
+++ b/tests/unit/Service/ResponseSummaryServiceTest.php
@@ -86,9 +86,10 @@ class ResponseSummaryServiceTest extends TestCase {
 		$this->appointmentMapper->method('find')->with($appointmentId)->willReturn($appointment);
 		$this->responseMapper->method('findByAppointment')->with($appointmentId)->willReturn([]);
 
-		// No whitelist → allowAllGroups path, which triggers array_keys() on a
-		// group-keyed cache where PHP has coerced "123" into int 123.
+		// "All groups" mode, which triggers array_keys() on a group-keyed
+		// cache where PHP has coerced "123" into int 123.
 		$this->configService->method('getWhitelistedGroups')->willReturn([]);
+		$this->configService->method('getResponseSummaryGroupsMode')->willReturn(ConfigService::RESPONSE_SUMMARY_MODE_ALL);
 		$this->configService->method('getWhitelistedTeams')->willReturn([]);
 
 		$this->visibilityService->method('getVisibilitySettings')
@@ -127,6 +128,7 @@ class ResponseSummaryServiceTest extends TestCase {
 		$this->responseMapper->method('findByAppointment')->with($appointmentId)->willReturn([]);
 
 		$this->configService->method('getWhitelistedGroups')->willReturn(['staff']);
+		$this->configService->method('getResponseSummaryGroupsMode')->willReturn(ConfigService::RESPONSE_SUMMARY_MODE_SPECIFIC);
 		$this->configService->method('getWhitelistedTeams')->willReturn([]);
 
 		$this->visibilityService->method('getVisibilitySettings')
@@ -172,6 +174,7 @@ class ResponseSummaryServiceTest extends TestCase {
 		$this->responseMapper->method('findByAppointment')->with($appointmentId)->willReturn([]);
 
 		$this->configService->method('getWhitelistedGroups')->willReturn(['staff']);
+		$this->configService->method('getResponseSummaryGroupsMode')->willReturn(ConfigService::RESPONSE_SUMMARY_MODE_SPECIFIC);
 		$this->configService->method('getWhitelistedTeams')->willReturn([]);
 
 		$this->visibilityService->method('getVisibilitySettings')
@@ -230,6 +233,7 @@ class ResponseSummaryServiceTest extends TestCase {
 
 		// The whitelist names a different group than the appointment targets.
 		$this->configService->method('getWhitelistedGroups')->willReturn(['staff']);
+		$this->configService->method('getResponseSummaryGroupsMode')->willReturn(ConfigService::RESPONSE_SUMMARY_MODE_SPECIFIC);
 		$this->configService->method('getWhitelistedTeams')->willReturn([]);
 
 		$this->visibilityService->method('getVisibilitySettings')
@@ -288,6 +292,7 @@ class ResponseSummaryServiceTest extends TestCase {
 		$this->responseMapper->method('findByAppointment')->with($appointmentId)->willReturn([]);
 
 		$this->configService->method('getWhitelistedGroups')->willReturn(['staff']);
+		$this->configService->method('getResponseSummaryGroupsMode')->willReturn(ConfigService::RESPONSE_SUMMARY_MODE_SPECIFIC);
 		$this->configService->method('getWhitelistedTeams')->willReturn([]);
 
 		$this->visibilityService->method('getVisibilitySettings')
@@ -345,8 +350,9 @@ class ResponseSummaryServiceTest extends TestCase {
 		$this->appointmentMapper->method('find')->with($appointmentId)->willReturn($appointment);
 		$this->responseMapper->method('findByAppointment')->with($appointmentId)->willReturn([$response]);
 
-		// No whitelist → alice lands in the "others" bucket.
+		// No grouping → alice lands in the "others" bucket.
 		$this->configService->method('getWhitelistedGroups')->willReturn([]);
+		$this->configService->method('getResponseSummaryGroupsMode')->willReturn(ConfigService::RESPONSE_SUMMARY_MODE_NONE);
 		$this->configService->method('getWhitelistedTeams')->willReturn([]);
 
 		$this->visibilityService->method('getVisibilitySettings')
@@ -460,6 +466,7 @@ class ResponseSummaryServiceTest extends TestCase {
 
 		// Grouping is configured by instrument, access is restricted by status.
 		$this->configService->method('getWhitelistedGroups')->willReturn(['sopranos', 'altos']);
+		$this->configService->method('getResponseSummaryGroupsMode')->willReturn(ConfigService::RESPONSE_SUMMARY_MODE_SPECIFIC);
 		$this->configService->method('getWhitelistedTeams')->willReturn([]);
 
 		$this->visibilityService->method('getVisibilitySettings')
@@ -535,7 +542,9 @@ class ResponseSummaryServiceTest extends TestCase {
 		$this->responseMapper->method('findByAppointment')->with($appointmentId)->willReturn([$response]);
 
 		$this->configService->method('getWhitelistedGroups')->willReturn([]);
+		$this->configService->method('getResponseSummaryGroupsMode')->willReturn(ConfigService::RESPONSE_SUMMARY_MODE_NONE);
 		$this->configService->method('getWhitelistedTeams')->willReturn(['team-b']);
+		$this->configService->method('getResponseSummaryTeamsMode')->willReturn(ConfigService::RESPONSE_SUMMARY_MODE_SPECIFIC);
 
 		$this->visibilityService->method('getVisibilitySettings')
 			->willReturn(['users' => [], 'groups' => [], 'teams' => ['team-a']]);
@@ -568,9 +577,10 @@ class ResponseSummaryServiceTest extends TestCase {
 	}
 
 	/**
-	 * Without a whitelist there is no configured grouping, so a restricted
-	 * appointment keeps grouping by its restriction groups — the audience's
-	 * other group memberships must not fan out into sections.
+	 * With no whitelist, mode defaults to "none" (issue #212) — but a
+	 * restricted appointment still groups by its own restriction groups
+	 * regardless of mode (issue #199); the audience's other group
+	 * memberships must not fan out into sections.
 	 */
 	public function testGetResponseSummaryWithoutWhitelistKeepsGroupingByRestrictionGroups(): void {
 		$appointmentId = 10;
@@ -590,6 +600,7 @@ class ResponseSummaryServiceTest extends TestCase {
 		$this->responseMapper->method('findByAppointment')->with($appointmentId)->willReturn([$response]);
 
 		$this->configService->method('getWhitelistedGroups')->willReturn([]);
+		$this->configService->method('getResponseSummaryGroupsMode')->willReturn(ConfigService::RESPONSE_SUMMARY_MODE_NONE);
 		$this->configService->method('getWhitelistedTeams')->willReturn([]);
 
 		$this->visibilityService->method('getVisibilitySettings')
@@ -623,7 +634,6 @@ class ResponseSummaryServiceTest extends TestCase {
 		$this->assertSame([], $summary['others']['responses']);
 	}
 
-	/**
 	/**
 	 * Regression test for issue #213: a response recorded while the user was
 	 * still a target attendee (e.g. a group/team member) must stay in the
@@ -726,12 +736,12 @@ class ResponseSummaryServiceTest extends TestCase {
 	}
 
 	/**
-	 * Regression test for issue #212: with neither a whitelist nor an
-	 * appointment-level group restriction configured, a responder's own
-	 * (possibly unrelated) Nextcloud group memberships must not each become
-	 * their own summary section — everyone falls back to Others.
+	 * Regression test for issue #212: in the default "none" mode, a
+	 * responder's own (possibly unrelated) Nextcloud group memberships must
+	 * not each become their own summary section on a fully open appointment
+	 * — everyone falls back to Others.
 	 */
-	public function testGetResponseSummaryWithoutWhitelistOrRestrictionDoesNotGroupByMemberGroups(): void {
+	public function testGetResponseSummaryNoneModeDoesNotGroupByMemberGroups(): void {
 		$appointmentId = 11;
 		$appointment = new Appointment();
 		$appointment->setId($appointmentId);
@@ -749,6 +759,7 @@ class ResponseSummaryServiceTest extends TestCase {
 		$this->responseMapper->method('findByAppointment')->with($appointmentId)->willReturn([$response]);
 
 		$this->configService->method('getWhitelistedGroups')->willReturn([]);
+		$this->configService->method('getResponseSummaryGroupsMode')->willReturn(ConfigService::RESPONSE_SUMMARY_MODE_NONE);
 		$this->configService->method('getWhitelistedTeams')->willReturn([]);
 
 		$this->visibilityService->method('getVisibilitySettings')
@@ -778,5 +789,59 @@ class ResponseSummaryServiceTest extends TestCase {
 		$this->assertSame(1, $summary['others']['yes']);
 		$this->assertCount(1, $summary['others']['responses']);
 		$this->assertSame('Eve', $summary['others']['responses'][0]['userName']);
+	}
+
+	/**
+	 * Counterpart to the regression above: "all" mode is the explicit opt-in
+	 * for the old fan-out behavior — every Nextcloud group a responder
+	 * belongs to becomes its own section.
+	 */
+	public function testGetResponseSummaryAllModeGroupsByEveryMemberGroup(): void {
+		$appointmentId = 14;
+		$appointment = new Appointment();
+		$appointment->setId($appointmentId);
+		$appointment->setVisibleUsers('[]');
+		$appointment->setVisibleGroups('[]');
+		$appointment->setVisibleTeams('[]');
+
+		$response = new AttendanceResponse();
+		$response->setId(1);
+		$response->setAppointmentId($appointmentId);
+		$response->setUserId('eve');
+		$response->setResponse('yes');
+
+		$this->appointmentMapper->method('find')->with($appointmentId)->willReturn($appointment);
+		$this->responseMapper->method('findByAppointment')->with($appointmentId)->willReturn([$response]);
+
+		$this->configService->method('getWhitelistedGroups')->willReturn([]);
+		$this->configService->method('getResponseSummaryGroupsMode')->willReturn(ConfigService::RESPONSE_SUMMARY_MODE_ALL);
+		$this->configService->method('getWhitelistedTeams')->willReturn([]);
+
+		$this->visibilityService->method('getVisibilitySettings')
+			->willReturn(['users' => [], 'groups' => [], 'teams' => []]);
+		$this->visibilityService->method('hasRestrictedVisibility')->willReturn(false);
+		$this->visibilityService->method('isUserTargetAttendee')->willReturn(true);
+
+		$eve = $this->createMock(IUser::class);
+		$eve->method('getUID')->willReturn('eve');
+		$eve->method('getDisplayName')->willReturn('Eve');
+
+		$choirGroup = $this->createMock(IGroup::class);
+		$choirGroup->method('getGID')->willReturn('choir');
+		$adminsGroup = $this->createMock(IGroup::class);
+		$adminsGroup->method('getGID')->willReturn('admins');
+
+		$this->userManager->method('get')->willReturnMap([['eve', $eve]]);
+		$this->groupManager->method('getUserGroups')->willReturn([$choirGroup, $adminsGroup]);
+		$this->groupManager->method('search')->with('')->willReturn([$choirGroup, $adminsGroup]);
+
+		$this->visibilityService->method('getTargetAttendees')->willReturn(['eve' => $eve]);
+
+		$summary = $this->service->getResponseSummary($appointmentId);
+
+		$this->assertSame(['admins', 'choir'], array_keys($summary['by_group']));
+		$this->assertSame(1, $summary['by_group']['choir']['yes']);
+		$this->assertSame(1, $summary['by_group']['admins']['yes']);
+		$this->assertSame(0, $summary['others']['yes']);
 	}
 }

--- a/tests/unit/Service/ResponseSummaryServiceTest.php
+++ b/tests/unit/Service/ResponseSummaryServiceTest.php
@@ -624,6 +624,7 @@ class ResponseSummaryServiceTest extends TestCase {
 	}
 
 	/**
+	/**
 	 * Regression test for issue #213: a response recorded while the user was
 	 * still a target attendee (e.g. a group/team member) must stay in the
 	 * summary after they leave that group — only a manager's own test
@@ -722,5 +723,60 @@ class ResponseSummaryServiceTest extends TestCase {
 		$this->assertSame(0, $summary['yes']);
 		$this->assertSame(0, $summary['others']['yes']);
 		$this->assertSame([], $summary['others']['responses']);
+	}
+
+	/**
+	 * Regression test for issue #212: with neither a whitelist nor an
+	 * appointment-level group restriction configured, a responder's own
+	 * (possibly unrelated) Nextcloud group memberships must not each become
+	 * their own summary section — everyone falls back to Others.
+	 */
+	public function testGetResponseSummaryWithoutWhitelistOrRestrictionDoesNotGroupByMemberGroups(): void {
+		$appointmentId = 11;
+		$appointment = new Appointment();
+		$appointment->setId($appointmentId);
+		$appointment->setVisibleUsers('[]');
+		$appointment->setVisibleGroups('[]');
+		$appointment->setVisibleTeams('[]');
+
+		$response = new AttendanceResponse();
+		$response->setId(1);
+		$response->setAppointmentId($appointmentId);
+		$response->setUserId('eve');
+		$response->setResponse('yes');
+
+		$this->appointmentMapper->method('find')->with($appointmentId)->willReturn($appointment);
+		$this->responseMapper->method('findByAppointment')->with($appointmentId)->willReturn([$response]);
+
+		$this->configService->method('getWhitelistedGroups')->willReturn([]);
+		$this->configService->method('getWhitelistedTeams')->willReturn([]);
+
+		$this->visibilityService->method('getVisibilitySettings')
+			->willReturn(['users' => [], 'groups' => [], 'teams' => []]);
+		$this->visibilityService->method('hasRestrictedVisibility')->willReturn(false);
+		$this->visibilityService->method('isUserTargetAttendee')->willReturn(true);
+
+		$eve = $this->createMock(IUser::class);
+		$eve->method('getUID')->willReturn('eve');
+		$eve->method('getDisplayName')->willReturn('Eve');
+
+		// Eve happens to belong to several unrelated Nextcloud groups.
+		$choirGroup = $this->createMock(IGroup::class);
+		$choirGroup->method('getGID')->willReturn('choir');
+		$adminsGroup = $this->createMock(IGroup::class);
+		$adminsGroup->method('getGID')->willReturn('admins');
+
+		$this->userManager->method('get')->willReturnMap([['eve', $eve]]);
+		$this->groupManager->method('getUserGroups')->willReturn([$choirGroup, $adminsGroup]);
+		$this->groupManager->method('search')->with('')->willReturn([$choirGroup, $adminsGroup]);
+
+		$this->visibilityService->method('getTargetAttendees')->willReturn(['eve' => $eve]);
+
+		$summary = $this->service->getResponseSummary($appointmentId);
+
+		$this->assertSame([], $summary['by_group']);
+		$this->assertSame(1, $summary['others']['yes']);
+		$this->assertCount(1, $summary['others']['responses']);
+		$this->assertSame('Eve', $summary['others']['responses'][0]['userName']);
 	}
 }


### PR DESCRIPTION
## Summary
- **Original fix (#212):** without a configured group whitelist and without an appointment-level group restriction, `ResponseSummaryService` allowed *every* Nextcloud group as a summary section — a responder's own group memberships, however unrelated to attendance tracking, each became their own section (e.g. a member in five unrelated groups produced five sections).
- Silently changing that default risked breaking any admin who relied on the old implicit "group by every Nextcloud group" fan-out, and the admin settings text still promised that legacy behavior ("Leave empty to include all groups"). Replaced the implicit boolean with an **explicit three-way mode**, mirroring the existing permissions pattern (`PermissionService`):
  - **No grouping** — no sections, everyone under Others (today's default)
  - **Specific groups** — only the configured whitelist (unchanged behavior)
  - **All groups** — every Nextcloud group a responder belongs to (the old opt-in fan-out, now a deliberate admin choice). Teams get only *No grouping*/*Specific* — there's no cheap way to enumerate every Nextcloud Team.
- **Migration:** an empty stored whitelist maps to "No grouping", a non-empty one to "Specific groups" — preserving today's behavior for existing installs, no action needed.
- A restricted appointment still groups by its own restriction groups regardless of "No grouping"/"All groups" mode (issue #199's original behavior), and now fetches only its own restriction groups instead of scanning every group in the instance.
- `PermissionRow.vue` (previously permissions-only) is generalized with a `modes`/`pickerMode`/`warningWhenMode` contract and a `#picker` scoped slot so the new UI reuses it instead of duplicating the radio-switch component; the setup wizard's copy is updated to match.

Fixes #212

## Test plan
- [x] `./scripts/check.sh` — all gates green (eslint, stylelint, php-cs-fixer, psalm, phpunit, vite build, l10n checks, openapi spec)
- [x] New/updated tests: `ConfigServiceTest` (new) covers the mode getters/setters and migration fallback; `ResponseSummaryServiceTest` covers "none" (default, no fan-out), "all" (opt-in fan-out), and the #199 restriction-grouping interaction with the new modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)