### PR TITLE
fix(summary): keep a response visible after the user leaves its group

### DIFF
--- a/lib/Service/AppointmentService.php
+++ b/lib/Service/AppointmentService.php
@@ -1332,7 +1332,14 @@ class AppointmentService {
 		$result = [];
 
 		foreach ($responses as $response) {
-			if (!$this->visibilityService->canUserSeeAppointment($appointment, $response->getUserId())) {
+			$responseUserId = $response->getUserId();
+
+			// A former target attendee keeps their recorded response after
+			// leaving the group/team that made the appointment visible to
+			// them (issue #213) — only a manager's test response on an
+			// appointment they were never part of is filtered.
+			if (!$this->visibilityService->isUserTargetAttendee($appointment, $responseUserId)
+				&& $this->permissionService->canManageAppointments($responseUserId)) {
 				continue;
 			}
 

--- a/lib/Service/ResponseSummaryService.php
+++ b/lib/Service/ResponseSummaryService.php
@@ -20,6 +20,7 @@ class ResponseSummaryService {
 	private AttendanceResponseMapper $responseMapper;
 	private ConfigService $configService;
 	private VisibilityService $visibilityService;
+	private PermissionService $permissionService;
 	private IGroupManager $groupManager;
 	private IUserManager $userManager;
 	private GuestService $guestService;
@@ -29,6 +30,7 @@ class ResponseSummaryService {
 		AttendanceResponseMapper $responseMapper,
 		ConfigService $configService,
 		VisibilityService $visibilityService,
+		PermissionService $permissionService,
 		IGroupManager $groupManager,
 		IUserManager $userManager,
 		GuestService $guestService,
@@ -37,6 +39,7 @@ class ResponseSummaryService {
 		$this->responseMapper = $responseMapper;
 		$this->configService = $configService;
 		$this->visibilityService = $visibilityService;
+		$this->permissionService = $permissionService;
 		$this->groupManager = $groupManager;
 		$this->userManager = $userManager;
 		$this->guestService = $guestService;
@@ -108,7 +111,7 @@ class ResponseSummaryService {
 		foreach ($responses as $response) {
 			$value = $response->getResponse();
 			if (!in_array($value, ['yes', 'no', 'maybe'], true)
-				|| !$this->visibilityService->isUserTargetAttendee($appointment, $response->getUserId())) {
+				|| $this->isNonAttendeeAdminResponse($appointment, $response->getUserId())) {
 				continue;
 			}
 			$counts[$value]++;
@@ -250,6 +253,19 @@ class ResponseSummaryService {
 	}
 
 	/**
+	 * Whether a response should be excluded as a non-attendee's admin
+	 * bypass: a manager can see (and thus respond to) any appointment via
+	 * PERMISSION_MANAGE_APPOINTMENTS without being part of its actual
+	 * audience. Only that case is filtered — a regular user who answered
+	 * while still a target attendee keeps their response even if they later
+	 * leave the group/team (issue #213).
+	 */
+	private function isNonAttendeeAdminResponse(Appointment $appointment, string $userId): bool {
+		return !$this->visibilityService->isUserTargetAttendee($appointment, $userId)
+			&& $this->permissionService->canManageAppointments($userId);
+	}
+
+	/**
 	 * Initialize the summary structure.
 	 */
 	private function initializeSummary(): array {
@@ -285,9 +301,11 @@ class ResponseSummaryService {
 	): void {
 		$userId = $response->getUserId();
 
-		// Filter: Only include responses from actual target attendees
-		// This excludes admins who can "see" all appointments but aren't actual attendees
-		if (!$this->visibilityService->isUserTargetAttendee($appointment, $userId)) {
+		// A former target attendee keeps their recorded response after leaving
+		// the group/team that made the appointment visible to them (issue
+		// #213) — only a manager's test response on an appointment they were
+		// never part of is filtered.
+		if ($this->isNonAttendeeAdminResponse($appointment, $userId)) {
 			return;
 		}
 

--- a/tests/unit/Service/AppointmentServiceTest.php
+++ b/tests/unit/Service/AppointmentServiceTest.php
@@ -1647,4 +1647,67 @@ class AppointmentServiceTest extends TestCase {
 
 		$this->assertTrue($this->service->hasAnyAppointment());
 	}
+
+	// --- detailed responses with users ---
+
+	/**
+	 * Regression test for issue #213: a response recorded while the user was
+	 * still a target attendee must stay listed after they leave the
+	 * group/team that made the appointment visible to them.
+	 */
+	public function testGetAppointmentResponsesWithUsersKeepsResponseFromFormerTargetAttendee(): void {
+		$appointmentId = 42;
+		$appointment = new Appointment();
+		$appointment->setId($appointmentId);
+
+		$response = new AttendanceResponse();
+		$response->setId(1);
+		$response->setAppointmentId($appointmentId);
+		$response->setUserId('member11');
+		$response->setResponse('yes');
+
+		$this->appointmentMapper->method('find')->with($appointmentId)->willReturn($appointment);
+		$this->responseMapper->method('findByAppointment')->with($appointmentId)->willReturn([$response]);
+
+		// member11 has since left the group and is no longer a target
+		// attendee, but is not an admin either — their response stays.
+		$this->visibilityService->method('isUserTargetAttendee')->willReturn(false);
+		$this->permissionService->method('canManageAppointments')->willReturn(false);
+
+		$member11 = $this->createMock(\OCP\IUser::class);
+		$member11->method('getDisplayName')->willReturn('Member 11');
+		$this->userManager->method('get')->with('member11')->willReturn($member11);
+		$this->groupManager->method('getUserGroups')->willReturn([]);
+
+		$result = $this->service->getAppointmentResponsesWithUsers($appointmentId, 'someManager');
+
+		$this->assertCount(1, $result);
+		$this->assertSame('Member 11', $result[0]['userName']);
+	}
+
+	/**
+	 * Counterpart: a manager's response on an appointment they are not a
+	 * target attendee of must still be filtered out.
+	 */
+	public function testGetAppointmentResponsesWithUsersFiltersNonAttendeeAdminResponse(): void {
+		$appointmentId = 43;
+		$appointment = new Appointment();
+		$appointment->setId($appointmentId);
+
+		$response = new AttendanceResponse();
+		$response->setId(1);
+		$response->setAppointmentId($appointmentId);
+		$response->setUserId('admin1');
+		$response->setResponse('yes');
+
+		$this->appointmentMapper->method('find')->with($appointmentId)->willReturn($appointment);
+		$this->responseMapper->method('findByAppointment')->with($appointmentId)->willReturn([$response]);
+
+		$this->visibilityService->method('isUserTargetAttendee')->willReturn(false);
+		$this->permissionService->method('canManageAppointments')->willReturn(true);
+
+		$result = $this->service->getAppointmentResponsesWithUsers($appointmentId, 'someManager');
+
+		$this->assertSame([], $result);
+	}
 }

--- a/tests/unit/Service/ResponseSummaryServiceTest.php
+++ b/tests/unit/Service/ResponseSummaryServiceTest.php
@@ -10,6 +10,7 @@ use OCA\Attendance\Db\AttendanceResponse;
 use OCA\Attendance\Db\AttendanceResponseMapper;
 use OCA\Attendance\Service\ConfigService;
 use OCA\Attendance\Service\GuestService;
+use OCA\Attendance\Service\PermissionService;
 use OCA\Attendance\Service\ResponseSummaryService;
 use OCA\Attendance\Service\VisibilityService;
 use OCP\IGroup;
@@ -32,6 +33,9 @@ class ResponseSummaryServiceTest extends TestCase {
 	/** @var VisibilityService|MockObject */
 	private $visibilityService;
 
+	/** @var PermissionService|MockObject */
+	private $permissionService;
+
 	/** @var IGroupManager|MockObject */
 	private $groupManager;
 
@@ -48,6 +52,7 @@ class ResponseSummaryServiceTest extends TestCase {
 		$this->responseMapper = $this->createMock(AttendanceResponseMapper::class);
 		$this->configService = $this->createMock(ConfigService::class);
 		$this->visibilityService = $this->createMock(VisibilityService::class);
+		$this->permissionService = $this->createMock(PermissionService::class);
 		$this->groupManager = $this->createMock(IGroupManager::class);
 		$this->userManager = $this->createMock(IUserManager::class);
 		$this->guestService = $this->createMock(GuestService::class);
@@ -57,6 +62,7 @@ class ResponseSummaryServiceTest extends TestCase {
 			$this->responseMapper,
 			$this->configService,
 			$this->visibilityService,
+			$this->permissionService,
 			$this->groupManager,
 			$this->userManager,
 			$this->guestService,
@@ -613,6 +619,107 @@ class ResponseSummaryServiceTest extends TestCase {
 
 		$this->assertSame(['board'], array_keys($summary['by_group']));
 		$this->assertSame(1, $summary['by_group']['board']['yes']);
+		$this->assertSame(0, $summary['others']['yes']);
+		$this->assertSame([], $summary['others']['responses']);
+	}
+
+	/**
+	 * Regression test for issue #213: a response recorded while the user was
+	 * still a target attendee (e.g. a group/team member) must stay in the
+	 * summary after they leave that group — only a manager's own test
+	 * response on an appointment they were never part of is filtered.
+	 */
+	public function testGetResponseSummaryKeepsResponseFromFormerTargetAttendee(): void {
+		$appointmentId = 12;
+		$appointment = new Appointment();
+		$appointment->setId($appointmentId);
+		$appointment->setVisibleUsers('[]');
+		$appointment->setVisibleGroups(json_encode(['team1']));
+		$appointment->setVisibleTeams('[]');
+
+		$response = new AttendanceResponse();
+		$response->setId(1);
+		$response->setAppointmentId($appointmentId);
+		$response->setUserId('member11');
+		$response->setResponse('yes');
+
+		$this->appointmentMapper->method('find')->with($appointmentId)->willReturn($appointment);
+		$this->responseMapper->method('findByAppointment')->with($appointmentId)->willReturn([$response]);
+
+		$this->configService->method('getWhitelistedGroups')->willReturn([]);
+		$this->configService->method('getWhitelistedTeams')->willReturn([]);
+
+		$this->visibilityService->method('getVisibilitySettings')
+			->willReturn(['users' => [], 'groups' => ['team1'], 'teams' => []]);
+		$this->visibilityService->method('hasRestrictedVisibility')->willReturn(true);
+
+		// member11 has since left team1 and is no longer a target attendee —
+		// but they are not an admin either, so their recorded response stays.
+		$this->visibilityService->method('isUserTargetAttendee')->willReturn(false);
+		$this->permissionService->method('canManageAppointments')->willReturn(false);
+
+		$member11 = $this->createMock(IUser::class);
+		$member11->method('getUID')->willReturn('member11');
+		$member11->method('getDisplayName')->willReturn('Member 11');
+
+		$this->userManager->method('get')->willReturnMap([['member11', $member11]]);
+		$this->groupManager->method('getUserGroups')->willReturn([]);
+		$this->groupManager->method('search')->with('')->willReturn([]);
+
+		$team1Group = $this->createMock(IGroup::class);
+		$team1Group->method('getGID')->willReturn('team1');
+		$team1Group->method('getUsers')->willReturn([]);
+		$this->groupManager->method('get')->with('team1')->willReturn($team1Group);
+
+		$this->visibilityService->method('getTargetAttendees')->willReturn([]);
+
+		$summary = $this->service->getResponseSummary($appointmentId);
+
+		$this->assertSame(1, $summary['yes']);
+		$this->assertSame(1, $summary['others']['yes']);
+		$this->assertCount(1, $summary['others']['responses']);
+		$this->assertSame('Member 11', $summary['others']['responses'][0]['userName']);
+	}
+
+	/**
+	 * Counterpart to the regression above: a manager who is not part of the
+	 * appointment's audience but can respond via admin bypass must still be
+	 * filtered out of the summary, exactly as before issue #213 was fixed.
+	 */
+	public function testGetResponseSummaryFiltersNonAttendeeAdminResponse(): void {
+		$appointmentId = 13;
+		$appointment = new Appointment();
+		$appointment->setId($appointmentId);
+		$appointment->setVisibleUsers('[]');
+		$appointment->setVisibleGroups(json_encode(['team1']));
+		$appointment->setVisibleTeams('[]');
+
+		$response = new AttendanceResponse();
+		$response->setId(1);
+		$response->setAppointmentId($appointmentId);
+		$response->setUserId('admin1');
+		$response->setResponse('yes');
+
+		$this->appointmentMapper->method('find')->with($appointmentId)->willReturn($appointment);
+		$this->responseMapper->method('findByAppointment')->with($appointmentId)->willReturn([$response]);
+
+		$this->configService->method('getWhitelistedGroups')->willReturn([]);
+		$this->configService->method('getWhitelistedTeams')->willReturn([]);
+
+		$this->visibilityService->method('getVisibilitySettings')
+			->willReturn(['users' => [], 'groups' => ['team1'], 'teams' => []]);
+		$this->visibilityService->method('hasRestrictedVisibility')->willReturn(true);
+
+		$this->visibilityService->method('isUserTargetAttendee')->willReturn(false);
+		$this->permissionService->method('canManageAppointments')->willReturn(true);
+
+		$this->groupManager->method('getUserGroups')->willReturn([]);
+		$this->groupManager->method('search')->with('')->willReturn([]);
+		$this->visibilityService->method('getTargetAttendees')->willReturn([]);
+
+		$summary = $this->service->getResponseSummary($appointmentId);
+
+		$this->assertSame(0, $summary['yes']);
 		$this->assertSame(0, $summary['others']['yes']);
 		$this->assertSame([], $summary['others']['responses']);
 	}


### PR DESCRIPTION
## Summary
- `ResponseSummaryService` (the per-appointment response overview, and its aggregate-counts variant) and `AppointmentService::getAppointmentResponsesWithUsers` (the "all appointments" detailed-response export) both dropped a response entirely once the responding user no longer passed a *live* target-attendee/visibility check.
- So a member who answered an appointment while still in the group or Nextcloud Team that made it visible to them, and later left that group, silently lost their recorded attendance from every view — with no trace it ever happened. Reported as attendance data becoming untraceable after a group-membership change, which matters for accountability (e.g. in the event of an accident).
- That check exists to filter out a manager's own test responses on appointments they were never part of (a manager can see, and thus respond to, *any* appointment via `PERMISSION_MANAGE_APPOINTMENTS` without being a real attendee) — narrowed it to only that case: a response is excluded solely when the user currently holds admin bypass **and** was never a target attendee, not merely because their group membership changed after they answered.

Fixes #213

## Test plan
- [x] `./scripts/check.sh` — all gates green (eslint, stylelint, php-cs-fixer, psalm, phpunit, vite build, l10n checks, openapi spec)
- [x] New regression tests in `ResponseSummaryServiceTest` and `AppointmentServiceTest` cover: a former target attendee's response stays visible, and a non-attendee manager's response is still filtered (unchanged prior behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)